### PR TITLE
Add jam update-dependencies that uses the dep-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ The `packit` library comes with a command-line tool called `jam` that can be
 used to create buildpack tarball artifacts. The `jam` name is simply a play on
 the idea of "packaging" or "packing" a buildpack.
 
+`jam` comes with the following commands:
+* help                : Help about any command
+* pack                : package buildpack
+* summarize           : summarize buildpackage
+* update-builder      : update builder
+* update-buildpack    : update buildpack
+* update-dependencies : update all depdendencies in a buildpack.toml according to metadata.constraints
+
 The `jam` executable can be installed by downloading the latest version from
 the [Releases](../../releases) page. Once downloaded, buildpacks can be created from
 a source repository using the `pack` command like this:
@@ -240,6 +248,5 @@ jam pack \
   --offline \
   --output ./buildpack.tgz
 ```
-
 ---
 Readme created from Go doc with [goreadme](https://github.com/posener/goreadme)

--- a/cargo/buildpack_parser_test.go
+++ b/cargo/buildpack_parser_test.go
@@ -38,6 +38,8 @@ pre-package = "some-pre-package-script.sh"
   id = "some-dependency"
   name = "Some Dependency"
   sha256 = "shasum"
+	source = "source"
+  source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   uri = "http://some-url"
   version = "1.2.3"
@@ -80,6 +82,8 @@ pre-package = "some-pre-package-script.sh"
 							ID:              "some-dependency",
 							Name:            "Some Dependency",
 							SHA256:          "shasum",
+							Source:          "source",
+							SourceSHA256:    "source-shasum",
 							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
 							URI:             "http://some-url",
 							Version:         "1.2.3",

--- a/cargo/config.go
+++ b/cargo/config.go
@@ -78,6 +78,8 @@ func EncodeConfig(writer io.Writer, config Config) error {
 		return err
 	}
 
+	c = convertPatches(config.Metadata.DependencyConstraints, c)
+
 	return toml.NewEncoder(writer).Encode(c)
 }
 
@@ -191,4 +193,16 @@ func (cd ConfigMetadataDependency) HasStack(stack string) bool {
 	}
 
 	return false
+}
+
+// Unmarshal stores json numbers in float64 types, adding an unnecessary decimal point to the patch in the final toml.
+// convertPatches converts this float64 into an int and returns a new map that contains an integer value for patches
+func convertPatches(constraints []ConfigMetadataDependencyConstraint, c map[string]interface{}) map[string]interface{} {
+	if len(constraints) > 0 {
+		for i, dependencyConstraint := range c["metadata"].(map[string]interface{})["dependency-constraints"].([]interface{}) {
+			patches := dependencyConstraint.(map[string]interface{})["patches"]
+			c["metadata"].(map[string]interface{})["dependency-constraints"].([]interface{})[i].(map[string]interface{})["patches"] = int(patches.(float64))
+		}
+	}
+	return c
 }

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -122,7 +122,7 @@ some-dependency = "1.2.x"
 [[metadata.dependency-constraints]]
   id = "some-dependency"
   constraint = "1.*"
-	patches = 1.0
+	patches = 1
 
 [[metadata.some-map]]
   key = "value"

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -160,6 +160,23 @@ some-dependency = "1.2.x"
 					Expect(err).To(MatchError(ContainSubstring("json: unsupported type")))
 				})
 			})
+
+			context("when the patches in dependency constraints cannot be converted to an int", func() {
+				it("returns an error", func() {
+					err := cargo.EncodeConfig(bytes.NewBuffer(nil), cargo.Config{
+						Metadata: cargo.ConfigMetadata{
+							DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+								{
+									Constraint: "some-valid-constraint",
+									ID:         "some-valid-ID",
+									Patches:    0,
+								},
+							},
+						},
+					})
+					Expect(err).To(MatchError(ContainSubstring("failure to assert type: unexpected data in constraint patches")))
+				})
+			})
 		})
 	})
 

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -60,9 +60,18 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							ID:              "some-dependency",
 							Name:            "Some Dependency",
 							SHA256:          "shasum",
+							Source:          "source",
+							SourceSHA256:    "source-shasum",
 							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
 							URI:             "http://some-url",
 							Version:         "1.2.3",
+						},
+					},
+					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+						{
+							ID:         "some-dependency",
+							Constraint: "1.*",
+							Patches:    1,
 						},
 					},
 					DefaultVersions: map[string]string{
@@ -104,9 +113,16 @@ some-dependency = "1.2.x"
   id = "some-dependency"
   name = "Some Dependency"
   sha256 = "shasum"
+	source = "source"
+  source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   uri = "http://some-url"
   version = "1.2.3"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1.0
 
 [[metadata.some-map]]
   key = "value"
@@ -170,9 +186,16 @@ some-dependency = "1.2.x"
   id = "some-dependency"
   name = "Some Dependency"
   sha256 = "shasum"
+	source = "source"
+  source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   uri = "http://some-url"
   version = "1.2.3"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1
 
 [[stacks]]
   id = "some-stack-id"
@@ -220,12 +243,21 @@ some-dependency = "1.2.x"
 					PrePackage: "some-pre-package-script.sh",
 					Dependencies: []cargo.ConfigMetadataDependency{
 						{
-							ID:      "some-dependency",
-							Name:    "Some Dependency",
-							SHA256:  "shasum",
-							Stacks:  []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-							URI:     "http://some-url",
-							Version: "1.2.3",
+							ID:           "some-dependency",
+							Name:         "Some Dependency",
+							SHA256:       "shasum",
+							Source:       "source",
+							SourceSHA256: "source-shasum",
+							Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:          "http://some-url",
+							Version:      "1.2.3",
+						},
+					},
+					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+						{
+							ID:         "some-dependency",
+							Constraint: "1.*",
+							Patches:    1,
 						},
 					},
 					DefaultVersions: map[string]string{
@@ -312,6 +344,14 @@ some-dependency = "1.2.x"
 					it("it returns an error", func() {
 						var metadata cargo.ConfigMetadata
 						err := metadata.UnmarshalJSON([]byte(`{"dependencies": true}`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+
+				context("metadata field dependency-constraints is not an array of objects", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`{"dependency-constraints": true}`))
 						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
 					})
 				})

--- a/cargo/jam/commands/update_dependencies.go
+++ b/cargo/jam/commands/update_dependencies.go
@@ -1,0 +1,95 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/paketo-buildpacks/packit/cargo"
+	"github.com/paketo-buildpacks/packit/cargo/jam/internal"
+	"github.com/spf13/cobra"
+)
+
+type updateDependenciesFlags struct {
+	buildpackFile string
+	api           string
+}
+
+func updateDependencies() *cobra.Command {
+	flags := &updateDependenciesFlags{}
+	cmd := &cobra.Command{
+		Use:   "update-dependencies",
+		Short: "updates all depdendencies in a buildpack.toml according to metadata.constraints",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateDependenciesRun(*flags)
+		},
+	}
+	cmd.Flags().StringVar(&flags.buildpackFile, "buildpack-file", "", "path to the buildpack.toml file (required)")
+	cmd.Flags().StringVar(&flags.api, "api", "https://api.deps.paketo.io", "api to query for dependencies")
+
+	err := cmd.MarkFlagRequired("buildpack-file")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Unable to mark buildpack-file flag as required")
+	}
+	return cmd
+}
+
+func init() {
+	rootCmd.AddCommand(updateDependencies())
+}
+
+func updateDependenciesRun(flags updateDependenciesFlags) error {
+	configParser := cargo.NewBuildpackParser()
+	config, err := configParser.Parse(flags.buildpackFile)
+	if err != nil {
+		return fmt.Errorf("failed to parse buildpack.toml: %s", err)
+	}
+
+	api := flags.api
+
+	// All internal.Dependencies from the dep-server
+	var allDependencies []internal.Dependency
+	// All cargo.ConfigMetadataDependencies that match one of the given constraints
+	var matchingDependencies []cargo.ConfigMetadataDependency
+
+	dependencyID := ""
+
+	for _, constraint := range config.Metadata.DependencyConstraints {
+		// Only query the API once per unique dependency
+		if constraint.ID != dependencyID {
+			dependencyID = constraint.ID
+			fmt.Printf("reaching out to %s/v1/dependency?name=%s", api, constraint.ID)
+			allDependencies, err = internal.GetAllDependencies(api, dependencyID)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Manually lookup the existent dependency name from the buildpack.toml since this
+		// isn't specified via the dep-server
+		dependencyName := internal.FindDependencyName(constraint.ID, config)
+
+		// Filter allDependencies for only those that match the constraint
+		mds, err := internal.GetDependenciesWithinConstraint(allDependencies, constraint, dependencyName)
+		if err != nil {
+			return err
+		}
+		matchingDependencies = append(matchingDependencies, mds...)
+	}
+
+	if len(matchingDependencies) > 0 {
+		config.Metadata.Dependencies = matchingDependencies
+	}
+
+	file, err := os.OpenFile(flags.buildpackFile, os.O_RDWR|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open buildpack config file: %w", err)
+	}
+	defer file.Close()
+
+	err = cargo.EncodeConfig(file, config)
+	if err != nil {
+		return fmt.Errorf("failed to write buildpack config: %w", err)
+	}
+
+	return nil
+}

--- a/cargo/jam/init_test.go
+++ b/cargo/jam/init_test.go
@@ -29,6 +29,7 @@ func TestUnitJam(t *testing.T) {
 	suite("summarize", testSummarize)
 	suite("update-builder", testUpdateBuilder)
 	suite("update-buildpack", testUpdateBuildpack)
+	suite("update-dependencies", testUpdateDependencies)
 
 	suite.Before(func(t *testing.T) {
 		var (

--- a/cargo/jam/internal/dependency.go
+++ b/cargo/jam/internal/dependency.go
@@ -1,0 +1,141 @@
+package internal
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/Masterminds/semver/v3"
+	"github.com/paketo-buildpacks/packit/cargo"
+)
+
+// Dependency represents the structure of a single entry in the dep-server
+type Dependency struct {
+	DeprecationDate string `json:"deprecation_date,omitempty"`
+	// The ID field should be the `name` from the dep-server
+	ID           string  `json:"name,omitempty"`
+	SHA256       string  `json:"sha256,omitempty"`
+	Source       string  `json:"source,omitempty"`
+	SourceSHA256 string  `json:"source_sha256,omitempty"`
+	Stacks       []Stack `json:"stacks,omitempty"`
+	URI          string  `json:"uri,omitempty"`
+	Version      string  `json:"version,omitempty"`
+	CreatedAt    string  `json:"created_at,omitempty"`
+	ModifedAt    string  `json:"modified_at,omitempty"`
+	CPE          string  `json:"cpe,omitempty"`
+}
+
+type Stack struct {
+	ID string `json:"id,omitempty"`
+}
+
+// GetDependenciesWithinConstraint reaches out to the given API to search for all
+// dependencies that match the ID and version constraint of a cargo
+// DependencyConstraint. It returns a filtered list of dependencies that match the
+// constraint and ID, in order of lowest version to highest.
+
+func GetDependenciesWithinConstraint(dependencies []Dependency, constraint cargo.ConfigMetadataDependencyConstraint, dependencyName string) ([]cargo.ConfigMetadataDependency, error) {
+	var matchingDependencies []cargo.ConfigMetadataDependency
+
+	for _, dependency := range dependencies {
+		c, err := semver.NewConstraint(constraint.Constraint)
+		if err != nil {
+			return nil, err
+		}
+
+		depVersion, err := semver.NewVersion(dependency.Version)
+		if err != nil {
+			return nil, err
+		}
+
+		if !c.Check(depVersion) || dependency.ID != constraint.ID {
+			continue
+		}
+
+		matchingDependencies = append(matchingDependencies, convertToCargoDependency(dependency, dependencyName))
+	}
+
+	sort.Slice(matchingDependencies, func(i, j int) bool {
+		iVersion := semver.MustParse(matchingDependencies[i].Version)
+		jVersion := semver.MustParse(matchingDependencies[j].Version)
+		return iVersion.LessThan(jVersion)
+	})
+
+	// if there are more requested patches than matching dependencies, just
+	// return all matching dependencies.
+	if constraint.Patches > len(matchingDependencies) {
+		return matchingDependencies, nil
+	}
+
+	// Buildpack.toml dependencies are usually in order from lowest to highest
+	// version. We want to return the the n largest matching dependencies in the
+	// same order, n being the constraint.Patches field from the buildpack.toml.
+	// Here, we are returning the n highest matching Dependencies.
+	return matchingDependencies[len(matchingDependencies)-int(constraint.Patches):], nil
+}
+
+// GetDependencies returns all dependencies from a given API endpoint
+func GetAllDependencies(api, dependencyID string) ([]Dependency, error) {
+	url := fmt.Sprintf("%s/v1/dependency?name=%s", api, dependencyID)
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query url %s: %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to query url %s with: status code %d", url, resp.StatusCode)
+	}
+
+	defer resp.Body.Close()
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	var dependencies []Dependency
+	err = json.Unmarshal(b, &dependencies)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	return dependencies, nil
+}
+
+// FindDependencyName returns the name of a Dependency in a cargo.Config that
+// has a matching ID with a given dependency ID.
+func FindDependencyName(dependencyID string, config cargo.Config) string {
+	name := ""
+	for _, dependency := range config.Metadata.Dependencies {
+		if dependency.ID == dependencyID {
+			name = dependency.Name
+			continue
+		}
+	}
+	return name
+}
+
+// convertDependency converts an internal.Dependency type into a
+// cargo.ConfigMetadataDependency type. It takes in a dependency name as well
+// since this isn't a field on the internal.Dependency.
+func convertToCargoDependency(dependency Dependency, dependencyName string) cargo.ConfigMetadataDependency {
+	var cargoDependency cargo.ConfigMetadataDependency
+
+	if dependency.DeprecationDate != "" {
+		deprecationDate, _ := time.Parse(time.RFC3339, dependency.DeprecationDate)
+		cargoDependency.DeprecationDate = &deprecationDate
+	}
+
+	cargoDependency.ID = dependency.ID
+	cargoDependency.Name = dependencyName
+	cargoDependency.SHA256 = dependency.SHA256
+	cargoDependency.Source = dependency.Source
+	cargoDependency.SourceSHA256 = dependency.SourceSHA256
+	cargoDependency.URI = dependency.URI
+	cargoDependency.Version = strings.Replace(dependency.Version, "v", "", -1)
+	for _, stack := range dependency.Stacks {
+		cargoDependency.Stacks = append(cargoDependency.Stacks, stack.ID)
+	}
+	return cargoDependency
+}

--- a/cargo/jam/internal/dependency_cacher_test.go
+++ b/cargo/jam/internal/dependency_cacher_test.go
@@ -54,6 +54,10 @@ func testDependencyCacher(t *testing.T, context spec.G, it spec.S) {
 		cacher = internal.NewDependencyCacher(downloader, scribe.NewLogger(output))
 	})
 
+	it.After(func() {
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+	})
+
 	context("Cache", func() {
 		it("caches dependencies and returns updated dependencies list", func() {
 			deps, err := cacher.Cache(tmpDir, []cargo.ConfigMetadataDependency{

--- a/cargo/jam/internal/dependency_test.go
+++ b/cargo/jam/internal/dependency_test.go
@@ -1,0 +1,395 @@
+package internal_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/cargo"
+	"github.com/paketo-buildpacks/packit/cargo/jam/internal"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testDependency(t *testing.T, context spec.G, it spec.S) {
+	var (
+		withT           = NewWithT(t)
+		Expect          = withT.Expect
+		allDependencies []internal.Dependency
+	)
+
+	it.Before(func() {
+		allDependencies = []internal.Dependency{
+			{
+				DeprecationDate: "",
+				ID:              "some-dep",
+				SHA256:          "some-sha",
+				Source:          "some-source",
+				SourceSHA256:    "some-source-sha",
+				Stacks: []internal.Stack{
+					{
+						ID: "some-stack",
+					},
+				},
+				URI:       "some-dep-uri",
+				Version:   "v1.0.0",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
+			{
+				DeprecationDate: "",
+				ID:              "some-dep",
+				SHA256:          "some-sha-two",
+				Source:          "some-source-two",
+				SourceSHA256:    "some-source-sha-two",
+				Stacks: []internal.Stack{
+					{
+						ID: "some-stack-two",
+					},
+				},
+				URI:       "some-dep-uri-two",
+				Version:   "v1.1.2",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
+			{
+				DeprecationDate: "",
+				ID:              "some-dep",
+				SHA256:          "some-sha-three",
+				Source:          "some-source-three",
+				SourceSHA256:    "some-source-sha-three",
+				Stacks: []internal.Stack{
+					{
+						ID: "some-stack-three",
+					},
+				},
+				URI:       "some-dep-uri-three",
+				Version:   "v1.5.6",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
+			{
+				DeprecationDate: "",
+				ID:              "some-dep",
+				SHA256:          "some-sha-four",
+				Source:          "some-source-four",
+				SourceSHA256:    "some-source-sha-four",
+				Stacks: []internal.Stack{
+					{
+						ID: "some-stack-four",
+					},
+				},
+				URI:       "some-dep-uri-four",
+				Version:   "v2.3.2",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
+			{
+				DeprecationDate: "",
+				ID:              "different-dep",
+				SHA256:          "different-dep-sha",
+				Source:          "different-dep-source",
+				SourceSHA256:    "different-dep-source-sha",
+				Stacks: []internal.Stack{
+					{
+						ID: "different-dep-stack",
+					},
+				},
+				URI:       "different-dep-uri",
+				Version:   "v1.9.8",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
+		}
+	})
+
+	context("GetAllDependencies", func() {
+		var server *httptest.Server
+		it.Before(func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+				if req.Method == http.MethodHead {
+					http.Error(w, "NotFound", http.StatusNotFound)
+					return
+				}
+
+				switch req.URL.Path {
+				case "/v1/":
+					w.WriteHeader(http.StatusOK)
+
+				case "/v1/dependency":
+					if req.URL.RawQuery == "name=some-dep" {
+						w.WriteHeader(http.StatusOK)
+						fmt.Fprintln(w, `[
+  {
+    "name": "some-dep",
+    "version": "v1.0.0",
+    "sha256": "some-sha",
+    "uri": "some-dep-uri",
+    "stacks": [
+      {
+        "id": "some-stack"
+      }
+    ],
+    "source": "some-source",
+    "source_sha256": "some-source-sha",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation",
+		"deprecation_date" : ""
+  },
+  {
+    "name": "some-dep",
+    "version": "v1.1.2",
+    "sha256": "some-sha-two",
+    "uri": "some-dep-uri-two",
+    "stacks": [
+      {
+        "id": "some-stack-two"
+      }
+    ],
+    "source": "some-source-two",
+    "source_sha256": "some-source-sha-two",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation"
+  },
+  {
+    "name": "some-dep",
+    "version": "v1.5.6",
+    "sha256": "some-sha-three",
+    "uri": "some-dep-uri-three",
+    "stacks": [
+      {
+        "id": "some-stack-three"
+      }
+    ],
+    "source": "some-source-three",
+    "source_sha256": "some-source-sha-three",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation"
+  },
+  {
+    "name": "some-dep",
+    "version": "v2.3.2",
+    "sha256": "some-sha-four",
+    "uri": "some-dep-uri-four",
+    "stacks": [
+      {
+        "id": "some-stack-four"
+      }
+    ],
+    "source": "some-source-four",
+		"source_sha256": "some-source-sha-four",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation"
+  },
+  {
+    "name": "different-dep",
+    "version": "v1.9.8",
+    "sha256": "different-dep-sha",
+    "uri": "different-dep-uri",
+    "stacks": [
+      {
+        "id": "different-dep-stack"
+      }
+    ],
+    "source": "different-dep-source",
+		"source_sha256": "different-dep-source-sha",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation"
+  }
+]`)
+					}
+					if req.URL.RawQuery == "name=bad-status" {
+						w.WriteHeader(http.StatusBadRequest)
+					}
+
+					if req.URL.RawQuery == "name=bad-dep" {
+						w.WriteHeader(http.StatusOK)
+						filename := "other-payload"
+						w.Header().Set("Content-Type", "application/json")
+						w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+					}
+
+				default:
+					t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+				}
+			}))
+		})
+
+		it.After(func() {
+			server.Close()
+		})
+
+		context("given a valid API and dependencyID", func() {
+			it("returns a slice of Dependency from the API server", func() {
+				dependencies, err := internal.GetAllDependencies(server.URL, "some-dep")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependencies).To(Equal(allDependencies))
+			})
+		})
+
+		context("failure cases", func() {
+			context("the url cannot be queried", func() {
+				it("returns an error", func() {
+					_, err := internal.GetAllDependencies("%%%", "some-dep")
+					Expect(err).To(MatchError(ContainSubstring("failed to query url")))
+				})
+			})
+
+			context("the API returns a non 200 status code", func() {
+				it("returns an error", func() {
+					_, err := internal.GetAllDependencies(server.URL, "bad-status")
+					Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("failed to query url %s/v1/dependency?name=bad-status with: status code 400", server.URL))))
+				})
+			})
+
+			context("the API response is not unmarshal-able", func() {
+				it("returns an error", func() {
+					_, err := internal.GetAllDependencies(server.URL, "bad-dep")
+					Expect(err).To(MatchError(ContainSubstring("failed to unmarshal: unexpected end of JSON input")))
+				})
+			})
+		})
+	})
+
+	context("GetDependenciesWithinConstraint", func() {
+		context("given a valid api and constraint", func() {
+			it("returns a sorted list of dependencies that match the constraint", func() {
+				constraint := cargo.ConfigMetadataDependencyConstraint{
+					Constraint: "1.*",
+					ID:         "some-dep",
+					Patches:    3,
+				}
+
+				dependencies, err := internal.GetDependenciesWithinConstraint(allDependencies, constraint, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependencies).To(Equal([]cargo.ConfigMetadataDependency{
+					{
+						ID:           "some-dep",
+						Version:      "1.0.0",
+						Stacks:       []string{"some-stack"},
+						URI:          "some-dep-uri",
+						SHA256:       "some-sha",
+						Source:       "some-source",
+						SourceSHA256: "some-source-sha",
+					},
+					{
+						ID:           "some-dep",
+						Version:      "1.1.2",
+						Stacks:       []string{"some-stack-two"},
+						URI:          "some-dep-uri-two",
+						SHA256:       "some-sha-two",
+						Source:       "some-source-two",
+						SourceSHA256: "some-source-sha-two",
+					},
+					{
+						ID:           "some-dep",
+						Version:      "1.5.6",
+						Stacks:       []string{"some-stack-three"},
+						URI:          "some-dep-uri-three",
+						SHA256:       "some-sha-three",
+						Source:       "some-source-three",
+						SourceSHA256: "some-source-sha-three",
+					},
+				}))
+			})
+		})
+
+		context("failure cases", func() {
+			context("given an invalid constraint", func() {
+				it("returns an error", func() {
+					constraint := cargo.ConfigMetadataDependencyConstraint{
+						Constraint: "abc",
+						ID:         "some-dep",
+						Patches:    3,
+					}
+
+					_, err := internal.GetDependenciesWithinConstraint(allDependencies, constraint, "")
+					Expect(err).To(MatchError("improper constraint: abc"))
+				})
+			})
+
+			context("given a malformed dependency version", func() {
+				it("returns an error", func() {
+					constraint := cargo.ConfigMetadataDependencyConstraint{
+						Constraint: "1.*",
+						ID:         "some-dep",
+						Patches:    3,
+					}
+					dependencies := []internal.Dependency{
+						{
+							DeprecationDate: "",
+							ID:              "some-dep",
+							SHA256:          "some-sha",
+							Source:          "some-source",
+							SourceSHA256:    "some-source-sha",
+							Stacks: []internal.Stack{
+								{
+									ID: "some-stack",
+								},
+							},
+							URI:       "some-dep-uri",
+							Version:   "v1.xx",
+							CreatedAt: "sometime",
+							ModifedAt: "another-time",
+							CPE:       "cpe-notation",
+						},
+					}
+
+					_, err := internal.GetDependenciesWithinConstraint(dependencies, constraint, "")
+					Expect(err).To(MatchError("Invalid Semantic Version"))
+				})
+			})
+		})
+	})
+
+	context("FindDependencyName", func() {
+		var cargoConfig cargo.Config
+		it.Before(func() {
+			cargoConfig = cargo.Config{
+				API: "0.2",
+				Buildpack: cargo.ConfigBuildpack{
+					ID:       "some-buildpack-id",
+					Name:     "some-buildpack-name",
+					Version:  "some-buildpack-version",
+					Homepage: "some-homepage-link",
+				},
+				Metadata: cargo.ConfigMetadata{
+					Dependencies: []cargo.ConfigMetadataDependency{
+						{
+							ID:      "some-dependency",
+							Name:    "Some Dependency Name",
+							URI:     "http://some-url",
+							Version: "1.2.3",
+						},
+					},
+				},
+			}
+		})
+
+		context("given a dependency ID and valid cargo.Config that contain that dependency", func() {
+			it("returns the name of the dependency from the Config", func() {
+				name := internal.FindDependencyName("some-dependency", cargoConfig)
+				Expect(name).To(Equal("Some Dependency Name"))
+			})
+		})
+
+		context("given a dependency ID and a cargo.Config that does not contain that dependency", func() {
+			it("returns the empty string", func() {
+				name := internal.FindDependencyName("unmatched-dependency", cargoConfig)
+				Expect(name).To(Equal(""))
+			})
+		})
+	})
+}

--- a/cargo/jam/internal/formatter_test.go
+++ b/cargo/jam/internal/formatter_test.go
@@ -37,10 +37,12 @@ func testFormatter(t *testing.T, context spec.G, it spec.S) {
 					Metadata: cargo.ConfigMetadata{
 						Dependencies: []cargo.ConfigMetadataDependency{
 							{
-								ID:      "some-dependency",
-								Stacks:  []string{"some-stack"},
-								Version: "1.2.3",
-								SHA256:  "one-more-sha",
+								ID:           "some-dependency",
+								Stacks:       []string{"some-stack"},
+								Version:      "1.2.3",
+								SHA256:       "one-more-sha",
+								Source:       "some-source",
+								SourceSHA256: "source-sha",
 							},
 							{
 								ID:      "some-dependency",

--- a/cargo/jam/internal/init_test.go
+++ b/cargo/jam/internal/init_test.go
@@ -23,6 +23,7 @@ func TestUnitCargo(t *testing.T) {
 	suite("BuildpackConfig", testBuildpackConfig)
 	suite("BuildpackInspector", testBuildpackInspector)
 	suite("DependencyCacher", testDependencyCacher)
+	suite("Dependency", testDependency)
 	suite("FileBundler", testFileBundler)
 	suite("Formatter", testFormatter)
 	suite("Image", testImage)

--- a/cargo/jam/update_builder_test.go
+++ b/cargo/jam/update_builder_test.go
@@ -223,6 +223,7 @@ description = "Some description"
 
 	it.After(func() {
 		server.Close()
+		Expect(os.RemoveAll(builderDir)).To(Succeed())
 	})
 
 	it("updates the builder files", func() {

--- a/cargo/jam/update_buildpack_test.go
+++ b/cargo/jam/update_buildpack_test.go
@@ -214,6 +214,7 @@ func testUpdateBuildpack(t *testing.T, context spec.G, it spec.S) {
 
 	it.After(func() {
 		server.Close()
+		Expect(os.RemoveAll(buildpackDir)).To(Succeed())
 	})
 
 	it("updates the buildpack.toml and package.toml files", func() {

--- a/cargo/jam/update_dependencies_test.go
+++ b/cargo/jam/update_dependencies_test.go
@@ -1,0 +1,542 @@
+package main_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/matchers"
+)
+
+func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
+	var (
+		withT      = NewWithT(t)
+		Expect     = withT.Expect
+		Eventually = withT.Eventually
+
+		server       *httptest.Server
+		buildpackDir string
+	)
+
+	it.Before(func() {
+		var err error
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if req.Method == http.MethodHead {
+				http.Error(w, "NotFound", http.StatusNotFound)
+				return
+			}
+
+			switch req.URL.Path {
+			case "/v2/":
+				w.WriteHeader(http.StatusOK)
+
+			case "/v1/dependency":
+				if req.URL.RawQuery == "name=node" {
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintln(w, `[
+  {
+    "name": "node",
+		"version": "v1.2.4",
+    "sha256": "some-sha",
+    "uri": "some-dep-uri",
+    "stacks": [
+      {
+        "id": "io.buildpacks.stacks.bionic"
+      }
+    ],
+    "source": "some-source",
+    "source_sha256": "some-source-sha"
+	},
+  {
+    "name": "node",
+		"version": "v1.3.5",
+    "sha256": "some-sha",
+    "uri": "some-dep-uri",
+    "stacks": [
+      {
+        "id": "io.buildpacks.stacks.bionic"
+      }
+    ],
+    "source": "some-source",
+    "source_sha256": "some-source-sha"
+	},
+  {
+    "name": "node",
+		"version": "v2.1.9",
+    "sha256": "some-sha",
+    "uri": "some-dep-uri",
+    "stacks": [
+      {
+        "id": "io.buildpacks.stacks.bionic"
+      }
+    ],
+    "source": "some-source",
+    "source_sha256": "some-source-sha"
+	},
+  {
+    "name": "node",
+		"version": "v2.2.5",
+    "sha256": "some-sha",
+    "uri": "some-dep-uri",
+    "stacks": [
+      {
+        "id": "io.buildpacks.stacks.bionic"
+      }
+    ],
+    "source": "some-source",
+    "source_sha256": "some-source-sha"
+	}]`)
+				}
+
+				if req.URL.RawQuery == "name=non-existent" {
+					w.WriteHeader(http.StatusInternalServerError)
+					fmt.Fprintln(w, `{"error": "error getting dependency metadata"}`)
+				}
+
+			default:
+				t.Fatal(fmt.Sprintf("unknown path: %s", req.URL.Path))
+			}
+		}))
+
+		buildpackDir, err = os.MkdirTemp("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(filepath.Join(buildpackDir, "buildpack.toml"), []byte(`
+				api = "0.2"
+
+				[buildpack]
+					id = "some-buildpack"
+					name = "Some Buildpack"
+					version = "some-buildpack-version"
+
+				[metadata]
+					include-files = ["buildpack.toml"]
+
+					[[metadata.dependencies]]
+						id = "node"
+						name = "Node Engine"
+						sha256 = "some-sha"
+						source = "some-source"
+						source_sha256 = "some-source-sha"
+						stacks = ["io.buildpacks.stacks.bionic"]
+						uri = "some-dep-uri"
+						version = "1.2.3"
+
+					[[metadata.dependencies]]
+						id = "node"
+						name = "Node Engine"
+						sha256 = "some-sha"
+						source = "some-source"
+						source_sha256 = "some-source-sha"
+						stacks = ["io.buildpacks.stacks.bionic"]
+						uri = "some-dep-uri"
+						version = "2.1.1"
+
+					[[metadata.dependencies]]
+						id = "node"
+						name = "Node Engine"
+						sha256 = "some-sha"
+						source = "some-source"
+						source_sha256 = "some-source-sha"
+						stacks = ["io.buildpacks.stacks.bionic"]
+						uri = "some-dep-uri"
+						version = "2.2.5"
+
+				[[metadata.dependency-constraints]]
+					constraint = "1.*"
+					id = "node"
+					patches = 1.0
+
+				[[metadata.dependency-constraints]]
+					constraint = "2.*"
+					id = "node"
+					patches = 2.0
+
+				[[stacks]]
+				  id = "io.buildpacks.stacks.bionic"
+			`), 0644)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		server.Close()
+		Expect(os.RemoveAll(buildpackDir)).To(Succeed())
+	})
+
+	it("updates the buildpack.toml dependencies", func() {
+		command := exec.Command(
+			path,
+			"update-dependencies",
+			"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+			"--api", server.URL,
+		)
+
+		buffer := gbytes.NewBuffer()
+		session, err := gexec.Start(command, buffer, buffer)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session).Should(gexec.Exit(0), func() string { return string(buffer.Contents()) })
+
+		buildpackContents, err := os.ReadFile(filepath.Join(buildpackDir, "buildpack.toml"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(buildpackContents)).To(MatchTOML(`
+api = "0.2"
+
+[buildpack]
+	id = "some-buildpack"
+	name = "Some Buildpack"
+	version = "some-buildpack-version"
+
+[metadata]
+	include-files = ["buildpack.toml"]
+
+[[metadata.dependencies]]
+	id = "node"
+	name = "Node Engine"
+	sha256 = "some-sha"
+	source = "some-source"
+	source_sha256 = "some-source-sha"
+	stacks = ["io.buildpacks.stacks.bionic"]
+	uri = "some-dep-uri"
+	version = "1.3.5"
+
+[[metadata.dependencies]]
+	id = "node"
+	name = "Node Engine"
+	sha256 = "some-sha"
+	source = "some-source"
+	source_sha256 = "some-source-sha"
+	stacks = ["io.buildpacks.stacks.bionic"]
+	uri = "some-dep-uri"
+	version = "2.1.9"
+
+[[metadata.dependencies]]
+	id = "node"
+	name = "Node Engine"
+	sha256 = "some-sha"
+	source = "some-source"
+	source_sha256 = "some-source-sha"
+	stacks = ["io.buildpacks.stacks.bionic"]
+	uri = "some-dep-uri"
+	version = "2.2.5"
+
+[[metadata.dependency-constraints]]
+	constraint = "1.*"
+	id = "node"
+	patches = 1.0
+
+[[metadata.dependency-constraints]]
+	constraint = "2.*"
+	id = "node"
+	patches = 2.0
+
+[[stacks]]
+  id = "io.buildpacks.stacks.bionic"
+			`))
+	})
+
+	context("the server has less patches available than requested in constraint", func() {
+		it.Before(func() {
+			err := os.WriteFile(filepath.Join(buildpackDir, "buildpack.toml"), []byte(`
+				api = "0.2"
+
+				[buildpack]
+					id = "some-buildpack"
+					name = "Some Buildpack"
+					version = "some-buildpack-version"
+
+				[metadata]
+					include-files = ["buildpack.toml"]
+
+				[[metadata.dependencies]]
+					id = "node"
+					name = "Node Engine"
+					sha256 = "some-sha"
+					source = "some-source"
+					source_sha256 = "some-source-sha"
+					stacks = ["io.buildpacks.stacks.bionic"]
+					uri = "some-dep-uri"
+					version = "2.2.3"
+
+				[[metadata.dependency-constraints]]
+					constraint = "2.2.*"
+					id = "node"
+					patches = 3.0
+
+				[[stacks]]
+				  id = "io.buildpacks.stacks.bionic"
+			`), 0644)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+		it.After(func() {
+			Expect(os.RemoveAll(buildpackDir)).To(Succeed())
+		})
+
+		it("updates the buildpack.toml dependencies with as many as are available", func() {
+			command := exec.Command(
+				path,
+				"update-dependencies",
+				"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+				"--api", server.URL,
+			)
+
+			buffer := gbytes.NewBuffer()
+			session, err := gexec.Start(command, buffer, buffer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0), func() string { return string(buffer.Contents()) })
+
+			buildpackContents, err := os.ReadFile(filepath.Join(buildpackDir, "buildpack.toml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(buildpackContents)).To(MatchTOML(`
+api = "0.2"
+
+[buildpack]
+	id = "some-buildpack"
+	name = "Some Buildpack"
+	version = "some-buildpack-version"
+
+[metadata]
+	include-files = ["buildpack.toml"]
+
+[[metadata.dependencies]]
+	id = "node"
+	name = "Node Engine"
+	sha256 = "some-sha"
+	source = "some-source"
+	source_sha256 = "some-source-sha"
+	stacks = ["io.buildpacks.stacks.bionic"]
+	uri = "some-dep-uri"
+	version = "2.2.5"
+
+[[metadata.dependency-constraints]]
+	constraint = "2.2.*"
+	id = "node"
+	patches = 3.0
+
+[[stacks]]
+  id = "io.buildpacks.stacks.bionic"
+			`))
+		})
+	})
+
+	context("the server serves a different dependency", func() {
+		it.Before(func() {
+			err := os.WriteFile(filepath.Join(buildpackDir, "buildpack.toml"), []byte(`
+				api = "0.2"
+
+				[buildpack]
+					id = "some-buildpack"
+					name = "Some Buildpack"
+					version = "some-buildpack-version"
+
+				[metadata]
+					include-files = ["buildpack.toml"]
+
+				[[metadata.dependencies]]
+					id = "node"
+					name = "Node Engine"
+					sha256 = "some-sha"
+					source = "some-source"
+					source_sha256 = "some-source-sha"
+					stacks = ["io.buildpacks.stacks.bionic"]
+					uri = "some-dep-uri"
+					version = "2.2.3"
+
+				[[metadata.dependency-constraints]]
+					constraint = "2.2.*"
+					id = "node"
+					patches = 3.0
+
+				[[stacks]]
+				  id = "io.buildpacks.stacks.bionic"
+			`), 0644)
+
+			Expect(err).ToNot(HaveOccurred())
+		})
+		it.After(func() {
+			Expect(os.RemoveAll(buildpackDir)).To(Succeed())
+		})
+
+		it("updates the buildpack.toml dependencies with as many as are available", func() {
+			command := exec.Command(
+				path,
+				"update-dependencies",
+				"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+				"--api", server.URL,
+			)
+
+			buffer := gbytes.NewBuffer()
+			session, err := gexec.Start(command, buffer, buffer)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session).Should(gexec.Exit(0), func() string { return string(buffer.Contents()) })
+
+			buildpackContents, err := os.ReadFile(filepath.Join(buildpackDir, "buildpack.toml"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(buildpackContents)).To(MatchTOML(`
+api = "0.2"
+
+[buildpack]
+	id = "some-buildpack"
+	name = "Some Buildpack"
+	version = "some-buildpack-version"
+
+[metadata]
+	include-files = ["buildpack.toml"]
+
+[[metadata.dependencies]]
+	id = "node"
+	name = "Node Engine"
+	sha256 = "some-sha"
+	source = "some-source"
+	source_sha256 = "some-source-sha"
+	stacks = ["io.buildpacks.stacks.bionic"]
+	uri = "some-dep-uri"
+	version = "2.2.5"
+
+[[metadata.dependency-constraints]]
+	constraint = "2.2.*"
+	id = "node"
+	patches = 3.0
+
+[[stacks]]
+  id = "io.buildpacks.stacks.bionic"
+			`))
+		})
+	})
+
+	context("failure cases", func() {
+		context("the --buildpack-file flag is missing", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-dependencies",
+					"--api", server.URL,
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("Error: required flag(s) \"buildpack-file\" not set"))
+			})
+		})
+
+		context("the buildpack file does not exist", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-dependencies",
+					"--buildpack-file", "/no/such/file",
+					"--api", server.URL,
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to parse buildpack.toml"))
+			})
+		})
+
+		context("the dependencies cannot be retrieved from the server", func() {
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-dependencies",
+					"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+					"--api", "%%%",
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to query url"))
+			})
+		})
+
+		context("the server status code is not 200", func() {
+			it.Before(func() {
+				err := os.WriteFile(filepath.Join(buildpackDir, "buildpack.toml"), []byte(`
+				api = "0.2"
+
+				[buildpack]
+					id = "some-buildpack"
+					name = "Some Buildpack"
+					version = "some-buildpack-version"
+
+				[metadata]
+					include-files = ["buildpack.toml"]
+
+					[[metadata.dependencies]]
+						id = "non-existent"
+						sha256 = "some-sha"
+						source = "some-source"
+						source_sha256 = "some-source-sha"
+						stacks = ["io.buildpacks.stacks.bionic"]
+						uri = "some-dep-uri"
+						version = "1.2.3"
+
+				[[metadata.dependency-constraints]]
+					constraint = "1.*"
+					id = "non-existent"
+					patches = 1
+
+				[[stacks]]
+				  id = "io.buildpacks.stacks.bionic"
+			`), 0644)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-dependencies",
+					"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+					"--api", server.URL,
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring(fmt.Sprintf("failed to query url %s/v1/dependency?name=non-existent with: status code 500", server.URL)))
+			})
+		})
+		context("when the buildpack file cannot be opened", func() {
+			it.Before(func() {
+				Expect(os.Chmod(filepath.Join(buildpackDir, "buildpack.toml"), 0400)).To(Succeed())
+			})
+			it("prints an error and exits non-zero", func() {
+				command := exec.Command(
+					path,
+					"update-dependencies",
+					"--buildpack-file", filepath.Join(buildpackDir, "buildpack.toml"),
+					"--api", server.URL,
+				)
+
+				buffer := gbytes.NewBuffer()
+				session, err := gexec.Start(command, buffer, buffer)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session).Should(gexec.Exit(1), func() string { return string(buffer.Contents()) })
+				Expect(string(buffer.Contents())).To(ContainSubstring("failed to open buildpack config"))
+			})
+		})
+	})
+}

--- a/cargo/jam/update_dependencies_test.go
+++ b/cargo/jam/update_dependencies_test.go
@@ -154,12 +154,12 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
 				[[metadata.dependency-constraints]]
 					constraint = "1.*"
 					id = "node"
-					patches = 1.0
+					patches = 1
 
 				[[metadata.dependency-constraints]]
 					constraint = "2.*"
 					id = "node"
-					patches = 2.0
+					patches = 2
 
 				[[stacks]]
 				  id = "io.buildpacks.stacks.bionic"
@@ -232,12 +232,12 @@ api = "0.2"
 [[metadata.dependency-constraints]]
 	constraint = "1.*"
 	id = "node"
-	patches = 1.0
+	patches = 1
 
 [[metadata.dependency-constraints]]
 	constraint = "2.*"
 	id = "node"
-	patches = 2.0
+	patches = 2
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
@@ -270,7 +270,7 @@ api = "0.2"
 				[[metadata.dependency-constraints]]
 					constraint = "2.2.*"
 					id = "node"
-					patches = 3.0
+					patches = 3
 
 				[[stacks]]
 				  id = "io.buildpacks.stacks.bionic"
@@ -322,7 +322,7 @@ api = "0.2"
 [[metadata.dependency-constraints]]
 	constraint = "2.2.*"
 	id = "node"
-	patches = 3.0
+	patches = 3
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
@@ -356,7 +356,7 @@ api = "0.2"
 				[[metadata.dependency-constraints]]
 					constraint = "2.2.*"
 					id = "node"
-					patches = 3.0
+					patches = 3
 
 				[[stacks]]
 				  id = "io.buildpacks.stacks.bionic"
@@ -408,7 +408,7 @@ api = "0.2"
 [[metadata.dependency-constraints]]
 	constraint = "2.2.*"
 	id = "node"
-	patches = 3.0
+	patches = 3
 
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves https://github.com/paketo-buildpacks/packit/issues/178.

`jam update-dependencies` updates a `buildpack.toml` dependencies with the latest versions on the dep-server (api.deps.paketo.io) given a constraint in the `buildpack.toml` that looks like:
```
[[metadata.dependency-constraints]]
  id = "dependency-id"
  constraint = "1.*"
  patches = 2
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

This will allows us to consume dependencies from the dependency server rather than a hidden Concourse pipeline.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
