### PR TITLE
Fixes rendering on godocs

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -166,7 +166,7 @@
 //   	detect := func(context packit.DetectContext) (packit.DetectResult, error) {
 //   		return packit.DetectResult{}, nil
 //   	}
-
+//
 //   	build := func(context packit.BuildContext) (packit.BuildResult, error) {
 //   		return packit.BuildResult{
 //   			Processes: []packit.Process{


### PR DESCRIPTION
The lack of `//` was causing the top part of the godoc to be cut off.