### PR TITLE
Fixes tag action reference in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -38,7 +38,7 @@ jobs:
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
     - name: Tag
       id: tag
-      uses: paketo-buildpacks/github-config/actions/tag@main
+      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
     - name: Package Jam
       run : ./scripts/package.sh
     - name: Create Draft Release


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The action that increments the tag for a release was moved in https://github.com/paketo-buildpacks/github-config/pull/258. This updates the workflow to match that change.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
