### PR TITLE
use docker auth when pulling buildpackage ID from image metadata

### DIFF
--- a/cargo/jam/internal/image.go
+++ b/cargo/jam/internal/image.go
@@ -124,7 +124,7 @@ func GetBuildpackageID(uri string) (string, error) {
 		return "", err
 	}
 
-	image, err := remote.Image(ref)
+	image, err := remote.Image(ref, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Resolves #175 
When `GetBuildpackageID` was added, the image fetch command did not include the authentication option needed to pick up auth from the docker daemon. The WithAuthFromKeychain option has been added to align with the other uses of `remote.List()`

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
