### PR TITLE
Ensures layer launch/build/cache flags get cleared on Reset

### DIFF
--- a/layer.go
+++ b/layer.go
@@ -80,21 +80,26 @@ type Layer struct {
 // Reset clears the state of a layer such that the layer can be replaced with
 // new content and metadata. It clears all environment variables, and removes
 // the content of the layer directory on disk.
-func (l *Layer) Reset() error {
+func (l Layer) Reset() (Layer, error) {
+	l.Build = false
+	l.Launch = false
+	l.Cache = false
+
 	l.SharedEnv = Environment{}
 	l.BuildEnv = Environment{}
 	l.LaunchEnv = Environment{}
+
 	l.Metadata = nil
 
 	err := os.RemoveAll(l.Path)
 	if err != nil {
-		return fmt.Errorf("error could not remove file: %s", err)
+		return Layer{}, fmt.Errorf("error could not remove file: %s", err)
 	}
 
 	err = os.MkdirAll(l.Path, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("error could not create directory: %s", err)
+		return Layer{}, fmt.Errorf("error could not create directory: %s", err)
 	}
 
-	return nil
+	return l, nil
 }

--- a/layer_test.go
+++ b/layer_test.go
@@ -44,14 +44,16 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 			})
 
 			it("initializes an empty layer", func() {
-				Expect(layer.Reset()).To(Succeed())
+				var err error
+				layer, err = layer.Reset()
+				Expect(err).NotTo(HaveOccurred())
 
 				Expect(layer).To(Equal(packit.Layer{
 					Name:      "some-layer",
 					Path:      filepath.Join(layersDir, "some-layer"),
-					Launch:    true,
-					Build:     true,
-					Cache:     true,
+					Launch:    false,
+					Build:     false,
+					Cache:     false,
 					SharedEnv: packit.Environment{},
 					BuildEnv:  packit.Environment{},
 					LaunchEnv: packit.Environment{},
@@ -66,25 +68,25 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 				sharedEnvDir := filepath.Join(layersDir, "some-layer", "env")
 				Expect(os.MkdirAll(sharedEnvDir, os.ModePerm)).To(Succeed())
 
-				err := ioutil.WriteFile(filepath.Join(sharedEnvDir, "OVERRIDE_VAR.override"), []byte("override-value"), 0644)
+				err := ioutil.WriteFile(filepath.Join(sharedEnvDir, "OVERRIDE_VAR.override"), []byte("override-value"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
 				buildEnvDir := filepath.Join(layersDir, "some-layer", "env.build")
 				Expect(os.MkdirAll(buildEnvDir, os.ModePerm)).To(Succeed())
 
-				err = ioutil.WriteFile(filepath.Join(buildEnvDir, "DEFAULT_VAR.default"), []byte("default-value"), 0644)
+				err = ioutil.WriteFile(filepath.Join(buildEnvDir, "DEFAULT_VAR.default"), []byte("default-value"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(buildEnvDir, "INVALID_VAR.invalid"), []byte("invalid-value"), 0644)
+				err = ioutil.WriteFile(filepath.Join(buildEnvDir, "INVALID_VAR.invalid"), []byte("invalid-value"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
 				launchEnvDir := filepath.Join(layersDir, "some-layer", "env.launch")
 				Expect(os.MkdirAll(launchEnvDir, os.ModePerm)).To(Succeed())
 
-				err = ioutil.WriteFile(filepath.Join(launchEnvDir, "APPEND_VAR.append"), []byte("append-value"), 0644)
+				err = ioutil.WriteFile(filepath.Join(launchEnvDir, "APPEND_VAR.append"), []byte("append-value"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
-				err = ioutil.WriteFile(filepath.Join(launchEnvDir, "APPEND_VAR.delim"), []byte("!"), 0644)
+				err = ioutil.WriteFile(filepath.Join(launchEnvDir, "APPEND_VAR.delim"), []byte("!"), 0600)
 				Expect(err).NotTo(HaveOccurred())
 
 				layer = packit.Layer{
@@ -111,15 +113,16 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 
 			context("when Reset is called on a layer", func() {
 				it("resets all of the layer data and clears the directory", func() {
-					err := layer.Reset()
+					var err error
+					layer, err = layer.Reset()
 					Expect(err).NotTo(HaveOccurred())
 
 					Expect(layer).To(Equal(packit.Layer{
 						Name:      "some-layer",
 						Path:      filepath.Join(layersDir, "some-layer"),
-						Launch:    true,
-						Build:     true,
-						Cache:     true,
+						Launch:    false,
+						Build:     false,
+						Cache:     false,
 						SharedEnv: packit.Environment{},
 						BuildEnv:  packit.Environment{},
 						LaunchEnv: packit.Environment{},
@@ -151,7 +154,7 @@ func testLayer(t *testing.T, context spec.G, it spec.S) {
 						Path: filepath.Join(layersDir, "some-layer"),
 					}
 
-					err := layer.Reset()
+					_, err := layer.Reset()
 					Expect(err).To(MatchError(ContainSubstring("error could not remove file: ")))
 					Expect(err).To(MatchError(ContainSubstring("permission denied")))
 				})


### PR DESCRIPTION
## Summary
The `Layer.Reset` method clears everything except the `Build`/`Launch`/`Cache` flags on the layer. This results in some strange looking code in buildpacks where we can set these flags, then call `Reset` and still have the flags apply later.

## Use Case
This **breaking change** in the API will ensure that these fields are also cleared. That should make code that implements this logic incorrectly break, and hopefully result in buildpacks that have code that is easier to understand.

Please confirm the following:
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
