### PR TITLE
Create draft releases of packit

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: unit
     steps:
+    - name: Reset Draft Release
+      uses: paketo-buildpacks/github-config/actions/release/reset-draft@master
+      with:
+        repo: ${{ github.repository }}
+        token: ${{ github.token }}
     - name: Checkout
       uses: actions/checkout@v2
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
@@ -32,32 +37,27 @@ jobs:
       uses: paketo-buildpacks/github-config/actions/tag@master
     - name: Package Jam
       run : ./scripts/package.sh
-    - name: Create Release
-      id: create-release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Create Draft Release
+      uses: paketo-buildpacks/github-config/actions/release/create@master
       with:
+        repo: ${{ github.repository }}
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
         tag_name: v${{ steps.tag.outputs.tag }}
-        release_name: v${{ steps.tag.outputs.tag }}
-        draft: false
-        prerelease: false
-    - name: Upload Jam (darwin)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: build/jam-darwin
-        asset_name: jam-darwin
-        asset_content_type: application/octet-stream
-    - name: Upload Jam (linux)
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create-release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: build/jam-linux
-        asset_name: jam-linux
-        asset_content_type: application/octet-stream
+        target_commitish: ${{ github.sha }}
+        name: v${{ steps.tag.outputs.tag }}
+        body: '' # TODO: remove this once body is made optional
+        draft: true
+        assets: |
+          [
+            {
+              "path": "build/jam-darwin",
+              "name": "jam-darwin",
+              "content_type": "application/octet-stream"
+            },
+            {
+              "path": "build/jam-linux",
+              "name": "jam-linux",
+              "content_type": "application/octet-stream"
+            }
+          ]
 


### PR DESCRIPTION
It would be nice to have a bit more control over releasing packit. This would allow us to bucket up some changes instead of releasing them on every commit.