### PR TITLE
Removes functionality to symlink to something with and absolute path

### DIFF
--- a/vacation/vacation.go
+++ b/vacation/vacation.go
@@ -206,14 +206,8 @@ func (ta TarArchive) Decompress(destination string) error {
 	})
 
 	for _, h := range symlinkHeaders {
-		evalPath := linknameFullPath(h.path, h.linkname)
-		// Don't use constucted link if the link is absolute
-		if filepath.IsAbs(h.linkname) {
-			evalPath = h.linkname
-		}
-
 		// Check to see if the file that will be linked to is valid for symlinking
-		_, err := filepath.EvalSymlinks(evalPath)
+		_, err := filepath.EvalSymlinks(linknameFullPath(h.path, h.linkname))
 		if err != nil {
 			return fmt.Errorf("failed to evaluate symlink %s: %w", h.path, err)
 		}
@@ -481,14 +475,8 @@ func (z ZipArchive) Decompress(destination string) error {
 	})
 
 	for _, h := range symlinkHeaders {
-		evalPath := linknameFullPath(h.path, h.linkname)
-		// Don't use constucted link if the link is absolute
-		if filepath.IsAbs(h.linkname) {
-			evalPath = h.linkname
-		}
-
 		// Check to see if the file that will be linked to is valid for symlinking
-		_, err := filepath.EvalSymlinks(evalPath)
+		_, err := filepath.EvalSymlinks(linknameFullPath(h.path, h.linkname))
 		if err != nil {
 			return fmt.Errorf("failed to evaluate symlink %s: %w", h.path, err)
 		}


### PR DESCRIPTION
This removes a security regression in the decompression code. You should not be able to link to things outside of the destination directory.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
