### PR TITLE
Don't try to flush stdout when exiting with an error

### DIFF
--- a/internal/exit_handler.go
+++ b/internal/exit_handler.go
@@ -50,7 +50,6 @@ func NewExitHandler(options ...Option) ExitHandler {
 }
 
 func (h ExitHandler) Error(err error) {
-	fmt.Fprintln(h.stdout, "")
 	fmt.Fprintln(h.stderr, err)
 
 	var code int

--- a/internal/exit_handler_test.go
+++ b/internal/exit_handler_test.go
@@ -3,7 +3,6 @@ package internal_test
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
 	"testing"
 
 	"github.com/paketo-buildpacks/packit/internal"
@@ -18,15 +17,17 @@ func testExitHandler(t *testing.T, context spec.G, it spec.S) {
 
 		exitCode int
 		stderr   *bytes.Buffer
+		stdout   *bytes.Buffer
 		handler  internal.ExitHandler
 	)
 
 	it.Before(func() {
 		stderr = bytes.NewBuffer([]byte{})
+		stdout = bytes.NewBuffer([]byte{})
 
 		handler = internal.NewExitHandler(
 			internal.WithExitHandlerStderr(stderr),
-			internal.WithExitHandlerStdout(ioutil.Discard),
+			internal.WithExitHandlerStdout(stdout),
 			internal.WithExitHandlerExitFunc(func(c int) { exitCode = c }),
 		)
 	})
@@ -34,6 +35,7 @@ func testExitHandler(t *testing.T, context spec.G, it spec.S) {
 	it("prints the error message and exits with the right error code", func() {
 		handler.Error(errors.New("some-error-message"))
 		Expect(stderr).To(ContainSubstring("some-error-message"))
+		Expect(stdout.String()).To(BeEmpty())
 	})
 
 	context("when the error is nil", func() {


### PR DESCRIPTION
This removes an extra log line that was being printed when the detection for a buildpack failed. Here is an example of what that looked like.

```
===> DETECTING
[detector] ======== Output: paketo-buildpacks/go-build@0.0.36 ========
[detector]
[detector] failed
[detector] ======== Results ========
[detector] fail: paketo-buildpacks/go-build@0.0.36
[detector] ERROR: No buildpack groups passed detection.
[detector] ERROR: Please check that you are running against the correct path.
[detector] ERROR: failed to detect: no buildpacks participating
ERROR: failed to build: executing lifecycle. This may be the result of using an untrusted builder: failed with status code: 100
```