### PR TITLE
Call out the Go Docs explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # packit
 
+Checkout the Go Docs for details on how to use the sub-packages within packit:
 [![GoDoc](https://img.shields.io/badge/pkg.go.dev-doc-blue)](http://pkg.go.dev/github.com/paketo-buildpacks/packit)
 
 Package packit provides primitives for implementing a Cloud Native Buildpack


### PR DESCRIPTION
Signed-off-by: Forest Eckhardt <feckhardt@pivotal.io>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Explicitly calls out that documentation on the packit subpackages can be found in the Go Docs.

## Use Cases
<!-- An explanation of the use cases your change enables -->

A year ago, I had never known about GoDocs and probably wouldn't have thought to click on the GoDoc button. Some projects have GoDocs but they're not fleshed out so I don't always bother checking them.  
The purpose of this PR is to draw attention to the fact we have GoDocs so that people can find all of the information about the subpackages in packit without confusion.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
