### PR TITLE
Adds command for updating builder.toml

### DIFF
--- a/cargo/jam/commands/update_builder.go
+++ b/cargo/jam/commands/update_builder.go
@@ -1,0 +1,85 @@
+package commands
+
+import (
+	"flag"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/cargo/jam/internal"
+)
+
+type UpdateBuilder struct{}
+
+func NewUpdateBuilder() UpdateBuilder {
+	return UpdateBuilder{}
+}
+
+func (ub UpdateBuilder) Execute(args []string) error {
+	var options struct {
+		BuilderFile  string
+		LifecycleURI string
+	}
+
+	fset := flag.NewFlagSet("update-builder", flag.ContinueOnError)
+	fset.StringVar(&options.BuilderFile, "builder-file", "", "path to the builder.toml file (required)")
+	fset.StringVar(&options.LifecycleURI, "lifecycle-uri", "index.docker.io/buildpacksio/lifecycle", "URI for lifecycle image (optional: default=index.docker.io/buildpacksio/lifecycle)")
+	err := fset.Parse(args)
+	if err != nil {
+		panic(err)
+	}
+
+	if options.BuilderFile == "" {
+		panic("no builder-file flag")
+		// return errors.New("--builder-file is a required flag")
+	}
+
+	builder, err := internal.ParseBuilderConfig(options.BuilderFile)
+	if err != nil {
+		panic(err)
+	}
+
+	for i, buildpack := range builder.Buildpacks {
+		image, err := internal.FindLatestImage(buildpack.URI)
+		if err != nil {
+			panic(err)
+			// return err
+		}
+
+		builder.Buildpacks[i].Version = image.Version
+		builder.Buildpacks[i].URI = fmt.Sprintf("%s:%s", image.Name, image.Version)
+
+		for j, order := range builder.Order {
+			for k, group := range order.Group {
+				if group.ID == image.Path {
+					builder.Order[j].Group[k].Version = image.Version
+				}
+			}
+		}
+	}
+
+	uri, err := url.Parse(options.LifecycleURI)
+	if err != nil {
+		panic(err)
+		// return err
+	}
+
+	uri.Scheme = ""
+
+	lifecycleURI := strings.TrimPrefix(uri.String(), "//")
+
+	image, err := internal.FindLatestImage(lifecycleURI)
+	if err != nil {
+		panic(err)
+		// return err
+	}
+
+	builder.Lifecycle.Version = image.Version
+
+	err = internal.OverwriteBuilderConfig(options.BuilderFile, builder)
+	if err != nil {
+		panic(err)
+	}
+
+	return nil
+}

--- a/cargo/jam/init_test.go
+++ b/cargo/jam/init_test.go
@@ -25,10 +25,11 @@ func TestUnitJam(t *testing.T) {
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("cargo/jam", spec.Report(report.Terminal{}))
+	suite("Errors", testErrors)
 	suite("pack", testPack)
 	suite("summarize", testSummarize)
+	suite("update-builder", testUpdateBuilder)
 	suite("update-buildpack", testUpdateBuildpack)
-	suite("Errors", testErrors)
 
 	suite.Before(func(t *testing.T) {
 		var (

--- a/cargo/jam/internal/builder_config.go
+++ b/cargo/jam/internal/builder_config.go
@@ -1,0 +1,108 @@
+package internal
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/pelletier/go-toml"
+)
+
+type BuilderConfig struct {
+	Description string                   `toml:"description"`
+	Buildpacks  []BuilderConfigBuildpack `toml:"buildpacks"`
+	Lifecycle   BuilderConfigLifecycle   `toml:"lifecycle"`
+	Order       []BuilderConfigOrder     `toml:"order"`
+	Stack       BuilderConfigStack       `toml:"stack"`
+}
+
+type BuilderConfigBuildpack struct {
+	URI     string `toml:"uri"`
+	Version string `toml:"version"`
+}
+
+type BuilderConfigLifecycle struct {
+	Version string `toml:"version"`
+}
+
+type BuilderConfigOrder struct {
+	Group []BuilderConfigOrderGroup `toml:"group"`
+}
+
+type BuilderConfigOrderGroup struct {
+	ID      string `toml:"id"`
+	Version string `toml:"version"`
+}
+type BuilderConfigStack struct {
+	ID              string   `toml:"id"`
+	BuildImage      string   `toml:"build-image"`
+	RunImage        string   `toml:"run-image"`
+	RunImageMirrors []string `toml:"run-image-mirrors"`
+}
+
+// Note: this is to support that buildpackages can refer to this field as `image` or `uri`.
+func (b *BuilderConfigBuildpack) UnmarshalTOML(v interface{}) error {
+	if m, ok := v.(map[string]interface{}); ok {
+		if image, ok := m["image"].(string); ok {
+			b.URI = image
+		}
+
+		if uri, ok := m["uri"].(string); ok {
+			b.URI = uri
+		}
+
+		if version, ok := m["version"].(string); ok {
+			b.Version = version
+		}
+	}
+
+	if b.URI != "" {
+		uri, err := url.Parse(b.URI)
+		if err != nil {
+			return err
+		}
+
+		uri.Scheme = ""
+
+		b.URI = strings.TrimPrefix(uri.String(), "//")
+	}
+
+	return nil
+}
+
+func ParseBuilderConfig(path string) (BuilderConfig, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return BuilderConfig{}, fmt.Errorf("failed to open builder config file: %w", err)
+	}
+	defer file.Close()
+
+	var config BuilderConfig
+	err = toml.NewDecoder(file).Decode(&config)
+	if err != nil {
+		return BuilderConfig{}, fmt.Errorf("failed to parse builder config: %w", err)
+	}
+
+	return config, nil
+}
+
+func OverwriteBuilderConfig(path string, config BuilderConfig) error {
+	for i, buildpack := range config.Buildpacks {
+		if !strings.HasPrefix(buildpack.URI, "docker://") {
+			config.Buildpacks[i].URI = fmt.Sprintf("docker://%s", buildpack.URI)
+		}
+	}
+
+	file, err := os.OpenFile(path, os.O_RDWR|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open builder config file: %w", err)
+	}
+
+	err = toml.NewEncoder(file).Encode(config)
+	if err != nil {
+		return fmt.Errorf("failed to write builder config: %w", err)
+	}
+
+	return nil
+}

--- a/cargo/jam/internal/builder_config_test.go
+++ b/cargo/jam/internal/builder_config_test.go
@@ -1,0 +1,274 @@
+package internal_test
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/cargo/jam/internal"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/matchers"
+)
+
+func testBuilderConfig(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		path string
+	)
+
+	context("ParsePackageConfig", func() {
+		it.Before(func() {
+			file, err := ioutil.TempFile("", "package.toml")
+			Expect(err).NotTo(HaveOccurred())
+			defer file.Close()
+
+			_, err = file.WriteString(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	image = "some-registry/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[lifecycle]
+  version = "0.10.2"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.0.10"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+  build-image = "some-registry/somerepository/build:1.2.3-some-cnb"
+  run-image = "some-registry/somerepository/run:some-cnb"
+  run-image-mirrors = ["some-registry/some-repository/run:some-cnb"]
+			`)
+			Expect(err).NotTo(HaveOccurred())
+
+			path = file.Name()
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(path)).To(Succeed())
+		})
+
+		it("parses the builder.toml configuration", func() {
+			config, err := internal.ParseBuilderConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config).To(Equal(internal.BuilderConfig{
+				Description: "Some description",
+				Buildpacks: []internal.BuilderConfigBuildpack{
+					{
+						URI:     "some-registry/some-repository/some-buildpack-id:0.0.10",
+						Version: "0.0.10",
+					},
+					{
+						URI:     "some-registry/some-repository/other-buildpack-id:0.20.22",
+						Version: "0.20.22",
+					},
+				},
+				Lifecycle: internal.BuilderConfigLifecycle{
+					Version: "0.10.2",
+				},
+				Order: []internal.BuilderConfigOrder{
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/other-buildpack-id",
+								Version: "0.20.22",
+							},
+						},
+					},
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/some-buildpack-id",
+								Version: "0.0.10",
+							},
+						},
+					},
+				},
+				Stack: internal.BuilderConfigStack{
+					ID:              "io.paketo.stacks.some-stack",
+					BuildImage:      "some-registry/somerepository/build:1.2.3-some-cnb",
+					RunImage:        "some-registry/somerepository/run:some-cnb",
+					RunImageMirrors: []string{"some-registry/some-repository/run:some-cnb"},
+				},
+			}))
+		})
+
+		context("failure cases", func() {
+			context("when the file cannot be opened", func() {
+				it.Before(func() {
+					Expect(os.Remove(path)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := internal.ParseBuilderConfig(path)
+					Expect(err).To(MatchError(ContainSubstring("failed to open builder config file:")))
+					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+				})
+			})
+		})
+
+		context("when the file contents cannot be parsed", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(path, []byte("%%%"), 0600)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := internal.ParseBuilderConfig(path)
+				Expect(err).To(MatchError(ContainSubstring("failed to parse builder config:")))
+				Expect(err).To(MatchError(ContainSubstring("keys cannot contain % character")))
+			})
+		})
+
+		context("when a dependency uri is not valid", func() {
+			it.Before(func() {
+				Expect(ioutil.WriteFile(path, []byte(`
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	image = "some-registry/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[[buildpacks]]
+	uri = "%%%"
+  version = "1.2.3"
+					`), 0600)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := internal.ParseBuilderConfig(path)
+				Expect(err).To(MatchError(ContainSubstring("failed to parse builder config:")))
+				Expect(err).To(MatchError(ContainSubstring("invalid URL escape")))
+			})
+		})
+	})
+
+	context("OverwritePackageConfig", func() {
+		it.Before(func() {
+			file, err := ioutil.TempFile("", "builder.toml")
+			Expect(err).NotTo(HaveOccurred())
+			defer file.Close()
+
+			_, err = file.WriteString(`previous contents of the file`)
+			Expect(err).NotTo(HaveOccurred())
+
+			path = file.Name()
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(path)).To(Succeed())
+		})
+
+		it("overwrites the package.toml configuration", func() {
+			err := internal.OverwriteBuilderConfig(path, internal.BuilderConfig{
+				Description: "Some description",
+				Buildpacks: []internal.BuilderConfigBuildpack{
+					{
+						URI:     "some-registry/some-repository/some-buildpack-id:0.0.10",
+						Version: "0.0.10",
+					},
+					{
+						URI:     "some-registry/some-repository/other-buildpack-id:0.20.22",
+						Version: "0.20.22",
+					},
+				},
+				Lifecycle: internal.BuilderConfigLifecycle{
+					Version: "0.10.2",
+				},
+				Order: []internal.BuilderConfigOrder{
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/other-buildpack-id",
+								Version: "0.20.22",
+							},
+						},
+					},
+					{
+						Group: []internal.BuilderConfigOrderGroup{
+							{
+								ID:      "some-repository/some-buildpack-id",
+								Version: "0.0.10",
+							},
+						},
+					},
+				},
+				Stack: internal.BuilderConfigStack{
+					ID:              "io.paketo.stacks.some-stack",
+					BuildImage:      "some-registry/somerepository/build:1.2.3-some-cnb",
+					RunImage:        "some-registry/somerepository/run:some-cnb",
+					RunImageMirrors: []string{"some-registry/some-repository/run:some-cnb"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			contents, err := ioutil.ReadFile(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(contents)).To(MatchTOML(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	uri = "docker://some-registry/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[lifecycle]
+  version = "0.10.2"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.0.10"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+  build-image = "some-registry/somerepository/build:1.2.3-some-cnb"
+  run-image = "some-registry/somerepository/run:some-cnb"
+  run-image-mirrors = ["some-registry/some-repository/run:some-cnb"]
+				`))
+		})
+
+		context("failure cases", func() {
+			context("when the file cannot be opened", func() {
+				it.Before(func() {
+					Expect(os.Remove(path)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					err := internal.OverwriteBuilderConfig(path, internal.BuilderConfig{})
+					Expect(err).To(MatchError(ContainSubstring("failed to open builder config file:")))
+					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+				})
+			})
+		})
+	})
+}

--- a/cargo/jam/internal/formatter.go
+++ b/cargo/jam/internal/formatter.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"sort"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/cargo"
 )
 

--- a/cargo/jam/internal/image.go
+++ b/cargo/jam/internal/image.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/docker/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -41,7 +41,7 @@ func FindLatestImage(uri string) (Image, error) {
 
 	var versions []*semver.Version
 	for _, tag := range tags {
-		version, err := semver.NewVersion(tag)
+		version, err := semver.StrictNewVersion(tag)
 		if err != nil {
 			continue
 		}
@@ -97,7 +97,7 @@ func FindLatestBuildImage(runURI, buildURI string) (Image, error) {
 			continue
 		}
 
-		version, err := semver.NewVersion(strings.TrimSuffix(tag, suffix))
+		version, err := semver.StrictNewVersion(strings.TrimSuffix(tag, suffix))
 		if err != nil {
 			continue
 		}

--- a/cargo/jam/internal/image_test.go
+++ b/cargo/jam/internal/image_test.go
@@ -44,6 +44,7 @@ func testImage(t *testing.T, context spec.G, it spec.S) {
 								"0.0.10",
 								"0.20.1",
 								"0.20.12",
+								"999999",
 								"latest"
 							]
 					}`)
@@ -136,6 +137,7 @@ func testImage(t *testing.T, context spec.G, it spec.S) {
 								"0.20.1",
 								"0.20.12-some-cnb",
 								"0.20.12-other-cnb",
+								"999999-some-cnb",
 								"latest"
 							]
 					}`)

--- a/cargo/jam/internal/image_test.go
+++ b/cargo/jam/internal/image_test.go
@@ -113,5 +113,129 @@ func testImage(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 		})
-	})
+	}, spec.Sequential())
+
+	context("FindLatestBuildImage", func() {
+		it.Before(func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Header.Get("Authorization") != "Basic c29tZS11c2VybmFtZTpzb21lLXBhc3N3b3Jk" {
+					w.Header().Set("WWW-Authenticate", `Basic realm="localhost"`)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				switch req.URL.Path {
+				case "/v2/":
+					w.WriteHeader(http.StatusOK)
+
+				case "/v2/some-org/some-repo-build/tags/list":
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10-some-cnb",
+								"0.20.1",
+								"0.20.12-some-cnb",
+								"0.20.12-other-cnb",
+								"latest"
+							]
+					}`)
+
+				case "/v2/some-org/error-repo/tags/list":
+					w.WriteHeader(http.StatusTeapot)
+
+				default:
+					t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+				}
+			}))
+
+			var err error
+			dockerConfig, err = ioutil.TempDir("", "docker-config")
+			Expect(err).NotTo(HaveOccurred())
+
+			contents := fmt.Sprintf(`{
+				"auths": {
+					%q: {
+						"username": "some-username",
+						"password": "some-password"
+					}
+				}
+			}`, strings.TrimPrefix(server.URL, "http://"))
+
+			err = ioutil.WriteFile(filepath.Join(dockerConfig, "config.json"), []byte(contents), 0600)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(os.Setenv("DOCKER_CONFIG", dockerConfig)).To(Succeed())
+		})
+
+		it.After(func() {
+			Expect(os.Unsetenv("DOCKER_CONFIG")).To(Succeed())
+			Expect(os.RemoveAll(dockerConfig)).To(Succeed())
+		})
+
+		it("returns the latest semver tag for the given image uri", func() {
+			image, err := internal.FindLatestBuildImage(
+				fmt.Sprintf("%s/some-org/some-repo-run:some-cnb", strings.TrimPrefix(server.URL, "http://")),
+				fmt.Sprintf("%s/some-org/some-repo-build:0.0.10-some-cnb", strings.TrimPrefix(server.URL, "http://")),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(image).To(Equal(internal.Image{
+				Name:    fmt.Sprintf("%s/some-org/some-repo-build", strings.TrimPrefix(server.URL, "http://")),
+				Path:    "some-org/some-repo-build",
+				Version: "0.20.12-some-cnb",
+			}))
+		})
+
+		context("failure cases", func() {
+			context("when the run uri cannot be parsed", func() {
+				it("returns an error", func() {
+					_, err := internal.FindLatestBuildImage(
+						"not a valid uri",
+						fmt.Sprintf("%s/some-org/some-repo-build:0.0.10-some-cnb", strings.TrimPrefix(server.URL, "http://")),
+					)
+					Expect(err).To(MatchError("failed to parse run image reference \"not a valid uri\": invalid reference format"))
+				})
+			})
+
+			context("when the run image is not tagged", func() {
+				it("returns an error", func() {
+					_, err := internal.FindLatestBuildImage(
+						fmt.Sprintf("%s/some-org/some-repo-run", strings.TrimPrefix(server.URL, "http://")),
+						fmt.Sprintf("%s/some-org/some-repo-build:0.0.10-some-cnb", strings.TrimPrefix(server.URL, "http://")),
+					)
+					Expect(err).To(MatchError("expected the run image to be tagged but it was not"))
+				})
+			})
+
+			context("when the build uri cannot be parsed", func() {
+				it("returns an error", func() {
+					_, err := internal.FindLatestBuildImage(
+						fmt.Sprintf("%s/some-org/some-repo-run:some-cnb", strings.TrimPrefix(server.URL, "http://")),
+						"not a valid uri",
+					)
+					Expect(err).To(MatchError("failed to parse build image reference \"not a valid uri\": invalid reference format"))
+				})
+			})
+
+			context("when the repo name cannot be parsed", func() {
+				it("returns an error", func() {
+					_, err := internal.FindLatestBuildImage(
+						fmt.Sprintf("%s/some-org/some-repo-run:some-cnb", strings.TrimPrefix(server.URL, "http://")),
+						fmt.Sprintf("%s/a:latest", strings.TrimPrefix(server.URL, "http://")),
+					)
+					Expect(err).To(MatchError("failed to parse build image repository: repository must be between 2 and 255 runes in length: a"))
+				})
+			})
+
+			context("when the tags cannot be listed", func() {
+				it("returns an error", func() {
+					_, err := internal.FindLatestBuildImage(
+						fmt.Sprintf("%s/some-org/some-repo-run:some-cnb", strings.TrimPrefix(server.URL, "http://")),
+						fmt.Sprintf("%s/some-org/error-repo:latest", strings.TrimPrefix(server.URL, "http://")),
+					)
+					Expect(err).To(MatchError(ContainSubstring("failed to list tags:")))
+					Expect(err).To(MatchError(ContainSubstring("status code 418")))
+				})
+			})
+		})
+	}, spec.Sequential())
 }

--- a/cargo/jam/internal/init_test.go
+++ b/cargo/jam/internal/init_test.go
@@ -20,6 +20,7 @@ func TestUnitCargo(t *testing.T) {
 	gomega.SetDefaultEventuallyTimeout(10 * time.Second)
 
 	suite := spec.New("cargo/jam/internal", spec.Report(report.Terminal{}))
+	suite("BuilderConfig", testBuilderConfig)
 	suite("BuildpackConfig", testBuildpackConfig)
 	suite("BuildpackInspector", testBuildpackInspector)
 	suite("DependencyCacher", testDependencyCacher)

--- a/cargo/jam/main.go
+++ b/cargo/jam/main.go
@@ -44,6 +44,9 @@ func main() {
 	case "update-buildpack":
 		command = commands.NewUpdateBuildpack()
 
+	case "update-builder":
+		command = commands.NewUpdateBuilder()
+
 	default:
 		fail("unknown command: %q", os.Args[1])
 	}

--- a/cargo/jam/update_builder_test.go
+++ b/cargo/jam/update_builder_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -74,7 +75,25 @@ func testUpdateBuilder(t *testing.T, context spec.G, it spec.S) {
 							]
 					}`)
 
+			case "/v2/somerepository/build/tags/list":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10-some-cnb",
+								"0.20.1",
+								"0.20.12-some-cnb",
+								"0.20.12-other-cnb",
+								"latest"
+							]
+					}`)
+
 			case "/v2/some-repository/error-buildpack-id/tags/list":
+				w.WriteHeader(http.StatusTeapot)
+
+			case "/v2/some-repository/error-lifecycle/tags/list":
+				w.WriteHeader(http.StatusTeapot)
+
+			case "/v2/somerepository/error-build/tags/list":
 				w.WriteHeader(http.StatusTeapot)
 
 			default:
@@ -114,8 +133,8 @@ description = "Some description"
 
 [stack]
   id = "io.paketo.stacks.some-stack"
-  build-image = "REGISTRY-URI/somerepository/build:1.2.3-some-cnb"
-  run-image = "REGISTRY-URI.io/somerepository/run:some-cnb"
+  build-image = "REGISTRY-URI/somerepository/build:0.0.10-some-cnb"
+  run-image = "REGISTRY-URI/somerepository/run:some-cnb"
   run-image-mirrors = ["REGISTRY-URI/some-repository/run:some-cnb"]
 			`), []byte(`REGISTRY-URI`), []byte(strings.TrimPrefix(server.URL, "http://"))), 0600)
 		Expect(err).NotTo(HaveOccurred())
@@ -130,7 +149,7 @@ description = "Some description"
 			path,
 			"update-builder",
 			"--builder-file", filepath.Join(builderDir, "builder.toml"),
-			"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", server.URL),
+			"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
 		)
 
 		buffer := gbytes.NewBuffer()
@@ -169,9 +188,168 @@ description = "Some description"
 
 [stack]
   id = "io.paketo.stacks.some-stack"
-  build-image = "REGISTRY-URI/somerepository/build:1.2.3-some-cnb"
-  run-image = "REGISTRY-URI.io/somerepository/run:some-cnb"
+  build-image = "REGISTRY-URI/somerepository/build:0.20.12-some-cnb"
+  run-image = "REGISTRY-URI/somerepository/run:some-cnb"
   run-image-mirrors = ["REGISTRY-URI/some-repository/run:some-cnb"]
 			`, "REGISTRY-URI", strings.TrimPrefix(server.URL, "http://"))))
+	})
+
+	context("failure cases", func() {
+		context("when the --builder-file flag is missing", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(Equal("failed to execute: --builder-file is a required flag"))
+			})
+		})
+
+		context("when the builder file cannot be found", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--builder-file", "/no/such/file",
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(Equal("failed to execute: failed to open builder config file: open /no/such/file: no such file or directory"))
+			})
+		})
+
+		context("when the latest buildpack image cannot be found", func() {
+			it.Before(func() {
+				err := ioutil.WriteFile(filepath.Join(builderDir, "builder.toml"), bytes.ReplaceAll([]byte(`
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/error-buildpack-id:0.0.10"
+  version = "0.0.10"
+			`), []byte(`REGISTRY-URI`), []byte(strings.TrimPrefix(server.URL, "http://"))), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--builder-file", filepath.Join(builderDir, "builder.toml"),
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to list tags"))
+			})
+		})
+
+		context("when the latest lifecycle image cannot be found", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--builder-file", filepath.Join(builderDir, "builder.toml"),
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/error-lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to list tags"))
+			})
+		})
+
+		context("when the latest build image cannot be found", func() {
+			it.Before(func() {
+				err := ioutil.WriteFile(filepath.Join(builderDir, "builder.toml"), bytes.ReplaceAll([]byte(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[lifecycle]
+  version = "0.10.2"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.0.10"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+	build-image = "REGISTRY-URI/somerepository/error-build:0.0.10-some-cnb"
+  run-image = "REGISTRY-URI/somerepository/run:some-cnb"
+  run-image-mirrors = ["REGISTRY-URI/some-repository/run:some-cnb"]
+			`), []byte(`REGISTRY-URI`), []byte(strings.TrimPrefix(server.URL, "http://"))), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--builder-file", filepath.Join(builderDir, "builder.toml"),
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to list tags"))
+			})
+		})
+
+		context("when the builder file cannot be overwritten", func() {
+			it.Before(func() {
+				err := os.Chmod(filepath.Join(builderDir, "builder.toml"), 0400)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-builder",
+					"--builder-file", filepath.Join(builderDir, "builder.toml"),
+					"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", strings.TrimPrefix(server.URL, "http://")),
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to open builder config"))
+			})
+		})
 	})
 }

--- a/cargo/jam/update_builder_test.go
+++ b/cargo/jam/update_builder_test.go
@@ -1,0 +1,177 @@
+package main_test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/matchers"
+)
+
+func testUpdateBuilder(t *testing.T, context spec.G, it spec.S) {
+	var (
+		withT      = NewWithT(t)
+		Expect     = withT.Expect
+		Eventually = withT.Eventually
+
+		server     *httptest.Server
+		builderDir string
+	)
+
+	it.Before(func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodHead {
+				http.Error(w, "NotFound", http.StatusNotFound)
+
+				return
+			}
+
+			switch req.URL.Path {
+			case "/v2/":
+				w.WriteHeader(http.StatusOK)
+
+			case "/v2/some-repository/some-buildpack-id/tags/list":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10",
+								"0.20.1",
+								"0.20.12",
+								"latest"
+							]
+					}`)
+
+			case "/v2/some-repository/other-buildpack-id/tags/list":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10",
+								"0.1.0",
+								"0.20.2",
+								"0.20.22"
+							]
+					}`)
+
+			case "/v2/some-repository/lifecycle/tags/list":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintln(w, `{
+						  "tags": [
+								"0.0.10",
+								"0.20.1",
+								"0.21.1",
+								"latest"
+							]
+					}`)
+
+			case "/v2/some-repository/error-buildpack-id/tags/list":
+				w.WriteHeader(http.StatusTeapot)
+
+			default:
+				t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+			}
+		}))
+
+		var err error
+		builderDir, err = ioutil.TempDir("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = ioutil.WriteFile(filepath.Join(builderDir, "builder.toml"), bytes.ReplaceAll([]byte(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/some-buildpack-id:0.0.10"
+  version = "0.0.10"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[lifecycle]
+  version = "0.10.2"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.0.10"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+  build-image = "REGISTRY-URI/somerepository/build:1.2.3-some-cnb"
+  run-image = "REGISTRY-URI.io/somerepository/run:some-cnb"
+  run-image-mirrors = ["REGISTRY-URI/some-repository/run:some-cnb"]
+			`), []byte(`REGISTRY-URI`), []byte(strings.TrimPrefix(server.URL, "http://"))), 0600)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		server.Close()
+	})
+
+	it("updates the builder files", func() {
+		command := exec.Command(
+			path,
+			"update-builder",
+			"--builder-file", filepath.Join(builderDir, "builder.toml"),
+			"--lifecycle-uri", fmt.Sprintf("%s/some-repository/lifecycle", server.URL),
+		)
+
+		buffer := gbytes.NewBuffer()
+		session, err := gexec.Start(command, buffer, buffer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(0), func() string { return string(buffer.Contents()) })
+
+		builderContents, err := ioutil.ReadFile(filepath.Join(builderDir, "builder.toml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(builderContents)).To(MatchTOML(strings.ReplaceAll(`
+description = "Some description"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/some-buildpack-id:0.20.12"
+  version = "0.20.12"
+
+[[buildpacks]]
+	uri = "docker://REGISTRY-URI/some-repository/other-buildpack-id:0.20.22"
+  version = "0.20.22"
+
+[lifecycle]
+  version = "0.21.1"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/other-buildpack-id"
+    version = "0.20.22"
+
+[[order]]
+
+  [[order.group]]
+    id = "some-repository/some-buildpack-id"
+    version = "0.20.12"
+
+[stack]
+  id = "io.paketo.stacks.some-stack"
+  build-image = "REGISTRY-URI/somerepository/build:1.2.3-some-cnb"
+  run-image = "REGISTRY-URI.io/somerepository/run:some-cnb"
+  run-image-mirrors = ["REGISTRY-URI/some-repository/run:some-cnb"]
+			`, "REGISTRY-URI", strings.TrimPrefix(server.URL, "http://"))))
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/Masterminds/semver v1.5.0
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/fatih/color v1.9.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.13
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/cheggaaa/pb/v3 v3.0.5
 	github.com/docker/distribution v2.7.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.1.2
 	github.com/google/go-containerregistry v0.4.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
-	github.com/onsi/gomega v1.10.4
+	github.com/onsi/gomega v1.10.5
 	github.com/pelletier/go-toml v1.8.1
 	github.com/sclevine/spec v1.4.0
 	github.com/ulikunitz/xz v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -25,8 +25,6 @@ github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
-github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
-github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
+github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/postal/service.go
+++ b/postal/service.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/cargo"
 	"github.com/paketo-buildpacks/packit/vacation"
 )


### PR DESCRIPTION

## Summary
<!-- A short explanation of the proposed change -->
A `jam` command that will update a user `builder.toml` to use the latest versions of the buildpacks, lifecycle, and build image.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Maintaining a `builder.toml`.

Partially solves the following [issue](https://github.com/paketo-buildpacks/github-config/issues/187).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
