### PR TITLE
jam update-dependencies: Cut non-digit characters from dependency versions

### DIFF
--- a/cargo/jam/internal/dependency.go
+++ b/cargo/jam/internal/dependency.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -46,6 +47,12 @@ func GetDependenciesWithinConstraint(dependencies []Dependency, constraint cargo
 		if err != nil {
 			return nil, err
 		}
+
+		// Cut off any non-digit characters at the beginning of the version and update dependency.Version to have that version.
+		// EX. go1.2.3  becomes 1.2.3
+		// EX. v2.3.4   becomes 2.3.4
+		cutOffCharacters := regexp.MustCompile(`\D*`)
+		dependency.Version = cutOffCharacters.Split(dependency.Version, 2)[1]
 
 		depVersion, err := semver.NewVersion(dependency.Version)
 		if err != nil {

--- a/cargo/jam/internal/dependency_test.go
+++ b/cargo/jam/internal/dependency_test.go
@@ -107,6 +107,23 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 				ModifedAt: "another-time",
 				CPE:       "cpe-notation",
 			},
+			{
+				DeprecationDate: "",
+				ID:              "non-semver-dep",
+				SHA256:          "non-semver-sha",
+				Source:          "non-semver-source",
+				SourceSHA256:    "non-semver-source-sha",
+				Stacks: []internal.Stack{
+					{
+						ID: "non-semver-stack",
+					},
+				},
+				URI:       "non-semver-uri",
+				Version:   "non-semver1.9.8",
+				CreatedAt: "sometime",
+				ModifedAt: "another-time",
+				CPE:       "cpe-notation",
+			},
 		}
 	})
 
@@ -207,6 +224,22 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
     "created_at": "sometime",
     "modified_at": "another-time",
 		"cpe": "cpe-notation"
+  },
+  {
+    "name": "non-semver-dep",
+    "version": "non-semver1.9.8",
+    "sha256": "non-semver-sha",
+    "uri": "non-semver-uri",
+    "stacks": [
+      {
+        "id": "non-semver-stack"
+      }
+    ],
+    "source": "non-semver-source",
+		"source_sha256": "non-semver-source-sha",
+    "created_at": "sometime",
+    "modified_at": "another-time",
+		"cpe": "cpe-notation"
   }
 ]`)
 					}
@@ -304,6 +337,31 @@ func testDependency(t *testing.T, context spec.G, it spec.S) {
 						SHA256:       "some-sha-three",
 						Source:       "some-source-three",
 						SourceSHA256: "some-source-sha-three",
+					},
+				}))
+			})
+		})
+
+		context("given a valid api and constraint that returns a dependency with non-semver version", func() {
+			it("returns dependencies and makes the version semver-compatible", func() {
+				constraint := cargo.ConfigMetadataDependencyConstraint{
+					Constraint: "1.*",
+					ID:         "non-semver-dep",
+					Patches:    1,
+				}
+
+				dependencies, err := internal.GetDependenciesWithinConstraint(allDependencies, constraint, "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependencies).To(Equal([]cargo.ConfigMetadataDependency{
+					{
+						CPE:          "cpe-notation",
+						ID:           "non-semver-dep",
+						Version:      "1.9.8",
+						Stacks:       []string{"non-semver-stack"},
+						URI:          "non-semver-uri",
+						SHA256:       "non-semver-sha",
+						Source:       "non-semver-source",
+						SourceSHA256: "non-semver-source-sha",
 					},
 				}))
 			})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Will resolve issue described in https://github.com/paketo-buildpacks/go-dist/issues/280#issuecomment-877368726 in which the versions published to the dep-server for some dependencies are not in semver format. This occurs because the dep-server grabs whatever version is published on the official release website, so Go versions, for example, have versions like `go1.2.3`. 

This change will cut off any non-digit characters from the version, so that `jam` can properly update the version in the `buildpack.toml` using semver compatible versions. This will have no effect on any other versions that don't have non-digit characters at the beginning.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
