### PR TITLE
Removes useage of OS specfic path separator

### DIFF
--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -477,10 +477,11 @@ func (z ZipArchive) Decompress(destination string) error {
 
 // This function checks to see that the given path is within the destination
 // directory
-func checkExtractPath(filePath string, destination string) error {
-	destpath := filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+"/") {
-		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", filePath)
+func checkExtractPath(tarFilePath string, destination string) error {
+	osPath := filepath.FromSlash(tarFilePath)
+	destpath := filepath.Join(destination, osPath)
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", tarFilePath)
 	}
 	return nil
 }

--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -96,7 +96,7 @@ func (ta TarArchive) Decompress(destination string) error {
 		}
 
 		// Skip if the destination it the destination directory itself i.e. ./
-		if hdr.Name == "."+string(filepath.Separator) {
+		if hdr.Name == "./" {
 			continue
 		}
 
@@ -105,7 +105,7 @@ func (ta TarArchive) Decompress(destination string) error {
 			return err
 		}
 
-		fileNames := strings.Split(hdr.Name, string(filepath.Separator))
+		fileNames := strings.Split(hdr.Name, "/")
 
 		// Checks to see if file should be written when stripping components
 		if len(fileNames) <= ta.components {
@@ -366,7 +366,7 @@ func (z ZipArchive) Decompress(destination string) error {
 
 	for _, f := range zr.File {
 		// Skip if the destination it the destination directory itself i.e. ./
-		if f.Name == "."+string(filepath.Separator) {
+		if f.Name == "./" {
 			continue
 		}
 
@@ -479,7 +479,7 @@ func (z ZipArchive) Decompress(destination string) error {
 // directory
 func checkExtractPath(filePath string, destination string) error {
 	destpath := filepath.Join(destination, filePath)
-	if !strings.HasPrefix(destpath, filepath.Clean(destination)+string(os.PathSeparator)) {
+	if !strings.HasPrefix(destpath, filepath.Clean(destination)+"/") {
 		return fmt.Errorf("illegal file path %q: the file path does not occur within the destination directory", filePath)
 	}
 	return nil


### PR DESCRIPTION
[TAR uses "/" regardless of the OS](https://www.gnu.org/software/tar/manual/html_node/Standard.html#:~:text=separated%20by%20slashes) therefore usage of "\" causes
incorrect behavior.

Resolves #185 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
