### PR TITLE
Prevent file descriptor exhaustion when decompressing zip files

### DIFF
--- a/vacation/zip_archive.go
+++ b/vacation/zip_archive.go
@@ -112,16 +112,22 @@ func (z ZipArchive) Decompress(destination string) error {
 			if err != nil {
 				return fmt.Errorf("failed to unzip file: %w", err)
 			}
-			defer dst.Close()
 
 			src, err := f.Open()
 			if err != nil {
 				return err
 			}
-			defer src.Close()
 
 			_, err = io.Copy(dst, src)
 			if err != nil {
+				return err
+			}
+
+			if err := dst.Close(); err != nil {
+				return err
+			}
+
+			if err := src.Close(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As currently implemented, the `vacation.ZipArchive` can exhaust file descriptors on the operating system as it decompresses the files. The issue is that we are using `defer file.Close()` in a `for` loop. These `defer` invocations don't get run as each loop finishes, but instead at the end of the function body. This means that if the zip archive contains enough files, it can exhaust file descriptors, causing the code to error.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
