### PR TITLE
Add licenses to cargo dependency metadata

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -50,6 +50,7 @@ type ConfigMetadataDependency struct {
 	CPE             string     `toml:"cpe"              json:"cpe,omitempty"`
 	DeprecationDate *time.Time `toml:"deprecation_date" json:"deprecation_date,omitempty"`
 	ID              string     `toml:"id"               json:"id,omitempty"`
+	Licenses        []string   `toml:"licenses"         json:"licenses,omitempty"`
 	Name            string     `toml:"name"             json:"name,omitempty"`
 	SHA256          string     `toml:"sha256"           json:"sha256,omitempty"`
 	Source          string     `toml:"source"           json:"source,omitempty"`

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -65,6 +65,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							CPE:             "some-cpe",
 							DeprecationDate: &deprecationDate,
 							ID:              "some-dependency",
+							Licenses:        []string{"fancy-license", "fancy-license-2"},
 							Name:            "Some Dependency",
 							SHA256:          "shasum",
 							Source:          "source",
@@ -125,6 +126,7 @@ api = "0.2"
   cpe = "some-cpe"
   deprecation_date = "2020-06-01T00:00:00Z"
   id = "some-dependency"
+	licenses = ["fancy-license", "fancy-license-2"]
   name = "Some Dependency"
   sha256 = "shasum"
 	source = "source"
@@ -222,6 +224,7 @@ api = "0.2"
 [[metadata.dependencies]]
   cpe = "some-cpe"
   id = "some-dependency"
+	licenses = ["fancy-license", "fancy-license-2"]
   name = "Some Dependency"
   sha256 = "shasum"
 	source = "source"
@@ -289,6 +292,7 @@ api = "0.2"
 						{
 							CPE:          "some-cpe",
 							ID:           "some-dependency",
+							Licenses:     []string{"fancy-license", "fancy-license-2"},
 							Name:         "Some Dependency",
 							SHA256:       "shasum",
 							Source:       "source",

--- a/cargo/jam/internal/dependency.go
+++ b/cargo/jam/internal/dependency.go
@@ -139,8 +139,6 @@ func convertToCargoDependency(dependency Dependency, dependencyName string) carg
 	for _, stack := range dependency.Stacks {
 		cargoDependency.Stacks = append(cargoDependency.Stacks, stack.ID)
 	}
-	for _, license := range dependency.Licenses {
-		cargoDependency.Licenses = append(cargoDependency.Licenses, license)
-	}
+	cargoDependency.Licenses = append(cargoDependency.Licenses, dependency.Licenses...)
 	return cargoDependency
 }

--- a/cargo/jam/internal/dependency.go
+++ b/cargo/jam/internal/dependency.go
@@ -17,16 +17,17 @@ import (
 type Dependency struct {
 	DeprecationDate string `json:"deprecation_date,omitempty"`
 	// The ID field should be the `name` from the dep-server
-	ID           string  `json:"name,omitempty"`
-	SHA256       string  `json:"sha256,omitempty"`
-	Source       string  `json:"source,omitempty"`
-	SourceSHA256 string  `json:"source_sha256,omitempty"`
-	Stacks       []Stack `json:"stacks,omitempty"`
-	URI          string  `json:"uri,omitempty"`
-	Version      string  `json:"version,omitempty"`
-	CreatedAt    string  `json:"created_at,omitempty"`
-	ModifedAt    string  `json:"modified_at,omitempty"`
-	CPE          string  `json:"cpe,omitempty"`
+	ID           string   `json:"name,omitempty"`
+	SHA256       string   `json:"sha256,omitempty"`
+	Source       string   `json:"source,omitempty"`
+	SourceSHA256 string   `json:"source_sha256,omitempty"`
+	Stacks       []Stack  `json:"stacks,omitempty"`
+	URI          string   `json:"uri,omitempty"`
+	Version      string   `json:"version,omitempty"`
+	CreatedAt    string   `json:"created_at,omitempty"`
+	ModifedAt    string   `json:"modified_at,omitempty"`
+	CPE          string   `json:"cpe,omitempty"`
+	Licenses     []string `json:"licenses,omitempty"`
 }
 
 type Stack struct {
@@ -137,6 +138,9 @@ func convertToCargoDependency(dependency Dependency, dependencyName string) carg
 	cargoDependency.Version = strings.Replace(dependency.Version, "v", "", -1)
 	for _, stack := range dependency.Stacks {
 		cargoDependency.Stacks = append(cargoDependency.Stacks, stack.ID)
+	}
+	for _, license := range dependency.Licenses {
+		cargoDependency.Licenses = append(cargoDependency.Licenses, license)
 	}
 	return cargoDependency
 }

--- a/cargo/jam/internal/dependency_test.go
+++ b/cargo/jam/internal/dependency_test.go
@@ -38,6 +38,10 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				CreatedAt: "sometime",
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
+				Licenses: []string{
+					"fancy-license",
+					"fancy-license-2",
+				},
 			},
 			{
 				DeprecationDate: "",
@@ -55,6 +59,10 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				CreatedAt: "sometime",
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
+				Licenses: []string{
+					"fancy-license",
+					"fancy-license-2",
+				},
 			},
 			{
 				DeprecationDate: "",
@@ -72,6 +80,10 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				CreatedAt: "sometime",
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
+				Licenses: []string{
+					"fancy-license",
+					"fancy-license-2",
+				},
 			},
 			{
 				DeprecationDate: "",
@@ -89,6 +101,10 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				CreatedAt: "sometime",
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
+				Licenses: []string{
+					"fancy-license",
+					"fancy-license-2",
+				},
 			},
 			{
 				DeprecationDate: "",
@@ -106,6 +122,10 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				CreatedAt: "sometime",
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
+				Licenses: []string{
+					"fancy-license",
+					"fancy-license-2",
+				},
 			},
 		}
 	})
@@ -142,7 +162,8 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
     "created_at": "sometime",
     "modified_at": "another-time",
 		"cpe": "cpe-notation",
-		"deprecation_date" : ""
+		"deprecation_date": "",
+		"licenses": ["fancy-license", "fancy-license-2"]
   },
   {
     "name": "some-dep",
@@ -158,7 +179,8 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
     "source_sha256": "some-source-sha-two",
     "created_at": "sometime",
     "modified_at": "another-time",
-		"cpe": "cpe-notation"
+		"cpe": "cpe-notation",
+		"licenses": ["fancy-license", "fancy-license-2"]
   },
   {
     "name": "some-dep",
@@ -174,7 +196,8 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
     "source_sha256": "some-source-sha-three",
     "created_at": "sometime",
     "modified_at": "another-time",
-		"cpe": "cpe-notation"
+		"cpe": "cpe-notation",
+		"licenses": ["fancy-license", "fancy-license-2"]
   },
   {
     "name": "some-dep",
@@ -190,7 +213,8 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 		"source_sha256": "some-source-sha-four",
     "created_at": "sometime",
     "modified_at": "another-time",
-		"cpe": "cpe-notation"
+		"cpe": "cpe-notation",
+		"licenses": ["fancy-license", "fancy-license-2"]
   },
   {
     "name": "different-dep",
@@ -206,7 +230,8 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 		"source_sha256": "different-dep-source-sha",
     "created_at": "sometime",
     "modified_at": "another-time",
-		"cpe": "cpe-notation"
+		"cpe": "cpe-notation",
+		"licenses": ["fancy-license", "fancy-license-2"]
   }
 ]`)
 					}
@@ -278,6 +303,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 					{
 						CPE:          "cpe-notation",
 						ID:           "some-dep",
+						Licenses:     []string{"fancy-license", "fancy-license-2"},
 						Version:      "1.0.0",
 						Stacks:       []string{"some-stack"},
 						URI:          "some-dep-uri",
@@ -288,6 +314,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 					{
 						CPE:          "cpe-notation",
 						ID:           "some-dep",
+						Licenses:     []string{"fancy-license", "fancy-license-2"},
 						Version:      "1.1.2",
 						Stacks:       []string{"some-stack-two"},
 						URI:          "some-dep-uri-two",
@@ -298,6 +325,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 					{
 						CPE:          "cpe-notation",
 						ID:           "some-dep",
+						Licenses:     []string{"fancy-license", "fancy-license-2"},
 						Version:      "1.5.6",
 						Stacks:       []string{"some-stack-three"},
 						URI:          "some-dep-uri-three",
@@ -347,6 +375,7 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 							CreatedAt: "sometime",
 							ModifedAt: "another-time",
 							CPE:       "cpe-notation",
+							Licenses:  []string{"fancy-license", "fancy-license-2"},
 						},
 					}
 

--- a/cargo/jam/update_dependencies_test.go
+++ b/cargo/jam/update_dependencies_test.go
@@ -55,7 +55,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
     ],
     "source": "some-source",
     "source_sha256": "some-source-sha",
-		"cpe": "node-cpe"
+		"cpe": "node-cpe",
+		"licenses": ["MIT", "MIT-2"]
 	},
   {
     "name": "node",
@@ -69,7 +70,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
     ],
     "source": "some-source",
     "source_sha256": "some-source-sha",
-		"cpe": "node-cpe"
+		"cpe": "node-cpe",
+		"licenses": ["MIT", "MIT-2"]
 	},
   {
     "name": "node",
@@ -83,7 +85,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
     ],
     "source": "some-source",
     "source_sha256": "some-source-sha",
-		"cpe": "node-cpe"
+		"cpe": "node-cpe",
+		"licenses": ["MIT", "MIT-2"]
 	},
   {
     "name": "node",
@@ -97,7 +100,8 @@ func testUpdateDependencies(t *testing.T, context spec.G, it spec.S) {
     ],
     "source": "some-source",
     "source_sha256": "some-source-sha",
-		"cpe": "node-cpe"
+		"cpe": "node-cpe",
+		"licenses": ["MIT", "MIT-2"]
 	}]`)
 				}
 
@@ -209,6 +213,7 @@ api = "0.2"
 [[metadata.dependencies]]
 	cpe = "node-cpe"
 	id = "node"
+	licenses = ["MIT", "MIT-2"]
 	name = "Node Engine"
 	sha256 = "some-sha"
 	source = "some-source"
@@ -220,6 +225,7 @@ api = "0.2"
 [[metadata.dependencies]]
 	cpe = "node-cpe"
 	id = "node"
+	licenses = ["MIT", "MIT-2"]
 	name = "Node Engine"
 	sha256 = "some-sha"
 	source = "some-source"
@@ -231,6 +237,7 @@ api = "0.2"
 [[metadata.dependencies]]
 	cpe = "node-cpe"
 	id = "node"
+	licenses = ["MIT", "MIT-2"]
 	name = "Node Engine"
 	sha256 = "some-sha"
 	source = "some-source"
@@ -270,6 +277,7 @@ api = "0.2"
 				[[metadata.dependencies]]
 	        cpe = "node-cpe"
 					id = "node"
+					licenses = ["MIT", "MIT-2"]
 					name = "Node Engine"
 					sha256 = "some-sha"
 					source = "some-source"
@@ -323,6 +331,7 @@ api = "0.2"
 [[metadata.dependencies]]
 	cpe = "node-cpe"
 	id = "node"
+	licenses = ["MIT", "MIT-2"]
 	name = "Node Engine"
 	sha256 = "some-sha"
 	source = "some-source"
@@ -359,6 +368,7 @@ api = "0.2"
 	        cpe = "node-cpe"
 					id = "node"
 					name = "Node Engine"
+					licenses = ["MIT", "MIT-2"]
 					sha256 = "some-sha"
 					source = "some-source"
 					source_sha256 = "some-source-sha"
@@ -411,6 +421,7 @@ api = "0.2"
 [[metadata.dependencies]]
 	cpe = "node-cpe"
 	id = "node"
+	licenses = ["MIT", "MIT-2"]
 	name = "Node Engine"
 	sha256 = "some-sha"
 	source = "some-source"
@@ -500,6 +511,7 @@ api = "0.2"
 					[[metadata.dependencies]]
 	          cpe = "non-existent-cpe"
 						id = "non-existent"
+					  licenses = ["MIT", "MIT-2"]
 						sha256 = "some-sha"
 						source = "some-source"
 						source_sha256 = "some-source-sha"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Will resolve #189. 

~~This will remain a draft PR to avoid confusion until~~ This is ready to merge now that  https://github.com/paketo-buildpacks/dep-server/pull/49 and https://github.com/paketo-buildpacks/dep-server/pull/44 are merged, so that dependencies on the dep-server actually contain license information.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
