### PR TITLE
Add support for supplying strip-components via buildpack.toml

### DIFF
--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -36,6 +36,10 @@ type Dependency struct {
 
 	// Version is the specific version of the dependency.
 	Version string `toml:"version"`
+
+	// StripComponents behaves like the --strip-components flag on tar command
+	// removing the first n levels from the final decompression destination.
+	StripComponents int `toml:"strip-components"`
 }
 
 func parseBuildpack(path, name string) ([]Dependency, string, error) {

--- a/postal/service.go
+++ b/postal/service.go
@@ -156,7 +156,7 @@ func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath
 
 	validatedReader := cargo.NewValidatedReader(bundle, dependency.SHA256)
 
-	err = vacation.NewArchive(validatedReader).Decompress(layerPath)
+	err = vacation.NewArchive(validatedReader).StripComponents(dependency.StripComponents).Decompress(layerPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <sambhavs.email@gmail.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds a `strip-components` flag to postal’s service resolver. So that when it parses the buildpack tomls it can use artifacts that are tar’d in a slightly different manner. This would allow for customization of paketo forks that only have a different buildpack.toml.

For more details see https://paketobuildpacks.slack.com/archives/CULAS8ACD/p1619441959093300

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
