### PR TITLE
Deprecates Version field on BuildPlanRequirement and BuildpackPlanEntry

### DIFF
--- a/build.go
+++ b/build.go
@@ -134,11 +134,13 @@ type BuildpackPlanEntry struct {
 
 	// Version if the version contraint that defines what would be an acceptable
 	// dependency provided by the buildpack.
+	//
+	// Deprecated: Retrieve version information from Metadata instead.
 	Version string `toml:"version"`
 
 	// Metadata is an unspecified field allowing buildpacks to communicate extra
 	// details about their requirement. Examples of this type of metadata might
-	// include details about what source was used to decide the Version
+	// include details about what source was used to decide the version
 	// constraint for a requirement.
 	Metadata map[string]interface{} `toml:"metadata"`
 }

--- a/detect.go
+++ b/detect.go
@@ -76,11 +76,13 @@ type BuildPlanRequirement struct {
 
 	// Version allows a requirement to include a constraint describing what
 	// versions of the dependency are considered acceptable.
+	//
+	// Deprecated: Store version information in Metadata instead.
 	Version string `toml:"version"`
 
 	// Metadata is an unspecified field allowing buildpacks to communicate extra
 	// details about their requirement. Examples of this type of metadata might
-	// include details about what source was used to decide the Version
+	// include details about what source was used to decide the version
 	// constraint for a requirement.
 	Metadata interface{} `toml:"metadata"`
 }


### PR DESCRIPTION
These fields were deprecated as part of Buildpack Spec [RFC0043](https://github.com/buildpacks/rfcs/blob/main/text/0043-increase-build-plan-flexibility.md). All buildpacks that make use of these fields should instead switch to using the Metadata field to store/retrieve version information. This field will be removed at some point in the future.