### PR TITLE
build: support image labels in launch.toml

### DIFF
--- a/build.go
+++ b/build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -67,6 +68,10 @@ type BuildResult struct {
 	// Slices is a list of slices that will be returned to the lifecycle to be
 	// exported as separate layers during the export phase.
 	Slices []Slice
+
+	// Labels is a map of key-value pairs that will be returned to the lifecycle to be
+	// added as config label on the image metadata. Keys must be unique.
+	Labels map[string]string `toml:"labels"`
 }
 
 // Process represents a process to be run during the launch phase as described
@@ -252,13 +257,34 @@ func Build(f BuildFunc, options ...Option) {
 		}
 	}
 
-	if len(result.Processes) > 0 || len(result.Slices) > 0 {
+	if len(result.Processes) > 0 ||
+		len(result.Slices) > 0 ||
+		len(result.Labels) > 0 {
+
+		type label struct {
+			Key   string `toml:"key"`
+			Value string `toml:"value"`
+		}
+
 		var launch struct {
 			Processes []Process `toml:"processes"`
 			Slices    []Slice   `toml:"slices"`
+			Labels    []label   `toml:"labels"`
 		}
+
 		launch.Processes = result.Processes
 		launch.Slices = result.Slices
+
+		if len(result.Labels) > 0 {
+			launch.Labels = []label{}
+			for k, v := range result.Labels {
+				launch.Labels = append(launch.Labels, label{Key: k, Value: v})
+			}
+
+			sort.Slice(launch.Labels, func(i, j int) bool {
+				return launch.Labels[i].Key < launch.Labels[j].Key
+			})
+		}
 
 		err = config.tomlWriter.Write(filepath.Join(layersPath, "launch.toml"), launch)
 		if err != nil {

--- a/build_test.go
+++ b/build_test.go
@@ -283,7 +283,33 @@ some-key = "some-value"
 		})
 	})
 
-	context("when there are no processes or slices in the result", func() {
+	context("when there are labels in the result", func() {
+		it("persists a launch.toml", func() {
+			packit.Build(func(ctx packit.BuildContext) (packit.BuildResult, error) {
+				return packit.BuildResult{
+					Labels: map[string]string{
+						"some key":       "some value",
+						"some-other-key": "some-other-value",
+					},
+				}, nil
+			}, packit.WithArgs([]string{binaryPath, layersDir, "", planPath}))
+
+			contents, err := ioutil.ReadFile(filepath.Join(layersDir, "launch.toml"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(string(contents)).To(MatchTOML(`
+	[[labels]]
+	key = "some key"
+	value = "some value"
+
+	[[labels]]
+	key = "some-other-key"
+	value = "some-other-value"
+	`))
+		})
+	})
+
+	context("when there are no processes, slices or labels in the result", func() {
 		it("does not persist a launch.toml", func() {
 			packit.Build(func(ctx packit.BuildContext) (packit.BuildResult, error) {
 				return packit.BuildResult{}, nil


### PR DESCRIPTION
Used a map instead of a Label{string,string} because
the buildpack sepc says there must not be duplicate keys.

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>

Resolves #61 