### PR TITLE
Adds support for a WithMessage modifier on packit.Fail

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -9,11 +9,6 @@ import (
 	"github.com/paketo-buildpacks/packit/internal"
 )
 
-// Fail is a sentinal value that can be used to indicate a failure to detect
-// during the detect phase. Fail implements the Error interface and should be
-// returned as the error value in the DetectFunc signature.
-var Fail = internal.Fail
-
 // DetectContext provides the contextual details that are made available by the
 // buildpack lifecycle during the detect phase. This context is populated by
 // the Detect function and passed to the DetectFunc during execution.

--- a/fail.go
+++ b/fail.go
@@ -1,0 +1,12 @@
+package packit
+
+import "github.com/paketo-buildpacks/packit/internal"
+
+// Fail is a sentinal value that can be used to indicate a failure to detect
+// during the detect phase. Fail implements the Error interface and should be
+// returned as the error value in the DetectFunc signature. Fail also supports
+// a modifier function, WithMessage, that allows the caller to set a custom
+// failure message. The WithMessage function supports a fmt.Printf-like format
+// string and variadic arguments to build a message, eg:
+// packit.Fail.WithMessage("failed: %w", err).
+var Fail = internal.Fail

--- a/internal/exit_handler.go
+++ b/internal/exit_handler.go
@@ -1,13 +1,10 @@
 package internal
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"os"
 )
-
-var Fail = errors.New("failed")
 
 type Option func(handler ExitHandler) ExitHandler
 
@@ -57,8 +54,8 @@ func (h ExitHandler) Error(err error) {
 	fmt.Fprintln(h.stderr, err)
 
 	var code int
-	switch err {
-	case Fail:
+	switch err.(type) {
+	case failError:
 		code = 100
 	case nil:
 		code = 0

--- a/internal/fail.go
+++ b/internal/fail.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"errors"
+	"fmt"
+)
+
+var Fail = failError{error: errors.New("failed")}
+
+type failError struct {
+	error
+}
+
+func (f failError) WithMessage(format string, v ...interface{}) failError {
+	return failError{error: fmt.Errorf(format, v...)}
+}

--- a/internal/fail_test.go
+++ b/internal/fail_test.go
@@ -1,0 +1,28 @@
+package internal_test
+
+import (
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/internal"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testFail(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	it("acts as an error", func() {
+		fail := internal.Fail
+		Expect(fail).To(MatchError("failed"))
+	})
+
+	context("when given a message", func() {
+		it("acts as an error with that message", func() {
+			fail := internal.Fail.WithMessage("this is a %s", "failure message")
+			Expect(fail).To(MatchError("this is a failure message"))
+		})
+	})
+}

--- a/internal/init_test.go
+++ b/internal/init_test.go
@@ -11,6 +11,7 @@ func TestUnitInternal(t *testing.T) {
 	suite := spec.New("packit/internal", spec.Report(report.Terminal{}))
 	suite("EnvironmentWriter", testEnvironmentWriter)
 	suite("ExitHandler", testExitHandler)
+	suite("Fail", testFail)
 	suite("TOMLWriter", testTOMLWriter)
 	suite.Run(t)
 }


### PR DESCRIPTION
For example, a call to `packit.Fail.WithMessage("my error")` will result in an error that triggers the correct fail exit code for the buildpack lifecycle, and also included the given message. This change is backwards compatible and so should not impact any buildpacks currently just using `packit.Fail`.