### PR TITLE
Adds support for writing text files in Vacation

### DIFF
--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -450,7 +450,8 @@ version = "this is super not semver"
 
 			context("when the file contents are empty", func() {
 				it.Before(func() {
-					buffer := bytes.NewBuffer(nil)
+					// This is a FLAC header
+					buffer := bytes.NewBuffer([]byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
 					transport.DropCall.Returns.ReadCloser = io.NopCloser(buffer)
 
 					sum := sha256.Sum256(buffer.Bytes())
@@ -703,7 +704,8 @@ version = "this is super not semver"
 
 			context("when the file contents are empty", func() {
 				it.Before(func() {
-					buffer := bytes.NewBuffer(nil)
+					// This is a FLAC header
+					buffer := bytes.NewBuffer([]byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
 					transport.DropCall.Returns.ReadCloser = io.NopCloser(buffer)
 
 					sum := sha256.Sum256(buffer.Bytes())

--- a/vacation/init_test.go
+++ b/vacation/init_test.go
@@ -13,6 +13,7 @@ func TestVacation(t *testing.T) {
 	suite("VacationTar", testVacationTar)
 	suite("VacationTarGzip", testVacationTarGzip)
 	suite("VacationTarXZ", testVacationTarXZ)
+	suite("VacationText", testVacationText)
 	suite("VacationZip", testVacationZip)
 	suite.Run(t)
 }

--- a/vacation/vacation_archive_test.go
+++ b/vacation/vacation_archive_test.go
@@ -264,7 +264,8 @@ func testVacationArchive(t *testing.T, context spec.G, it spec.S) {
 					tempDir, err = os.MkdirTemp("", "vacation")
 					Expect(err).NotTo(HaveOccurred())
 
-					buffer := bytes.NewBuffer([]byte(`some contents`))
+					// This is a FLAC header
+					buffer := bytes.NewBuffer([]byte("\x66\x4C\x61\x43\x00\x00\x00\x22"))
 
 					archive = vacation.NewArchive(buffer)
 				})

--- a/vacation/vacation_text_test.go
+++ b/vacation/vacation_text_test.go
@@ -1,0 +1,49 @@
+package vacation_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/vacation"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testVacationText(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	context("when passed the reader of a text file", func() {
+		var (
+			archive vacation.Archive
+			tempDir string
+		)
+
+		it.Before(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "vacation")
+			Expect(err).NotTo(HaveOccurred())
+
+			buffer := bytes.NewBuffer([]byte(`some contents`))
+
+			archive = vacation.NewArchive(buffer)
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
+		})
+
+		it("writes a text file onto the path", func() {
+			err := archive.Decompress(tempDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			content, err := os.ReadFile(filepath.Join(tempDir, "artifact"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(content).To(Equal([]byte(`some contents`)))
+		})
+	})
+}


### PR DESCRIPTION
Signed-off-by: Timothy Hitchener <thitchener@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adds support for handling writing text files in vacation.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This change allows us to download buildpack dependencies that are scripts as opposed to traditional archive formats

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
