### PR TITLE
Adds StripComponents to vacation.ZipArchive

### DIFF
--- a/vacation/archive.go
+++ b/vacation/archive.go
@@ -64,7 +64,7 @@ func (a Archive) Decompress(destination string) error {
 	case "application/x-bzip2":
 		decompressor = NewTarBzip2Archive(bufferedReader).StripComponents(a.components)
 	case "application/zip":
-		decompressor = NewZipArchive(bufferedReader)
+		decompressor = NewZipArchive(bufferedReader).StripComponents(a.components)
 	case "text/plain; charset=utf-8", "application/jar":
 		destination = filepath.Join(destination, a.name)
 		decompressor = NewNopArchive(bufferedReader)

--- a/vacation/example_test.go
+++ b/vacation/example_test.go
@@ -191,8 +191,7 @@ func ExampleArchive_StripComponents() {
 
 	// Output:
 	// some-tar-file
-	// some-zip-dir/some-zip-file
-	// zip-file
+	// some-zip-file
 }
 
 func ExampleTarArchive() {

--- a/vacation/zip_archive_test.go
+++ b/vacation/zip_archive_test.go
@@ -113,6 +113,21 @@ func testZipArchive(t *testing.T, context spec.G, it spec.S) {
 			Expect(data).To(Equal([]byte("nested file")))
 		})
 
+		it("unpackages the archive into the path but also strips the first component", func() {
+			var err error
+			err = zipArchive.StripComponents(1).Decompress(tempDir)
+			Expect(err).ToNot(HaveOccurred())
+
+			files, err := filepath.Glob(fmt.Sprintf("%s/*", tempDir))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(files).To(ConsistOf([]string{
+				filepath.Join(tempDir, "some-other-dir"),
+			}))
+
+			Expect(filepath.Join(tempDir, "some-other-dir")).To(BeADirectory())
+			Expect(filepath.Join(tempDir, "some-other-dir", "some-file")).To(BeARegularFile())
+		})
+
 		context("failure cases", func() {
 			context("when it fails to create a zip reader", func() {
 				it("returns an error", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change brings zip archives into alignment with the other support archive types in the `vacation` package. Its implementation aligns with the existing feature.

## Use Cases
<!-- An explanation of the use cases your change enables -->
If you need to remove outer directories from a zip archive, then using the `StripComponents` feature on the `vacation.ZipArchive` type will do the job.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
