### PR TITLE
Reverts changes that added headers to the Drop function.

### DIFF
--- a/cargo/transport.go
+++ b/cargo/transport.go
@@ -9,15 +9,13 @@ import (
 	"strings"
 )
 
-type Transport struct{
-	header http.Header
-}
+type Transport struct{}
 
 func NewTransport() Transport {
 	return Transport{}
 }
 
-func (t Transport) Drop(root, uri string, header http.Header) (io.ReadCloser, error) {
+func (t Transport) Drop(root, uri string) (io.ReadCloser, error) {
 	if strings.HasPrefix(uri, "file://") {
 		file, err := os.Open(filepath.Join(root, strings.TrimPrefix(uri, "file://")))
 		if err != nil {
@@ -32,10 +30,6 @@ func (t Transport) Drop(root, uri string, header http.Header) (io.ReadCloser, er
 		return nil, fmt.Errorf("failed to parse request uri: %s", err)
 	}
 
-	if header != nil {
-		request.Header = header
-	}
-
 	response, err := http.DefaultClient.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make request: %s", err)
@@ -43,4 +37,3 @@ func (t Transport) Drop(root, uri string, header http.Header) (io.ReadCloser, er
 
 	return response.Body, nil
 }
-

--- a/cargo/transport_test.go
+++ b/cargo/transport_test.go
@@ -30,20 +30,11 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 
 			it.Before(func() {
 				server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					if req.Header.Get("header") == "some-header" {
-						switch req.URL.Path {
-						case "/some-bundle-with-header":
-							w.Write([]byte("some-bundle-with-header-contents"))
-						default:
-							http.NotFound(w, req)
-						}
-					} else {
-						switch req.URL.Path {
-						case "/some-bundle":
-							w.Write([]byte("some-bundle-contents"))
-						default:
-							http.NotFound(w, req)
-						}
+					switch req.URL.Path {
+					case "/some-bundle":
+						w.Write([]byte("some-bundle-contents"))
+					default:
+						http.NotFound(w, req)
 					}
 				}))
 			})
@@ -53,7 +44,7 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("downloads the file from a URI", func() {
-				bundle, err := transport.Drop("", fmt.Sprintf("%s/some-bundle", server.URL), nil)
+				bundle, err := transport.Drop("", fmt.Sprintf("%s/some-bundle", server.URL))
 				Expect(err).NotTo(HaveOccurred())
 
 				contents, err := ioutil.ReadAll(bundle)
@@ -63,23 +54,10 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 				Expect(bundle.Close()).To(Succeed())
 			})
 
-			context("when there are request headers", func() {
-				it("downloads the file from a URI", func() {
-					bundle, err := transport.Drop("", fmt.Sprintf("%s/some-bundle-with-header", server.URL), http.Header{"header": []string{"some-header"}})
-					Expect(err).NotTo(HaveOccurred())
-
-					contents, err := ioutil.ReadAll(bundle)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(string(contents)).To(Equal("some-bundle-with-header-contents"))
-
-					Expect(bundle.Close()).To(Succeed())
-				})
-			})
-
 			context("failure cases", func() {
 				context("when the uri is malformed", func() {
 					it("returns an error", func() {
-						_, err := transport.Drop("", "%%%%", nil)
+						_, err := transport.Drop("", "%%%%")
 						Expect(err).To(MatchError(ContainSubstring("failed to parse request uri")))
 						Expect(err).To(MatchError(ContainSubstring("invalid URL escape")))
 					})
@@ -91,7 +69,7 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 					})
 
 					it("returns an error", func() {
-						_, err := transport.Drop("", fmt.Sprintf("%s/some-bundle", server.URL), nil)
+						_, err := transport.Drop("", fmt.Sprintf("%s/some-bundle", server.URL))
 						Expect(err).To(MatchError(ContainSubstring("failed to make request")))
 						Expect(err).To(MatchError(ContainSubstring("connection refused")))
 					})
@@ -121,7 +99,7 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("returns the file descriptor", func() {
-				bundle, err := transport.Drop(dir, fmt.Sprintf("file://%s", path), nil)
+				bundle, err := transport.Drop(dir, fmt.Sprintf("file://%s", path))
 				Expect(err).NotTo(HaveOccurred())
 
 				contents, err := ioutil.ReadAll(bundle)
@@ -138,7 +116,7 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 
 				context("when the file does not exist", func() {
 					it("returns an error", func() {
-						_, err := transport.Drop(dir, fmt.Sprintf("file://%s", path), nil)
+						_, err := transport.Drop(dir, fmt.Sprintf("file://%s", path))
 						Expect(err).To(MatchError(ContainSubstring("failed to open file")))
 						Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 					})


### PR DESCRIPTION
- After reconsideration we came to the conclusion that it does not make
  sense to support custom headers at this time and they unnecessarily
  dirty the API.

- We consider downloading to only be part of Drop() main functionality the
  other half being detecting on disk depenencies as well, the headers
  change only affected half of Drop() functionality which is a weird API
  to enforce.

This reverts commit 947aca1774897b5721d4ec44eb7b74f414207b95.