### PR TITLE
Updates Markdown to support the html.md.erb table format

### DIFF
--- a/cargo/jam/internal/formatter.go
+++ b/cargo/jam/internal/formatter.go
@@ -35,7 +35,7 @@ func (f Formatter) Markdown(configs []cargo.Config) {
 		if len(config.Order) > 0 {
 			fmt.Fprintf(f.writer, "### Order Groupings\n")
 			for _, o := range config.Order {
-				fmt.Fprintf(f.writer, "| name | version | optional |\n|-|-|-|\n")
+				fmt.Fprintf(f.writer, "| name | version | optional |\n|---|---|---|\n")
 				for _, g := range o.Group {
 					fmt.Fprintf(f.writer, "| %s | %s | %t |\n", g.ID, g.Version, g.Optional)
 				}
@@ -82,7 +82,7 @@ func (f Formatter) Markdown(configs []cargo.Config) {
 				return iVal.ID == jVal.ID && iVersion.GreaterThan(jVersion)
 			})
 
-			fmt.Fprintf(f.writer, "### Dependencies\n| name | version | stacks |\n|-|-|-|\n")
+			fmt.Fprintf(f.writer, "### Dependencies\n| name | version | stacks |\n|---|---|---|\n")
 			for _, d := range sorted {
 				fmt.Fprintf(f.writer, "| %s | %s | %s |\n", d.ID, d.Version, strings.Join(d.Stacks, ", "))
 			}
@@ -90,7 +90,7 @@ func (f Formatter) Markdown(configs []cargo.Config) {
 		}
 
 		if len(config.Metadata.DefaultVersions) > 0 {
-			fmt.Fprintf(f.writer, "### Default Dependencies\n| name | version |\n|-|-|\n")
+			fmt.Fprintf(f.writer, "### Default Dependencies\n| name | version |\n|---|---|\n")
 			var sortedDependencies []string
 			for key := range config.Metadata.DefaultVersions {
 				sortedDependencies = append(sortedDependencies, key)
@@ -109,7 +109,7 @@ func (f Formatter) Markdown(configs []cargo.Config) {
 				return config.Stacks[i].ID < config.Stacks[j].ID
 			})
 
-			fmt.Fprintf(f.writer, "### Supported Stacks\n| name |\n|-|\n")
+			fmt.Fprintf(f.writer, "### Supported Stacks\n| name |\n|---|\n")
 			for _, s := range config.Stacks {
 				fmt.Fprintf(f.writer, "| %s |\n", s.ID)
 			}

--- a/cargo/jam/internal/formatter_test.go
+++ b/cargo/jam/internal/formatter_test.go
@@ -69,20 +69,20 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 			Expect(buffer.String()).To(Equal(`## some-buildpack some-version
 ### Dependencies
 | name | version | stacks |
-|-|-|-|
+|---|---|---|
 | other-dependency | 2.3.5 | other-stack |
 | other-dependency | 2.3.4 | other-stack, some-stack |
 | some-dependency | 1.2.3 | other-stack, some-stack |
 
 ### Default Dependencies
 | name | version |
-|-|-|
+|---|---|
 | other-dependency | 2.3.x |
 | some-dependency | 1.2.x |
 
 ### Supported Stacks
 | name |
-|-|
+|---|
 | other-stack |
 | some-stack |
 `))
@@ -105,7 +105,7 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 				Expect(buffer.String()).To(Equal(`## some-buildpack some-version
 ### Supported Stacks
 | name |
-|-|
+|---|
 | other-stack |
 | some-stack |
 `))
@@ -153,14 +153,14 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 				Expect(buffer.String()).To(Equal(`## some-buildpack some-version
 ### Dependencies
 | name | version | stacks |
-|-|-|-|
+|---|---|---|
 | other-dependency | 2.3.5 | other-stack |
 | other-dependency | 2.3.4 | other-stack, some-stack |
 | some-dependency | 1.2.3 | other-stack, some-stack |
 
 ### Default Dependencies
 | name | version |
-|-|-|
+|---|---|
 | other-dependency | 2.3.x |
 | some-dependency | 1.2.x |
 
@@ -204,12 +204,12 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 				Expect(buffer.String()).To(Equal(`# some-buildpack some-version
 ### Order Groupings
 | name | version | optional |
-|-|-|-|
+|---|---|---|
 | some-buildpack | 1.2.3 | false |
 | optional-buildpack | 2.3.4 | true |
 
 | name | version | optional |
-|-|-|-|
+|---|---|---|
 | other-buildpack | 3.4.5 | false |
 
 `))


### PR DESCRIPTION
- Github still renders this format properly
- Adds html.md.erb support