### PR TITLE
Fixes issue with stripping '.' directory

### DIFF
--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ulikunitz/xz"
 )
 
-// An Archive decompresses tar, gzip and xz compressed tar, and zip files from
+// An Archive decompresses tar, gzip, xz, and bzip2 compressed tar, and zip files from
 // an input stream.
 type Archive struct {
 	reader     io.Reader
@@ -107,17 +107,20 @@ func (ta TarArchive) Decompress(destination string) error {
 			return fmt.Errorf("failed to read tar response: %s", err)
 		}
 
-		// Skip if the destination it the destination directory itself i.e. ./
-		if hdr.Name == "./" {
+		// Clean the name in the header to prevent './filename' being stripped to
+		// 'filename' also to skip if the destination it the destination directory
+		// itself i.e. './'
+		var name string
+		if name = filepath.Clean(hdr.Name); name == "." {
 			continue
 		}
 
-		err = checkExtractPath(hdr.Name, destination)
+		err = checkExtractPath(name, destination)
 		if err != nil {
 			return err
 		}
 
-		fileNames := strings.Split(hdr.Name, "/")
+		fileNames := strings.Split(name, "/")
 
 		// Checks to see if file should be written when stripping components
 		if len(fileNames) <= ta.components {
@@ -392,17 +395,20 @@ func (z ZipArchive) Decompress(destination string) error {
 	}
 
 	for _, f := range zr.File {
-		// Skip if the destination it the destination directory itself i.e. ./
-		if f.Name == "./" {
+		// Clean the name in the header to prevent './filename' being stripped to
+		// 'filename' also to skip if the destination it the destination directory
+		// itself i.e. './'
+		var name string
+		if name = filepath.Clean(f.Name); name == "." {
 			continue
 		}
 
-		err = checkExtractPath(f.Name, destination)
+		err = checkExtractPath(name, destination)
 		if err != nil {
 			return err
 		}
 
-		path := filepath.Join(destination, f.Name)
+		path := filepath.Join(destination, name)
 
 		switch {
 		case f.FileInfo().IsDir():

--- a/vacation/vacation_tar_test.go
+++ b/vacation/vacation_tar_test.go
@@ -39,7 +39,7 @@ func testVacationTar(t *testing.T, context spec.G, it spec.S) {
 			_, err = tw.Write(nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(tw.WriteHeader(&tar.Header{Name: "some-dir", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
+			Expect(tw.WriteHeader(&tar.Header{Name: "./some-dir", Mode: 0755, Typeflag: tar.TypeDir})).To(Succeed())
 			_, err = tw.Write(nil)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Strip components would string `.` off of the path when stripping components. This leads to some hard to parse behavior by the end user as it appears that strip components does nothing. The path is now cleaned before stripping to ensure more expected behavior.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
