### PR TITLE
Adds Stack ID to detect context

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -25,6 +25,10 @@ type DetectContext struct {
 	// BuildpackInfo includes the details of the buildpack parsed from the
 	// buildpack.toml included in the buildpack contents.
 	BuildpackInfo BuildpackInfo
+
+	// Stack is the value of the chosen stack. This value is populated from the
+	// $CNB_STACK_ID environment variable.
+	Stack string
 }
 
 // DetectFunc is the definition of a callback that can be invoked when the
@@ -124,6 +128,7 @@ func Detect(f DetectFunc, options ...Option) {
 		WorkingDir:    dir,
 		CNBPath:       cnbPath,
 		BuildpackInfo: buildpackInfo.Buildpack,
+		Stack:         os.Getenv("CNB_STACK_ID"),
 	})
 	if err != nil {
 		config.exitHandler.Error(err)

--- a/detect_test.go
+++ b/detect_test.go
@@ -26,6 +26,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		cnbDir      string
 		cnbEnvDir   string
 		binaryPath  string
+		stackID     string
 		exitHandler *fakes.ExitHandler
 	)
 
@@ -44,6 +45,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		cnbDir, err = ioutil.TempDir("", "cnb")
 		Expect(err).NotTo(HaveOccurred())
+
+		stackID = "io.packit.test.stack"
+		Expect(os.Setenv("CNB_STACK_ID", stackID)).To(Succeed())
 
 		//Separate, but valid CNB dir for testing env parsing
 		cnbEnvDir, err = ioutil.TempDir("", "cnbEnv")
@@ -68,6 +72,7 @@ clear-env = false
 		Expect(os.Chdir(workingDir)).To(Succeed())
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		Expect(os.RemoveAll(cnbDir)).To(Succeed())
+		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
 	})
 
 	context("when providing the detect context to the given DetectFunc", func() {
@@ -94,6 +99,7 @@ clear-env = false
 					Name:    "some-name",
 					Version: "some-version",
 				},
+				Stack: stackID,
 			}))
 		})
 	})
@@ -254,6 +260,7 @@ some-key = "some-value"
 					Name:    "some-name",
 					Version: "some-version",
 				},
+				Stack: stackID,
 			}))
 		})
 	})


### PR DESCRIPTION
- This will allow detection logic to differ depending on the stack that
the buildpack is running on.
- This environment variable is available in both build and detect so it
makes sense to extend the functionality we have in build to detect given
that the same information is present.