### PR TITLE
Ensures relative links remain relative in fs.Copy

### DIFF
--- a/cargo/directory_duplicator_test.go
+++ b/cargo/directory_duplicator_test.go
@@ -30,7 +30,7 @@ func testDirectoryDuplicator(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(os.MkdirAll(filepath.Join(sourceDir, "some-dir"), os.ModePerm)).To(Succeed())
 		Expect(ioutil.WriteFile(filepath.Join(sourceDir, "some-dir", "other-file"), []byte("other content"), 0755)).To(Succeed())
-		Expect(os.Symlink(filepath.Join(sourceDir, "some-dir", "other-file"), filepath.Join(sourceDir, "some-dir", "link"))).To(Succeed())
+		Expect(os.Symlink("other-file", filepath.Join(sourceDir, "some-dir", "link"))).To(Succeed())
 
 		destDir, err = ioutil.TempDir("", "dest")
 		Expect(err).NotTo(HaveOccurred())
@@ -83,7 +83,7 @@ func testDirectoryDuplicator(t *testing.T, context spec.G, it spec.S) {
 
 			path, err := os.Readlink(filepath.Join(destDir, "some-dir", "link"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(path).To(Equal(filepath.Join(destDir, "some-dir", "other-file")))
+			Expect(path).To(Equal(filepath.Join("other-file")))
 		})
 	})
 

--- a/cargo/jam/pack_test.go
+++ b/cargo/jam/pack_test.go
@@ -204,7 +204,7 @@ func testPack(t *testing.T, context spec.G, it spec.S) {
 
 			_, hdr, err = ExtractFile(file, "bin/link")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(hdr.Linkname).To(Equal("bin/build"))
+			Expect(hdr.Linkname).To(Equal("build"))
 			Expect(hdr.Uname).To(Equal(userName))
 			Expect(hdr.Gname).To(Equal(groupName))
 

--- a/fs/copy.go
+++ b/fs/copy.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // Copy will move a source file or directory to a destination. For directories,
@@ -119,24 +118,7 @@ func copyLink(source, destination, path string) error {
 		return err
 	}
 
-	switch {
-	case strings.HasPrefix(link, string(filepath.Separator)):
-		// NOOP
-
-	default:
-		link = filepath.Clean(filepath.Join(source, filepath.Dir(path), link))
-	}
-
-	relativeLink, err := filepath.Rel(source, link)
-	if err != nil {
-		return err
-	}
-
-	if strings.HasPrefix(relativeLink, "..") {
-		err = os.Symlink(link, filepath.Join(destination, path))
-	} else {
-		err = os.Symlink(filepath.Join(destination, relativeLink), filepath.Join(destination, path))
-	}
+	err = os.Symlink(link, filepath.Join(destination, path))
 	if err != nil {
 		return err
 	}

--- a/fs/copy_test.go
+++ b/fs/copy_test.go
@@ -137,7 +137,7 @@ func testCopy(t *testing.T, context spec.G, it spec.S) {
 
 					path, err := os.Readlink(filepath.Join(destination, "some-dir", "some-symlink"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(path).To(Equal(filepath.Join(destination, "some-dir", "some-file")))
+					Expect(path).To(Equal("some-file"))
 
 					path, err = os.Readlink(filepath.Join(destination, "some-dir", "external-symlink"))
 					Expect(err).NotTo(HaveOccurred())
@@ -173,7 +173,7 @@ func testCopy(t *testing.T, context spec.G, it spec.S) {
 
 					path, err := os.Readlink(filepath.Join(destination, "some-dir", "some-symlink"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(path).To(Equal(filepath.Join(destination, "some-dir", "some-file")))
+					Expect(path).To(Equal("some-file"))
 
 					path, err = os.Readlink(filepath.Join(destination, "some-dir", "external-symlink"))
 					Expect(err).NotTo(HaveOccurred())

--- a/fs/move_test.go
+++ b/fs/move_test.go
@@ -109,7 +109,7 @@ func testMove(t *testing.T, context spec.G, it spec.S) {
 				err = ioutil.WriteFile(filepath.Join(source, "some-dir", "readonly-file"), []byte("some-content"), 0444)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = os.Symlink(filepath.Join(source, "some-dir", "some-file"), filepath.Join(source, "some-dir", "some-symlink"))
+				err = os.Symlink("some-file", filepath.Join(source, "some-dir", "some-symlink"))
 				Expect(err).NotTo(HaveOccurred())
 
 				err = os.Symlink(filepath.Join(external, "some-file"), filepath.Join(source, "some-dir", "external-symlink"))
@@ -137,7 +137,7 @@ func testMove(t *testing.T, context spec.G, it spec.S) {
 
 					path, err := os.Readlink(filepath.Join(destination, "some-dir", "some-symlink"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(path).To(Equal(filepath.Join(destination, "some-dir", "some-file")))
+					Expect(path).To(Equal("some-file"))
 
 					path, err = os.Readlink(filepath.Join(destination, "some-dir", "external-symlink"))
 					Expect(err).NotTo(HaveOccurred())
@@ -173,7 +173,7 @@ func testMove(t *testing.T, context spec.G, it spec.S) {
 
 					path, err := os.Readlink(filepath.Join(destination, "some-dir", "some-symlink"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(path).To(Equal(filepath.Join(destination, "some-dir", "some-file")))
+					Expect(path).To(Equal("some-file"))
 
 					path, err = os.Readlink(filepath.Join(destination, "some-dir", "external-symlink"))
 					Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Relative links were being converted to absolute paths that are then not portable when they are moved across the filesystem. This patch keeps them relative.