### PR TITLE
Improves jam summarize output for language-families

### DIFF
--- a/cargo/jam/internal/buildpack_inspector.go
+++ b/cargo/jam/internal/buildpack_inspector.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 
 	"github.com/paketo-buildpacks/packit/cargo"
@@ -95,10 +94,6 @@ func (i BuildpackInspector) Dependencies(path string) ([]cargo.Config, error) {
 
 		configs = append(configs, config)
 	}
-
-	sort.Slice(configs, func(i, j int) bool {
-		return len(configs[i].Order) > 0
-	})
 
 	return configs, nil
 }

--- a/cargo/jam/internal/buildpack_inspector_test.go
+++ b/cargo/jam/internal/buildpack_inspector_test.go
@@ -233,30 +233,6 @@ version = "2.3.4"
 			Expect(configs).To(Equal([]cargo.Config{
 				{
 					Buildpack: cargo.ConfigBuildpack{
-						ID:      "meta-buildpack",
-						Version: "3.4.5",
-					},
-					Order: []cargo.ConfigOrder{
-						{
-							Group: []cargo.ConfigOrderGroup{
-								{
-									ID:      "some-buildpack",
-									Version: "1.2.3",
-								},
-							},
-						},
-						{
-							Group: []cargo.ConfigOrderGroup{
-								{
-									ID:      "other-buildpack",
-									Version: "2.3.4",
-								},
-							},
-						},
-					},
-				},
-				{
-					Buildpack: cargo.ConfigBuildpack{
 						ID:      "some-buildpack",
 						Version: "1.2.3",
 					},
@@ -309,6 +285,30 @@ version = "2.3.4"
 					Stacks: []cargo.ConfigStack{
 						{ID: "first-stack"},
 						{ID: "second-stack"},
+					},
+				},
+				{
+					Buildpack: cargo.ConfigBuildpack{
+						ID:      "meta-buildpack",
+						Version: "3.4.5",
+					},
+					Order: []cargo.ConfigOrder{
+						{
+							Group: []cargo.ConfigOrderGroup{
+								{
+									ID:      "some-buildpack",
+									Version: "1.2.3",
+								},
+							},
+						},
+						{
+							Group: []cargo.ConfigOrderGroup{
+								{
+									ID:      "other-buildpack",
+									Version: "2.3.4",
+								},
+							},
+						},
 					},
 				},
 			}))

--- a/cargo/jam/internal/formatter_test.go
+++ b/cargo/jam/internal/formatter_test.go
@@ -30,6 +30,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 				{
 					Buildpack: cargo.ConfigBuildpack{
 						ID:      "some-buildpack",
+						Name:    "Some Buildpack",
 						Version: "some-version",
 					},
 					Metadata: cargo.ConfigMetadata{
@@ -66,25 +67,28 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 					},
 				},
 			})
-			Expect(buffer.String()).To(Equal(`## some-buildpack some-version
+			Expect(buffer.String()).To(Equal(`## Some Buildpack some-version
+**ID:** some-buildpack
+
 ### Dependencies
-| name | version | stacks |
+| Name | Version | Stacks |
 |-|-|-|
 | other-dependency | 2.3.5 | other-stack |
 | other-dependency | 2.3.4 | other-stack, some-stack |
 | some-dependency | 1.2.3 | other-stack, some-stack |
 
 ### Default Dependencies
-| name | version |
+| Name | Version |
 |-|-|
 | other-dependency | 2.3.x |
 | some-dependency | 1.2.x |
 
 ### Supported Stacks
-| name |
+| Name |
 |-|
 | other-stack |
 | some-stack |
+
 `))
 		})
 
@@ -94,6 +98,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 					{
 						Buildpack: cargo.ConfigBuildpack{
 							ID:      "some-buildpack",
+							Name:    "Some Buildpack",
 							Version: "some-version",
 						},
 						Stacks: []cargo.ConfigStack{
@@ -102,12 +107,15 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 				})
-				Expect(buffer.String()).To(Equal(`## some-buildpack some-version
+				Expect(buffer.String()).To(Equal(`## Some Buildpack some-version
+**ID:** some-buildpack
+
 ### Supported Stacks
-| name |
+| Name |
 |-|
 | other-stack |
 | some-stack |
+
 `))
 			})
 		})
@@ -118,6 +126,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 					{
 						Buildpack: cargo.ConfigBuildpack{
 							ID:      "some-buildpack",
+							Name:    "Some Buildpack",
 							Version: "some-version",
 						},
 						Metadata: cargo.ConfigMetadata{
@@ -150,16 +159,18 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 				})
-				Expect(buffer.String()).To(Equal(`## some-buildpack some-version
+				Expect(buffer.String()).To(Equal(`## Some Buildpack some-version
+**ID:** some-buildpack
+
 ### Dependencies
-| name | version | stacks |
+| Name | Version | Stacks |
 |-|-|-|
 | other-dependency | 2.3.5 | other-stack |
 | other-dependency | 2.3.4 | other-stack, some-stack |
 | some-dependency | 1.2.3 | other-stack, some-stack |
 
 ### Default Dependencies
-| name | version |
+| Name | Version |
 |-|-|
 | other-dependency | 2.3.x |
 | some-dependency | 1.2.x |
@@ -173,8 +184,9 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 				formatter.Markdown([]cargo.Config{
 					{
 						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Version: "some-version",
+							ID:      "order-buildpack",
+							Name:    "Order Buildpack",
+							Version: "order-version",
 						},
 						Order: []cargo.ConfigOrder{
 							{
@@ -193,6 +205,10 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 							{
 								Group: []cargo.ConfigOrderGroup{
 									{
+										ID:      "some-buildpack",
+										Version: "1.2.3",
+									},
+									{
 										ID:      "other-buildpack",
 										Version: "3.4.5",
 									},
@@ -200,18 +216,61 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
+					{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Name:    "Some Buildpack",
+							Version: "1.2.3",
+						},
+					},
+					{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "optional-buildpack",
+							Name:    "Optional Buildpack",
+							Version: "2.3.4",
+						},
+					},
+					{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "other-buildpack",
+							Name:    "Other Buildpack",
+							Version: "3.4.5",
+						},
+					},
 				})
-				Expect(buffer.String()).To(Equal(`# some-buildpack some-version
+				Expect(buffer.String()).To(ContainSubstring(`# Order Buildpack order-version
+**ID:** order-buildpack
+
+| Name | ID | Version |
+|-|-|-|
+| Some Buildpack | some-buildpack | 1.2.3 |
+| Optional Buildpack | optional-buildpack | 2.3.4 |
+| Other Buildpack | other-buildpack | 3.4.5 |
+
+<details>
+<summary>More Information</summary>
+
 ### Order Groupings
-| name | version | optional |
-|-|-|-|
-| some-buildpack | 1.2.3 | false |
-| optional-buildpack | 2.3.4 | true |
+| Name | ID | Version | Optional |
+|-|-|-|-|
+| Some Buildpack | some-buildpack | 1.2.3 | false |
+| Optional Buildpack | optional-buildpack | 2.3.4 | true |
 
-| name | version | optional |
-|-|-|-|
-| other-buildpack | 3.4.5 | false |
+| Name | ID | Version | Optional |
+|-|-|-|-|
+| Some Buildpack | some-buildpack | 1.2.3 | false |
+| Other Buildpack | other-buildpack | 3.4.5 | false |
 
+## Some Buildpack 1.2.3
+**ID:** some-buildpack
+
+## Optional Buildpack 2.3.4
+**ID:** optional-buildpack
+
+## Other Buildpack 3.4.5
+**ID:** other-buildpack
+
+</details>
 `))
 			})
 		})
@@ -316,6 +375,27 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 							ID:      "some-buildpack",
 							Version: "some-version",
 						},
+						Metadata: cargo.ConfigMetadata{
+							Dependencies: []cargo.ConfigMetadataDependency{
+								{
+									ID:      "some-dependency",
+									Stacks:  []string{"some-stack"},
+									Version: "1.2.3",
+								},
+							},
+							DefaultVersions: map[string]string{
+								"some-dependency": "1.2.x",
+							},
+						},
+						Stacks: []cargo.ConfigStack{
+							{ID: "some-stack"},
+						},
+					},
+					{
+						Buildpack: cargo.ConfigBuildpack{
+							ID:      "some-buildpack",
+							Version: "some-version",
+						},
 						Order: []cargo.ConfigOrder{
 							{
 								Group: []cargo.ConfigOrderGroup{
@@ -338,27 +418,6 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 									},
 								},
 							},
-						},
-					},
-					{
-						Buildpack: cargo.ConfigBuildpack{
-							ID:      "some-buildpack",
-							Version: "some-version",
-						},
-						Metadata: cargo.ConfigMetadata{
-							Dependencies: []cargo.ConfigMetadataDependency{
-								{
-									ID:      "some-dependency",
-									Stacks:  []string{"some-stack"},
-									Version: "1.2.3",
-								},
-							},
-							DefaultVersions: map[string]string{
-								"some-dependency": "1.2.x",
-							},
-						},
-						Stacks: []cargo.ConfigStack{
-							{ID: "some-stack"},
 						},
 					},
 				})


### PR DESCRIPTION
- implementation listings are now hidden under "More Information"
- includes other tweaks to provide consistency and further detail about both implementations and language-family buildpacks