### PR TITLE
Uses CNB_BUILDPACK_DIR env variable to set CNBPath

### DIFF
--- a/build.go
+++ b/build.go
@@ -183,8 +183,8 @@ func Build(f BuildFunc, options ...Option) {
 		return
 	}
 
-	cnbPath := os.Getenv("CNB_BUILDPACK_DIR")
-	if cnbPath == "" {
+	cnbPath, ok := os.LookupEnv("CNB_BUILDPACK_DIR")
+	if !ok {
 		cnbPath = filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "build")))
 	}
 

--- a/build.go
+++ b/build.go
@@ -178,7 +178,10 @@ func Build(f BuildFunc, options ...Option) {
 		return
 	}
 
-	cnbPath := filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "build")))
+	cnbPath := os.Getenv("CNB_BUILDPACK_DIR")
+	if cnbPath == "" {
+		cnbPath = filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "build")))
+	}
 
 	var buildpackInfo struct {
 		Buildpack BuildpackInfo `toml:"buildpack"`

--- a/detect.go
+++ b/detect.go
@@ -106,8 +106,8 @@ func Detect(f DetectFunc, options ...Option) {
 		return
 	}
 
-	cnbPath := os.Getenv("CNB_BUILDPACK_DIR")
-	if cnbPath == "" {
+	cnbPath, ok := os.LookupEnv("CNB_BUILDPACK_DIR")
+	if !ok {
 		cnbPath = filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "detect")))
 	}
 

--- a/detect.go
+++ b/detect.go
@@ -106,7 +106,10 @@ func Detect(f DetectFunc, options ...Option) {
 		return
 	}
 
-	cnbPath := filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "detect")))
+	cnbPath := os.Getenv("CNB_BUILDPACK_DIR")
+	if cnbPath == "" {
+		cnbPath = filepath.Clean(strings.TrimSuffix(config.args[0], filepath.Join("bin", "detect")))
+	}
 
 	var buildpackInfo struct {
 		Buildpack BuildpackInfo `toml:"buildpack"`


### PR DESCRIPTION
The old strategy is used if it is not available

Implements Buildpack API version 0.3 (and resolves #62 )

Signed-off-by: Timothy Hitchener <thitchener@pivotal.io>