### PR TITLE
Fix binding handling when binding root doesn't exist

### DIFF
--- a/servicebindings/resolver.go
+++ b/servicebindings/resolver.go
@@ -93,7 +93,9 @@ func (r *Resolver) ResolveOne(typ, provider, platformDir string) (Binding, error
 
 func loadBindings(bindingRoot string) ([]Binding, error) {
 	files, err := os.ReadDir(bindingRoot)
-	if err != nil {
+	if os.IsNotExist(err) {
+		return nil, nil
+	} else if err != nil {
 		return nil, err
 	}
 

--- a/servicebindings/resolver_test.go
+++ b/servicebindings/resolver_test.go
@@ -323,6 +323,14 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 				_, err = resolver.Resolve("bad-type", "", "")
 				Expect(err).To(MatchError(HavePrefix("failed to load bindings from '%s': failed to read binding 'bad-binding': open %s: permission denied", bindingRoot, filepath.Join(bindingRoot, "bad-binding", "type"))))
 			})
+
+			it("returns empty list if binding root doesn't exist", func() {
+				Expect(os.RemoveAll(bindingRoot)).To(Succeed())
+
+				bindings, err := resolver.Resolve("type-1", "", "")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(bindings).To(BeEmpty())
+			})
 		})
 
 		context("ResolveOne", func() {


### PR DESCRIPTION
Instead of erroring when the binding root doesn't exist, it returns an empty list of bindings. This change is necessary because the bindings volume is not always required to be mounted.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added tests.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
