### PR TITLE
Make dependency license an interface

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -47,18 +47,18 @@ type ConfigMetadata struct {
 }
 
 type ConfigMetadataDependency struct {
-	CPE             string     `toml:"cpe"              json:"cpe,omitempty"`
-	PURL            string     `toml:"purl"              json:"purl,omitempty"`
-	DeprecationDate *time.Time `toml:"deprecation_date" json:"deprecation_date,omitempty"`
-	ID              string     `toml:"id"               json:"id,omitempty"`
-	Licenses        []string   `toml:"licenses"         json:"licenses,omitempty"`
-	Name            string     `toml:"name"             json:"name,omitempty"`
-	SHA256          string     `toml:"sha256"           json:"sha256,omitempty"`
-	Source          string     `toml:"source"           json:"source,omitempty"`
-	SourceSHA256    string     `toml:"source_sha256"    json:"source_sha256,omitempty"`
-	Stacks          []string   `toml:"stacks"           json:"stacks,omitempty"`
-	URI             string     `toml:"uri"              json:"uri,omitempty"`
-	Version         string     `toml:"version"          json:"version,omitempty"`
+	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
+	PURL            string        `toml:"purl"              json:"purl,omitempty"`
+	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
+	ID              string        `toml:"id"               json:"id,omitempty"`
+	Licenses        []interface{} `toml:"licenses"         json:"licenses,omitempty"`
+	Name            string        `toml:"name"             json:"name,omitempty"`
+	SHA256          string        `toml:"sha256"           json:"sha256,omitempty"`
+	Source          string        `toml:"source"           json:"source,omitempty"`
+	SourceSHA256    string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
+	Stacks          []string      `toml:"stacks"           json:"stacks,omitempty"`
+	URI             string        `toml:"uri"              json:"uri,omitempty"`
+	Version         string        `toml:"version"          json:"version,omitempty"`
 }
 
 type ConfigMetadataDependencyConstraint struct {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Will resolve #222.
With version v0.14.1 of packit and beyond, any buildpacks that do not have a `buildpack.toml` that matches what we expect in packit, `jam summarize` fails because the license field (slice of strings) is represented as as struct.

This has been an issue in our language family buildpacks (https://github.com/paketo-community/rust/actions/runs/1225798554).

This change just makes the dependency license field in `cargo.Config` into a slice of `interface` rather than a slice of `string`. This makes the field more flexible so that commands in `jam` that consume `cargo.Config` (such as `jam summarize`) will not error out with `cannot unmarshal object into Go struct field Config.metadata of type string`.

This change should have no effect on buildpacks that have the `buildpack.toml` format we expect.
This will be followed by a PR in `jam` to slightly modify how dependency licenses are gathered.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
