### PR TITLE
Adds the PR semver labeling workflows

### DIFF
--- a/.github/.patch_files
+++ b/.github/.patch_files
@@ -1,0 +1,15 @@
+.github/.patch_files
+.github/.syncignore
+.github/CODEOWNERS
+.github/dependabot.yml
+.github/labels.yml
+.github/workflows/check-pr-labels.yml
+.github/workflows/codeql-analysis.yml
+.github/workflows/label-pr.yml
+.github/workflows/lint.yml
+.github/workflows/synchronize-labels.yml
+.github/workflows/test-pull-request.yml
+.gitignore
+LICENSE
+NOTICE
+README.md

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -1,0 +1,24 @@
+name: Validate PR Labels
+on:
+  pull_request:
+    branches:
+    - main
+    types:
+    - synchronize
+    - opened
+    - reopened
+    - labeled
+    - unlabeled
+
+concurrency: pr_labels
+
+jobs:
+  semver:
+    name: Ensure Minimal Semver Labels
+    runs-on: ubuntu-latest
+    steps:
+    - uses: mheap/github-action-required-labels@v1
+      with:
+        count: 1
+        labels: semver:major, semver:minor, semver:patch
+        mode: exactly

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,17 @@
+name: Auto-label PR
+on:
+  pull_request:
+    branches:
+    - main
+
+concurrency: pr_labels
+
+jobs:
+  semver-label:
+    name: Semver Auto-Label
+    runs-on: ubuntu-latest
+    steps:
+    - name: Auto-label Semver
+      uses: paketo-buildpacks/github-config/actions/pull-request/auto-semver-label@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

New workflows have been added to our buildpacks via [paketo-buildpacks/github-config](www.github.com/paketo-buildpacks/github-config) to auto-label some pull requests with semver labels, and to add a check that pull requests have semver labels before they are merged.

Packit often has breaking changes and it should reduce maintainer toil when cutting releases if the semver label workflow is followed.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
