### PR TITLE
Add CPE to cargo dependency metadata

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -40,6 +40,7 @@ type ConfigMetadata struct {
 }
 
 type ConfigMetadataDependency struct {
+	CPE             string     `toml:"cpe"              json:"cpe,omitempty"`
 	DeprecationDate *time.Time `toml:"deprecation_date" json:"deprecation_date,omitempty"`
 	ID              string     `toml:"id"               json:"id,omitempty"`
 	Name            string     `toml:"name"             json:"name,omitempty"`

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -56,6 +56,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 					PrePackage:   "some-pre-package-script.sh",
 					Dependencies: []cargo.ConfigMetadataDependency{
 						{
+							CPE:             "some-cpe",
 							DeprecationDate: &deprecationDate,
 							ID:              "some-dependency",
 							Name:            "Some Dependency",
@@ -109,6 +110,7 @@ pre-package = "some-pre-package-script.sh"
 some-dependency = "1.2.x"
 
 [[metadata.dependencies]]
+  cpe = "some-cpe"
   deprecation_date = "2020-06-01T00:00:00Z"
   id = "some-dependency"
   name = "Some Dependency"
@@ -200,6 +202,7 @@ some-dependency = "1.2.x"
   key = "value"
 
 [[metadata.dependencies]]
+  cpe = "some-cpe"
   id = "some-dependency"
   name = "Some Dependency"
   sha256 = "shasum"
@@ -260,6 +263,7 @@ some-dependency = "1.2.x"
 					PrePackage: "some-pre-package-script.sh",
 					Dependencies: []cargo.ConfigMetadataDependency{
 						{
+							CPE:          "some-cpe",
 							ID:           "some-dependency",
 							Name:         "Some Dependency",
 							SHA256:       "shasum",

--- a/cargo/jam/internal/dependency.go
+++ b/cargo/jam/internal/dependency.go
@@ -127,6 +127,7 @@ func convertToCargoDependency(dependency Dependency, dependencyName string) carg
 		cargoDependency.DeprecationDate = &deprecationDate
 	}
 
+	cargoDependency.CPE = dependency.CPE
 	cargoDependency.ID = dependency.ID
 	cargoDependency.Name = dependencyName
 	cargoDependency.SHA256 = dependency.SHA256

--- a/cargo/jam/internal/dependency_test.go
+++ b/cargo/jam/internal/dependency_test.go
@@ -276,6 +276,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dependencies).To(Equal([]cargo.ConfigMetadataDependency{
 					{
+						CPE:          "cpe-notation",
 						ID:           "some-dep",
 						Version:      "1.0.0",
 						Stacks:       []string{"some-stack"},
@@ -285,6 +286,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 						SourceSHA256: "some-source-sha",
 					},
 					{
+						CPE:          "cpe-notation",
 						ID:           "some-dep",
 						Version:      "1.1.2",
 						Stacks:       []string{"some-stack-two"},
@@ -294,6 +296,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 						SourceSHA256: "some-source-sha-two",
 					},
 					{
+						CPE:          "cpe-notation",
 						ID:           "some-dep",
 						Version:      "1.5.6",
 						Stacks:       []string{"some-stack-three"},

--- a/cargo/jam/update_dependencies_test.go
+++ b/cargo/jam/update_dependencies_test.go
@@ -54,7 +54,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
       }
     ],
     "source": "some-source",
-    "source_sha256": "some-source-sha"
+    "source_sha256": "some-source-sha",
+		"cpe": "node-cpe"
 	},
   {
     "name": "node",
@@ -67,7 +68,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
       }
     ],
     "source": "some-source",
-    "source_sha256": "some-source-sha"
+    "source_sha256": "some-source-sha",
+		"cpe": "node-cpe"
 	},
   {
     "name": "node",
@@ -80,7 +82,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
       }
     ],
     "source": "some-source",
-    "source_sha256": "some-source-sha"
+    "source_sha256": "some-source-sha",
+		"cpe": "node-cpe"
 	},
   {
     "name": "node",
@@ -93,7 +96,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
       }
     ],
     "source": "some-source",
-    "source_sha256": "some-source-sha"
+    "source_sha256": "some-source-sha",
+		"cpe": "node-cpe"
 	}]`)
 				}
 
@@ -122,6 +126,7 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
 					include-files = ["buildpack.toml"]
 
 					[[metadata.dependencies]]
+					  cpe = "node-cpe"
 						id = "node"
 						name = "Node Engine"
 						sha256 = "some-sha"
@@ -132,6 +137,7 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
 						version = "1.2.3"
 
 					[[metadata.dependencies]]
+					  cpe = "node-cpe"
 						id = "node"
 						name = "Node Engine"
 						sha256 = "some-sha"
@@ -142,6 +148,7 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
 						version = "2.1.1"
 
 					[[metadata.dependencies]]
+					  cpe = "node-cpe"
 						id = "node"
 						name = "Node Engine"
 						sha256 = "some-sha"
@@ -200,6 +207,7 @@ api = "0.2"
 	include-files = ["buildpack.toml"]
 
 [[metadata.dependencies]]
+	cpe = "node-cpe"
 	id = "node"
 	name = "Node Engine"
 	sha256 = "some-sha"
@@ -210,6 +218,7 @@ api = "0.2"
 	version = "1.3.5"
 
 [[metadata.dependencies]]
+	cpe = "node-cpe"
 	id = "node"
 	name = "Node Engine"
 	sha256 = "some-sha"
@@ -220,6 +229,7 @@ api = "0.2"
 	version = "2.1.9"
 
 [[metadata.dependencies]]
+	cpe = "node-cpe"
 	id = "node"
 	name = "Node Engine"
 	sha256 = "some-sha"
@@ -258,6 +268,7 @@ api = "0.2"
 					include-files = ["buildpack.toml"]
 
 				[[metadata.dependencies]]
+	        cpe = "node-cpe"
 					id = "node"
 					name = "Node Engine"
 					sha256 = "some-sha"
@@ -310,6 +321,7 @@ api = "0.2"
 	include-files = ["buildpack.toml"]
 
 [[metadata.dependencies]]
+	cpe = "node-cpe"
 	id = "node"
 	name = "Node Engine"
 	sha256 = "some-sha"
@@ -344,6 +356,7 @@ api = "0.2"
 					include-files = ["buildpack.toml"]
 
 				[[metadata.dependencies]]
+	        cpe = "node-cpe"
 					id = "node"
 					name = "Node Engine"
 					sha256 = "some-sha"
@@ -396,6 +409,7 @@ api = "0.2"
 	include-files = ["buildpack.toml"]
 
 [[metadata.dependencies]]
+	cpe = "node-cpe"
 	id = "node"
 	name = "Node Engine"
 	sha256 = "some-sha"
@@ -484,6 +498,7 @@ api = "0.2"
 					include-files = ["buildpack.toml"]
 
 					[[metadata.dependencies]]
+	          cpe = "non-existent-cpe"
 						id = "non-existent"
 						sha256 = "some-sha"
 						source = "some-source"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

In #181 we added the `jam update-dependencies` command to keep our buildpack dependencies up to date with our new dependency server. This PR results in a `buildpack.toml` with the same fields on `metadata.dependency` that we have always had.

This PR adds in the support for the new `CPE` field (common platform enumeration) field on each dependency, since this is important for vulnerability lookup.

The resulting `buildpack.toml` dependencies will look like:
```
[[metadata.dependencies]]	
  cpe = "dependency-specific-cpe"	
  id = "dependency-id"	
  name = "Dependency Name"	
  sha256 = "sha"	
  source = "source-uri"	
  source_sha256 = "source-sha"	
  stacks = ["stack"]	
  uri = "dependency-server-uri"	
  version = "version"
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

Our dependency server provides CPE notation for each dependency so that we can look up specific vulnerabilities in a NIST database, for example. This is helpful information to surface, so that we can include it in a bill of materials down the line.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).