### PR TITLE
Support the pessimistic operator in versions within postal

### DIFF
--- a/postal/service.go
+++ b/postal/service.go
@@ -57,11 +57,14 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 		}
 	}
 
+	// Handle the pessmistic operator (~>)
 	var re = regexp.MustCompile(`~>`)
 	if re.MatchString(version) {
 		res := re.ReplaceAllString(version, "")
 		parts := strings.Split(res, ".")
 
+		// if the version contains a major, minor, and patch use "~" Tilde Range Comparison
+		// if the version contains a major and minor only, or a major version only use "^" Caret Range Comparison
 		if len(parts) == 3 {
 			version = "~" + res
 		} else {

--- a/postal/service.go
+++ b/postal/service.go
@@ -3,6 +3,7 @@ package postal
 import (
 	"fmt"
 	"io"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -53,6 +54,18 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 		version = "*"
 		if defaultVersion != "" {
 			version = defaultVersion
+		}
+	}
+
+	var re = regexp.MustCompile(`~>`)
+	if re.MatchString(version) {
+		res := re.ReplaceAllString(version, "")
+		parts := strings.Split(res, ".")
+
+		if len(parts) == 3 {
+			version = "~" + res
+		} else {
+			version = "^" + res
 		}
 	}
 

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -140,7 +140,7 @@ version = "4.5.6"
 					deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
 					Expect(err).NotTo(HaveOccurred())
 
-					dependency, err := service.Resolve(path, "some-entry", "~> 1.2.3", "some-stack")
+					dependency, err := service.Resolve(path, "some-entry", "~> 1.2.0", "some-stack")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dependency).To(Equal(postal.Dependency{
 						DeprecationDate: deprecationDate,
@@ -171,7 +171,7 @@ version = "4.5.6"
 				})
 			})
 
-			context("when there is a version with a major line and pessimistic operator (~>)", func() {
+			context("when there is a version with a major line only and pessimistic operator (~>)", func() {
 				it("picks the dependency >= version.0.0 and < major+1.0.0", func() {
 					deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
 					Expect(err).NotTo(HaveOccurred())

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -60,6 +60,20 @@ uri = "some-uri"
 version = "1.2.5"
 
 [[metadata.dependencies]]
+id = "some-random-entry"
+sha256 = "some-random-sha"
+stacks = ["other-random-stack"]
+uri = "some-uri"
+version = "1.3.0"
+
+[[metadata.dependencies]]
+id = "some-random-other-entry"
+sha256 = "some-random-other-sha"
+stacks = ["some-other-random-stack"]
+uri = "some-uri"
+version = "2.0.0"
+
+[[metadata.dependencies]]
 id = "some-entry"
 sha256 = "some-sha"
 stacks = ["some-stack"]
@@ -117,6 +131,60 @@ version = "4.5.6"
 						URI:     "some-uri",
 						SHA256:  "some-sha",
 						Version: "4.5.6",
+					}))
+				})
+			})
+
+			context("when there is a version with a major, minor, patch, and pessimistic operator (~>)", func() {
+				it("picks the dependency >= version and < major.minor+1", func() {
+					deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+					Expect(err).NotTo(HaveOccurred())
+
+					dependency, err := service.Resolve(path, "some-entry", "~> 1.2.3", "some-stack")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(dependency).To(Equal(postal.Dependency{
+						DeprecationDate: deprecationDate,
+						ID:              "some-entry",
+						Stacks:          []string{"some-stack"},
+						URI:             "some-uri",
+						SHA256:          "some-sha",
+						Version:         "1.2.3",
+					}))
+				})
+			})
+
+			context("when there is a version with a major, minor, and pessimistic operator (~>)", func() {
+				it("picks the dependency >= version and < major+1", func() {
+					deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+					Expect(err).NotTo(HaveOccurred())
+
+					dependency, err := service.Resolve(path, "some-entry", "~> 1.1", "some-stack")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(dependency).To(Equal(postal.Dependency{
+						DeprecationDate: deprecationDate,
+						ID:              "some-entry",
+						Stacks:          []string{"some-stack"},
+						URI:             "some-uri",
+						SHA256:          "some-sha",
+						Version:         "1.2.3",
+					}))
+				})
+			})
+
+			context("when there is a version with a major line and pessimistic operator (~>)", func() {
+				it("picks the dependency >= version.0.0 and < major+1.0.0", func() {
+					deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+					Expect(err).NotTo(HaveOccurred())
+
+					dependency, err := service.Resolve(path, "some-entry", "~> 1", "some-stack")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(dependency).To(Equal(postal.Dependency{
+						DeprecationDate: deprecationDate,
+						ID:              "some-entry",
+						Stacks:          []string{"some-stack"},
+						URI:             "some-uri",
+						SHA256:          "some-sha",
+						Version:         "1.2.3",
 					}))
 				})
 			})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

If a version contains the pessimistic operator `~>` (as is common in Ruby Gemfiles), we should support the versioning logic associated with it in the `Resolve` function in `postal/service`. Currently, this operator is ignored.

## Use Cases
<!-- An explanation of the use cases your change enables -->

It's common for a Gemfile to contain something like `ruby "~> 2.0"` as a version. If this version is passed, we should use the semver version constraint equivalent of that when we are resolving a dependency version. 
Based off the relevant [Masterminds/semver](https://github.com/Masterminds/semver#tilde-range-comparisons-patch) docs, the conversion from the `~>` versioning logic to Masterminds/semver should be:
- `~> x` => `^x`
- `~> x.x` => `^x.x`
- `~> x.x.x` => `~x.x.x`


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have added an integration test, if necessary.
