### PR TITLE
Add bill of materials entry facility for postal.Service

### DIFF
--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -16,14 +16,8 @@ type Dependency struct {
 	// ID is the identifier used to specify the dependency.
 	ID string `toml:"id"`
 
-	// Version is the specific version of the dependency.
-	Version string `toml:"version"`
-
 	// Name is the human-readable name of the dependency.
 	Name string `toml:"name"`
-
-	// URI is the uri location of the built dependency.
-	URI string `toml:"uri"`
 
 	// SHA256 is the hex-encoded SHA256 checksum of the built dependency.
 	SHA256 string `toml:"sha256"`
@@ -36,6 +30,12 @@ type Dependency struct {
 
 	// Stacks is a list of stacks for which the dependency is built.
 	Stacks []string `toml:"stacks"`
+
+	// URI is the uri location of the built dependency.
+	URI string `toml:"uri"`
+
+	// Version is the specific version of the dependency.
+	Version string `toml:"version"`
 }
 
 func parseBuildpack(path, name string) ([]Dependency, string, error) {

--- a/postal/service.go
+++ b/postal/service.go
@@ -7,8 +7,10 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/cargo"
 	"github.com/paketo-buildpacks/packit/postal/internal"
 	"github.com/paketo-buildpacks/packit/vacation"
@@ -176,4 +178,29 @@ func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath
 // Deprecated: Use Deliver instead.
 func (s Service) Install(dependency Dependency, cnbPath, layerPath string) error {
 	return s.Deliver(dependency, cnbPath, layerPath, "/platform")
+}
+
+// GenerateBillOfMaterials will generate a list of BOMEntry values given a
+// collection of Dependency values.
+func (s Service) GenerateBillOfMaterials(dependencies ...Dependency) []packit.BOMEntry {
+	var entries []packit.BOMEntry
+	for _, dependency := range dependencies {
+		entry := packit.BOMEntry{
+			Name: dependency.Name,
+			Metadata: map[string]interface{}{
+				"sha256":  dependency.SHA256,
+				"stacks":  dependency.Stacks,
+				"uri":     dependency.URI,
+				"version": dependency.Version,
+			},
+		}
+
+		if (dependency.DeprecationDate != time.Time{}) {
+			entry.Metadata["deprecation-date"] = dependency.DeprecationDate
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
With the addition of buildpack spec API 0.5 support in recent versions of `packit`, it makes sense to add some convenience functionality that allows buildpack authors to quickly decorate their buildpacks with bill of materials data if they are using `postal`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
The `postal.Service` type now includes a `GenerateBillOfMaterials` method that will convert a list of `postal.Dependency` values into a valid list of `packit.BOMEntry` values. These can then be included in the `packit.LaunchMetadata` or the `packit.BuildMetadata` as needed.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
