### PR TITLE
Adds support for packaging to include [[buildpack.licenses]]

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -23,11 +23,18 @@ type ConfigStack struct {
 }
 
 type ConfigBuildpack struct {
-	ID       string `toml:"id"                 json:"id,omitempty"`
-	Name     string `toml:"name"               json:"name,omitempty"`
-	Version  string `toml:"version"            json:"version,omitempty"`
-	Homepage string `toml:"homepage,omitempty" json:"homepage,omitempty"`
-	SHA256   string `toml:"-"                  json:"-"`
+	ID       string                   `toml:"id"                 json:"id,omitempty"`
+	Name     string                   `toml:"name"               json:"name,omitempty"`
+	Version  string                   `toml:"version"            json:"version,omitempty"`
+	Homepage string                   `toml:"homepage,omitempty" json:"homepage,omitempty"`
+	Licenses []ConfigBuildpackLicense `toml:"licenses,omitempty" json:"licenses,omitempty"`
+
+	SHA256 string `toml:"-" json:"-"`
+}
+
+type ConfigBuildpackLicense struct {
+	Type string `toml:"type" json:"type"`
+	URI  string `toml:"uri"  json:"uri"`
 }
 
 type ConfigMetadata struct {

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -37,6 +37,12 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 					Name:     "some-buildpack-name",
 					Version:  "some-buildpack-version",
 					Homepage: "some-homepage-link",
+					Licenses: []cargo.ConfigBuildpackLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
 				},
 				Stacks: []cargo.ConfigStack{
 					{
@@ -95,19 +101,25 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(buffer.String()).To(MatchTOML(`api = "0.2"
+			Expect(buffer.String()).To(MatchTOML(`
+api = "0.2"
+
 [buildpack]
-id = "some-buildpack-id"
-name = "some-buildpack-name"
-version = "some-buildpack-version"
-homepage = "some-homepage-link"
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-homepage-link"
+
+[[buildpack.licenses]]
+  type = "some-license-type"
+	uri = "some-license-uri"
 
 [metadata]
-include-files = ["some-include-file", "other-include-file"]
-pre-package = "some-pre-package-script.sh"
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
 
 [metadata.default-versions]
-some-dependency = "1.2.x"
+	some-dependency = "1.2.x"
 
 [[metadata.dependencies]]
   cpe = "some-cpe"
@@ -184,19 +196,25 @@ some-dependency = "1.2.x"
 
 	context("DecodeConfig", func() {
 		it("decodes TOML to config", func() {
-			tomlBuffer := strings.NewReader(`api = "0.2"
+			tomlBuffer := strings.NewReader(`
+api = "0.2"
+
 [buildpack]
-id = "some-buildpack-id"
-name = "some-buildpack-name"
-version = "some-buildpack-version"
-homepage = "some-homepage-link"
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-homepage-link"
+
+[[buildpack.licenses]]
+	type = "some-license-type"
+	uri = "some-license-uri"
 
 [metadata]
-include-files = ["some-include-file", "other-include-file"]
-pre-package = "some-pre-package-script.sh"
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
 
 [metadata.default-versions]
-some-dependency = "1.2.x"
+	some-dependency = "1.2.x"
 
 [[metadata.some-map]]
   key = "value"
@@ -244,6 +262,12 @@ some-dependency = "1.2.x"
 					Name:     "some-buildpack-name",
 					Version:  "some-buildpack-version",
 					Homepage: "some-homepage-link",
+					Licenses: []cargo.ConfigBuildpackLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
 				},
 				Stacks: []cargo.ConfigStack{
 					{

--- a/cargo/jam/internal/formatter.go
+++ b/cargo/jam/internal/formatter.go
@@ -100,17 +100,17 @@ func printImplementation(writer io.Writer, config cargo.Config) {
 }
 
 func (f Formatter) Markdown(configs []cargo.Config) {
-	var familyConfig cargo.Config
-	for index, config := range configs {
-		if len(config.Order) > 0 {
-			familyConfig = config
-			configs = append(configs[:index], configs[index+1:]...)
-			break
-		}
-	}
-
 	//Language-family case
-	if (familyConfig.Buildpack != cargo.ConfigBuildpack{}) {
+	if len(configs) > 1 {
+		var familyConfig cargo.Config
+		for index, config := range configs {
+			if len(config.Order) > 0 {
+				familyConfig = config
+				configs = append(configs[:index], configs[index+1:]...)
+				break
+			}
+		}
+
 		//Header section
 		fmt.Fprintf(f.writer, "## %s %s\n\n**ID:** `%s`\n\n", familyConfig.Buildpack.Name, familyConfig.Buildpack.Version, familyConfig.Buildpack.ID)
 		fmt.Fprintf(f.writer, "**Digest:** `%s`\n\n", familyConfig.Buildpack.SHA256)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
We'd like to add license metadata into all of the buildpacks, but this data gets dropped when `jam` packages the buildpack. This PR includes the required changes to make sure the license metadata makes it through into the built artifact.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
