### PR TITLE
Test out GHA automation for synchronizing labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,18 @@
+- name: status/possible-priority
+  description: This issue is ready to work and should be considered as a potential priority
+  color: F9D0C4
+- name: status/prioritized
+  description: This issue has been triaged and resolving it is a priority
+  color: BFD4F2
+- name: status/blocked
+  description: This issue has been triaged and resolving it is blocked on some other issue
+  color: 848978
+- name: bug
+  description: Something isn't working
+  color: d73a4a
+- name: enhancement
+  description: A new feature or request
+  color: a2eeef
+- name: documentation
+  description: This issue relates to writing documentation
+  color: D4C5F9

--- a/.github/workflows/synchronize-labels.yml
+++ b/.github/workflows/synchronize-labels.yml
@@ -1,0 +1,17 @@
+name: Synchronize Labels
+"on":
+    push:
+        branches:
+            - main
+        paths:
+            - .github/labels.yml
+jobs:
+    synchronize:
+        name: Synchronize Labels
+        runs-on:
+            - ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: micnncim/action-label-syncer@v1
+              env:
+                GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR adds a Github workflow to synchronize the labels on a repository based on a `.github/labels.yml` file. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

I am testing it out on this repo, with the goal of moving this to paketo-buildpacks/github-config eventually so we have consistent label titles/colors/descriptions across all of our repos.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
