### PR TITLE
Bump go to 1.16 in create-release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Go
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.16
     - name: Checkout
       uses: actions/checkout@v2
     - name: Run Unit Tests


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Looks like we missed a spot when we bumped Go in #133.  This naturally caused a [failure](https://github.com/paketo-buildpacks/packit/actions/runs/644513058) when we merged in #132.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
