### PR TITLE
Fixes vacation regression

### DIFF
--- a/vacation/init_test.go
+++ b/vacation/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestVacation(t *testing.T) {
 	suite := spec.New("vacation", spec.Report(report.Terminal{}))
 	suite("VacationArchive", testVacationArchive)
+	suite("VacationSymlinkSorting", testVacationSymlinkSorting)
 	suite("VacationTar", testVacationTar)
 	suite("VacationTarGzip", testVacationTarGzip)
 	suite("VacationTarXZ", testVacationTarXZ)

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -93,6 +93,11 @@ func (ta TarArchive) Decompress(destination string) error {
 			return fmt.Errorf("failed to read tar response: %s", err)
 		}
 
+		// Skip if the destination it the destination directory itself i.e. ./
+		if hdr.Name == "."+string(filepath.Separator) {
+			continue
+		}
+
 		err = checkExtractPath(hdr.Name, destination)
 		if err != nil {
 			return err
@@ -328,6 +333,11 @@ func (z ZipArchive) Decompress(destination string) error {
 	}
 
 	for _, f := range zr.File {
+		// Skip if the destination it the destination directory itself i.e. ./
+		if f.Name == "."+string(filepath.Separator) {
+			continue
+		}
+
 		err = checkExtractPath(f.Name, destination)
 		if err != nil {
 			return err
@@ -409,12 +419,8 @@ func (z ZipArchive) Decompress(destination string) error {
 }
 
 // This function checks to see that the given path is within the destination
-// directory or it is the destination directory itself i.e. ./
+// directory
 func checkExtractPath(filePath string, destination string) error {
-	if filePath == "."+string(os.PathSeparator) {
-		return nil
-	}
-
 	destpath := filepath.Join(destination, filePath)
 	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
 		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", filePath)

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -411,8 +411,12 @@ func (z ZipArchive) Decompress(destination string) error {
 // This function checks to see that the given path is within the destination
 // directory or it is the destination directory itself i.e. ./
 func checkExtractPath(filePath string, destination string) error {
+	if filePath == "."+string(os.PathSeparator) {
+		return nil
+	}
+
 	destpath := filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) && destpath != filepath.Clean(destination) {
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
 		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", filePath)
 	}
 	return nil

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -76,6 +76,8 @@ func (ta TarArchive) Decompress(destination string) error {
 	// metadata.
 	directories := map[string]interface{}{}
 
+	// Struct and slice to collect symlinks and create them after all files have
+	// been created
 	type header struct {
 		name     string
 		linkname string
@@ -166,6 +168,18 @@ func (ta TarArchive) Decompress(destination string) error {
 		}
 	}
 
+	// Sort the symlinks so that symlinks of symlinks have their base link
+	// created before they are created.
+	//
+	// For example:
+	// b-sym -> a-sym/file
+	// a-sym -> dir
+	// c-sym -> a-sym/other-file
+	//
+	// Will sort to:
+	// a-sym -> dir
+	// b-sym -> a-sym/file
+	// c-sym -> a-sym/other-file
 	sort.Slice(symlinkHeaders, func(i, j int) bool {
 		return filepath.Clean(symlinkHeaders[i].name) < filepath.Clean(filepath.Join(filepath.Dir(symlinkHeaders[j].name), symlinkHeaders[j].linkname))
 	})
@@ -313,6 +327,8 @@ func NewZipArchive(inputReader io.Reader) ZipArchive {
 // Decompress reads from ZipArchive and writes files into the destination
 // specified.
 func (z ZipArchive) Decompress(destination string) error {
+	// Struct and slice to collect symlinks and create them after all files have
+	// been created
 	type header struct {
 		name     string
 		linkname string
@@ -400,6 +416,18 @@ func (z ZipArchive) Decompress(destination string) error {
 		}
 	}
 
+	// Sort the symlinks so that symlinks of symlinks have their base link
+	// created before they are created.
+	//
+	// For example:
+	// b-sym -> a-sym/file
+	// a-sym -> dir
+	// c-sym -> a-sym/other-file
+	//
+	// Will sort to:
+	// a-sym -> dir
+	// b-sym -> a-sym/file
+	// c-sym -> a-sym/other-file
 	sort.Slice(symlinkHeaders, func(i, j int) bool {
 		return filepath.Clean(symlinkHeaders[i].name) < filepath.Clean(filepath.Join(filepath.Dir(symlinkHeaders[j].name), symlinkHeaders[j].linkname))
 	})

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -409,10 +409,10 @@ func (z ZipArchive) Decompress(destination string) error {
 }
 
 // This function checks to see that the given path is within the destination
-// directory
+// directory or it is the destination directory itself i.e. ./
 func checkExtractPath(filePath string, destination string) error {
 	destpath := filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) && destpath != filepath.Clean(destination) {
 		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", filePath)
 	}
 	return nil

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/gabriel-vasile/mimetype"
@@ -165,11 +166,15 @@ func (ta TarArchive) Decompress(destination string) error {
 		}
 	}
 
+	sort.Slice(symlinkHeaders, func(i, j int) bool {
+		return filepath.Clean(symlinkHeaders[i].name) < filepath.Clean(filepath.Join(filepath.Dir(symlinkHeaders[j].name), symlinkHeaders[j].linkname))
+	})
+
 	for _, h := range symlinkHeaders {
 		// Check to see if the file that will be linked to is valid for symlinking
 		_, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(h.path), h.linkname))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to evaluate symlink %s: %w", h.path, err)
 		}
 
 		// Check that the file being symlinked to is inside the destination
@@ -395,11 +400,15 @@ func (z ZipArchive) Decompress(destination string) error {
 		}
 	}
 
+	sort.Slice(symlinkHeaders, func(i, j int) bool {
+		return filepath.Clean(symlinkHeaders[i].name) < filepath.Clean(filepath.Join(filepath.Dir(symlinkHeaders[j].name), symlinkHeaders[j].linkname))
+	})
+
 	for _, h := range symlinkHeaders {
 		// Check to see if the file that will be linked to is valid for symlinking
 		_, err := filepath.EvalSymlinks(filepath.Join(filepath.Dir(h.path), h.linkname))
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to evaluate symlink %s: %w", h.path, err)
 		}
 
 		// Check that the file being symlinked to is inside the destination

--- a/vacation/vacation_symlink_sorting_test.go
+++ b/vacation/vacation_symlink_sorting_test.go
@@ -1,0 +1,167 @@
+package vacation_test
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/vacation"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testVacationSymlinkSorting(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	context("TarArchive test that symlinks are sorted so that symlink to other symlinks are created after the initial symlink", func() {
+		var (
+			tempDir    string
+			tarArchive vacation.TarArchive
+		)
+
+		it.Before(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "vacation")
+			Expect(err).NotTo(HaveOccurred())
+
+			buffer := bytes.NewBuffer(nil)
+			tw := tar.NewWriter(buffer)
+
+			Expect(tw.WriteHeader(&tar.Header{Name: "b-symlink", Mode: 0755, Size: int64(0), Typeflag: tar.TypeSymlink, Linkname: filepath.Join("a-symlink", "x")})).To(Succeed())
+			_, err = tw.Write([]byte{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tw.WriteHeader(&tar.Header{Name: "a-symlink", Mode: 0755, Size: int64(0), Typeflag: tar.TypeSymlink, Linkname: "z"})).To(Succeed())
+			_, err = tw.Write([]byte{})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tw.WriteHeader(&tar.Header{Name: "z", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
+			_, err = tw.Write(nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			xFile := filepath.Join("z", "x")
+			Expect(tw.WriteHeader(&tar.Header{Name: xFile, Mode: 0755, Size: int64(len(xFile))})).To(Succeed())
+			_, err = tw.Write([]byte(xFile))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(tw.Close()).To(Succeed())
+
+			tarArchive = vacation.NewTarArchive(bytes.NewReader(buffer.Bytes()))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
+		})
+
+		it("unpackages the archive into the path", func() {
+			var err error
+			err = tarArchive.Decompress(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			files, err := filepath.Glob(fmt.Sprintf("%s/*", tempDir))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(files).To(ConsistOf([]string{
+				filepath.Join(tempDir, "a-symlink"),
+				filepath.Join(tempDir, "b-symlink"),
+				filepath.Join(tempDir, "z"),
+			}))
+
+			Expect(filepath.Join(tempDir, "z")).To(BeADirectory())
+			Expect(filepath.Join(tempDir, "z", "x")).To(BeARegularFile())
+
+			link, err := os.Readlink(filepath.Join(tempDir, "a-symlink"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(Equal("z"))
+
+			data, err := os.ReadFile(filepath.Join(tempDir, "b-symlink"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).To(Equal([]byte(filepath.Join("z", "x"))))
+		})
+	})
+
+	context("ZipArchive test that symlinks are sorted so that symlink to other symlinks are created after the initial symlink", func() {
+		var (
+			tempDir    string
+			zipArchive vacation.ZipArchive
+		)
+
+		it.Before(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "vacation")
+			Expect(err).NotTo(HaveOccurred())
+
+			buffer := bytes.NewBuffer(nil)
+			zw := zip.NewWriter(buffer)
+
+			fileHeader := &zip.FileHeader{Name: "b-symlink"}
+			fileHeader.SetMode(0755 | os.ModeSymlink)
+
+			bSymlink, err := zw.CreateHeader(fileHeader)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = bSymlink.Write([]byte(filepath.Join("a-symlink", "x")))
+			Expect(err).NotTo(HaveOccurred())
+
+			fileHeader = &zip.FileHeader{Name: "a-symlink"}
+			fileHeader.SetMode(0755 | os.ModeSymlink)
+
+			aSymlink, err := zw.CreateHeader(fileHeader)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = aSymlink.Write([]byte(`z`))
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = zw.Create("z" + string(filepath.Separator))
+			Expect(err).NotTo(HaveOccurred())
+
+			fileHeader = &zip.FileHeader{Name: filepath.Join("z", "x")}
+			fileHeader.SetMode(0644)
+
+			xFile, err := zw.CreateHeader(fileHeader)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = xFile.Write([]byte("x file"))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(zw.Close()).To(Succeed())
+
+			zipArchive = vacation.NewZipArchive(bytes.NewReader(buffer.Bytes()))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(tempDir)).To(Succeed())
+		})
+
+		it("unpackages the archive into the path", func() {
+			var err error
+			err = zipArchive.Decompress(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			files, err := filepath.Glob(fmt.Sprintf("%s/*", tempDir))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(files).To(ConsistOf([]string{
+				filepath.Join(tempDir, "a-symlink"),
+				filepath.Join(tempDir, "b-symlink"),
+				filepath.Join(tempDir, "z"),
+			}))
+
+			Expect(filepath.Join(tempDir, "z")).To(BeADirectory())
+			Expect(filepath.Join(tempDir, "z", "x")).To(BeARegularFile())
+
+			link, err := os.Readlink(filepath.Join(tempDir, "a-symlink"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(link).To(Equal("z"))
+
+			data, err := os.ReadFile(filepath.Join(tempDir, "b-symlink"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(data).To(Equal([]byte(`x file`)))
+		})
+	})
+}

--- a/vacation/vacation_tar_gzip_test.go
+++ b/vacation/vacation_tar_gzip_test.go
@@ -35,6 +35,12 @@ func testVacationTarGzip(t *testing.T, context spec.G, it spec.S) {
 			gw := gzip.NewWriter(buffer)
 			tw := tar.NewWriter(gw)
 
+			// Some archive files will make a relative top level path directory these
+			// should still successfully decompress.
+			Expect(tw.WriteHeader(&tar.Header{Name: "./", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
+			_, err = tw.Write(nil)
+			Expect(err).NotTo(HaveOccurred())
+
 			Expect(tw.WriteHeader(&tar.Header{Name: "some-dir", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
 			_, err = tw.Write(nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/vacation/vacation_tar_gzip_test.go
+++ b/vacation/vacation_tar_gzip_test.go
@@ -35,12 +35,6 @@ func testVacationTarGzip(t *testing.T, context spec.G, it spec.S) {
 			gw := gzip.NewWriter(buffer)
 			tw := tar.NewWriter(gw)
 
-			// Some archive files will make a relative top level path directory these
-			// should still successfully decompress.
-			Expect(tw.WriteHeader(&tar.Header{Name: "./", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
-			_, err = tw.Write(nil)
-			Expect(err).NotTo(HaveOccurred())
-
 			Expect(tw.WriteHeader(&tar.Header{Name: "some-dir", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
 			_, err = tw.Write(nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/vacation/vacation_tar_test.go
+++ b/vacation/vacation_tar_test.go
@@ -33,6 +33,12 @@ func testVacationTar(t *testing.T, context spec.G, it spec.S) {
 			buffer := bytes.NewBuffer(nil)
 			tw := tar.NewWriter(buffer)
 
+			// Some archive files will make a relative top level path directory these
+			// should still successfully decompress.
+			Expect(tw.WriteHeader(&tar.Header{Name: "./", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
+			_, err = tw.Write(nil)
+			Expect(err).NotTo(HaveOccurred())
+
 			Expect(tw.WriteHeader(&tar.Header{Name: "some-dir", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
 			_, err = tw.Write(nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/vacation/vacation_tar_test.go
+++ b/vacation/vacation_tar_test.go
@@ -255,6 +255,7 @@ func testVacationTar(t *testing.T, context spec.G, it spec.S) {
 
 				it("returns an error", func() {
 					err := zipSlipSymlinkTar.Decompress(tempDir)
+					Expect(err).To(MatchError(ContainSubstring("failed to evaluate symlink")))
 					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 				})
 			})

--- a/vacation/vacation_zip_test.go
+++ b/vacation/vacation_zip_test.go
@@ -42,6 +42,11 @@ func testVacationZip(t *testing.T, context spec.G, it spec.S) {
 			_, err = symlink.Write([]byte(filepath.Join("some-dir", "some-other-dir", "some-file")))
 			Expect(err).NotTo(HaveOccurred())
 
+			// Some archive files will make a relative top level path directory these
+			// should still successfully decompress.
+			_, err = zw.Create("./")
+			Expect(err).NotTo(HaveOccurred())
+
 			_, err = zw.Create("some-dir/")
 			Expect(err).NotTo(HaveOccurred())
 

--- a/vacation/vacation_zip_test.go
+++ b/vacation/vacation_zip_test.go
@@ -82,7 +82,7 @@ func testVacationZip(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(tempDir)).To(Succeed())
 		})
 
-		it("downloads the dependency and unpackages it into the path", func() {
+		it("unpackages the archive into the path", func() {
 			var err error
 			err = zipArchive.Decompress(tempDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -223,6 +223,7 @@ func testVacationZip(t *testing.T, context spec.G, it spec.S) {
 					readyArchive := vacation.NewZipArchive(buffer)
 
 					err := readyArchive.Decompress(tempDir)
+					Expect(err).To(MatchError(ContainSubstring("failed to evaluate symlink")))
 					Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
 				})
 			})


### PR DESCRIPTION
- Some archive files can have a relative reference to the destination
directory i.e. `./`. These files should still be able to be decompressed
so logic has been added to see if the destination path of the file is
the destination directory itself.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
