### PR TITLE
Use Docker config.json authentication when running jam update-buildpack

### DIFF
--- a/cargo/jam/internal/image.go
+++ b/cargo/jam/internal/image.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/docker/distribution/reference"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
@@ -32,7 +33,7 @@ func FindLatestImage(uri string) (Image, error) {
 		return Image{}, fmt.Errorf("failed to parse image registry: %w", err)
 	}
 
-	tags, err := remote.List(repo)
+	tags, err := remote.List(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return Image{}, fmt.Errorf("failed to list tags: %w", err)
 	}


### PR DESCRIPTION
## Summary
The `buildpack.toml` and `package.toml` in a buildpack may reference images that are hosted on a private registry. In order for `jam update-buildpack` to query those registries, the command will use the configuration defined for the local Docker daemon.

## Use Cases
If a user is trying to run `jam update-buildpack` and the images referenced in their `buildpack.toml` and `package.toml` are on a private GCR registry, then `jam update-buildpack` will check the local Docker `config.json` for the authentication mechanism for that registry to make an authenticated request to list the latest image tags. In this example, the user would be able to `gcloud auth login` and then `gcloud auth configure-docker`. At this point running `jam update-buildpack` would make correctly authenticated requests to their private registry and update the buildpack with the latest image versions.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
