### PR TITLE
print supported versions when an unsupported version of a dependency …

### DIFF
--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -229,9 +229,9 @@ version = "this is super not semver"
 			})
 
 			context("when the entry version constraint cannot be satisfied", func() {
-				it("return an error", func() {
+				it("returns an error with all the supported versions listed", func() {
 					_, err := service.Resolve(path, "some-entry", "9.9.9", "some-stack")
-					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions")))
+					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions. Supported versions are: [1.2.3, 4.5.6]")))
 				})
 			})
 		})


### PR DESCRIPTION
…is specified

resolves paketo-buildpacks/mri/issues/117

Co-authored-by: Josh Zarrabi <jzarrabi@vmware.com>

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:
The "no compatible versions" error message in postal was updated to include the supported versions.

* An explanation of the use cases your change enables:
Buildpack users can now see all the versions of a dependency that are included in the buildpack.

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
