### PR TITLE
add sbom field to buildpack.toml (Buildpack API 0.7)

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -80,7 +80,7 @@ api = "0.6"
 	homepage = "some-homepage"
 	description = "some-description"
 	keywords = ["some-keyword"]
-	sbom = ["some-sbom-format", "some-other-sbom-format"]
+	sbom-formats = ["some-sbom-format", "some-other-sbom-format"]
   clear-env = false
 
 	[[buildpack.licenses]]
@@ -143,7 +143,7 @@ api = "0.6"
 				Homepage:    "some-homepage",
 				Description: "some-description",
 				Keywords:    []string{"some-keyword"},
-				SBOM:        []string{"some-sbom-format", "some-other-sbom-format"},
+				SBOMFormats: []string{"some-sbom-format", "some-other-sbom-format"},
 				Licenses: []packit.BuildpackInfoLicense{
 					{
 						Type: "some-license-type",
@@ -428,7 +428,7 @@ api = "0.6"
 					Homepage:    "some-homepage",
 					Description: "some-description",
 					Keywords:    []string{"some-keyword"},
-					SBOM:        []string{"some-sbom-format", "some-other-sbom-format"},
+					SBOMFormats: []string{"some-sbom-format", "some-other-sbom-format"},
 					Licenses: []packit.BuildpackInfoLicense{
 						{
 							Type: "some-license-type",

--- a/build_test.go
+++ b/build_test.go
@@ -80,6 +80,7 @@ api = "0.6"
 	homepage = "some-homepage"
 	description = "some-description"
 	keywords = ["some-keyword"]
+	sbom = ["some-sbom-format", "some-other-sbom-format"]
   clear-env = false
 
 	[[buildpack.licenses]]
@@ -142,6 +143,7 @@ api = "0.6"
 				Homepage:    "some-homepage",
 				Description: "some-description",
 				Keywords:    []string{"some-keyword"},
+				SBOM:        []string{"some-sbom-format", "some-other-sbom-format"},
 				Licenses: []packit.BuildpackInfoLicense{
 					{
 						Type: "some-license-type",
@@ -426,6 +428,7 @@ api = "0.6"
 					Homepage:    "some-homepage",
 					Description: "some-description",
 					Keywords:    []string{"some-keyword"},
+					SBOM:        []string{"some-sbom-format", "some-other-sbom-format"},
 					Licenses: []packit.BuildpackInfoLicense{
 						{
 							Type: "some-license-type",

--- a/buildpack_info.go
+++ b/buildpack_info.go
@@ -31,6 +31,10 @@ type BuildpackInfo struct {
 	// Licenses are the list of licenses specified in the `buildpack.licenses`
 	// fields of the buildpack.toml.
 	Licenses []BuildpackInfoLicense
+
+	// SBOM is the list of Software Bill of Materials media types that the buildpack
+	// produces (e.g. "application/spdx+json").
+	SBOM []string `toml:"sbom"`
 }
 
 // BuildpackInfoLicense is a representation of a license specified in the

--- a/buildpack_info.go
+++ b/buildpack_info.go
@@ -32,9 +32,9 @@ type BuildpackInfo struct {
 	// fields of the buildpack.toml.
 	Licenses []BuildpackInfoLicense
 
-	// SBOM is the list of Software Bill of Materials media types that the buildpack
+	// SBOMFormats is the list of Software Bill of Materials media types that the buildpack
 	// produces (e.g. "application/spdx+json").
-	SBOM []string `toml:"sbom"`
+	SBOMFormats []string `toml:"sbom-formats"`
 }
 
 // BuildpackInfoLicense is a representation of a license specified in the

--- a/cargo/config.go
+++ b/cargo/config.go
@@ -31,7 +31,7 @@ type ConfigBuildpack struct {
 	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
 	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
 	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
-	SBOM        []string                 `toml:"sbom,omitempty"    json:"sbom,omitempty"`
+	SBOMFormats []string                 `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
 
 	// Deprecated: This field is not part of the official buildpack.toml spec and
 	// will therefore be removed in the next major release

--- a/cargo/config.go
+++ b/cargo/config.go
@@ -31,6 +31,7 @@ type ConfigBuildpack struct {
 	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
 	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
 	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
+	SBOM        []string                 `toml:"sbom,omitempty"    json:"sbom,omitempty"`
 
 	// Deprecated: This field is not part of the official buildpack.toml spec and
 	// will therefore be removed in the next major release

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -46,7 +46,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							URI:  "some-license-uri",
 						},
 					},
-					SBOM: []string{"some-sbom-format"},
+					SBOMFormats: []string{"some-sbom-format"},
 				},
 				Stacks: []cargo.ConfigStack{
 					{
@@ -118,7 +118,7 @@ api = "0.6"
 	clear-env = true
 	description = "some-buildpack-description"
 	keywords = [ "some-buildpack-keyword" ]
-	sbom = [ "some-sbom-format" ]
+	sbom-formats = [ "some-sbom-format" ]
 
 [[buildpack.licenses]]
   type = "some-license-type"
@@ -376,7 +376,7 @@ api = "0.6"
 	clear-env = true
 	description = "some-buildpack-description"
 	keywords = [ "some-buildpack-keyword" ]
-	sbom = [ "some-sbom-format" ]
+	sbom-formats = [ "some-sbom-format" ]
 
 [[buildpack.licenses]]
 	type = "some-license-type"
@@ -446,7 +446,7 @@ api = "0.6"
 							URI:  "some-license-uri",
 						},
 					},
-					SBOM: []string{"some-sbom-format"},
+					SBOMFormats: []string{"some-sbom-format"},
 				},
 				Stacks: []cargo.ConfigStack{
 					{

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -46,6 +46,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							URI:  "some-license-uri",
 						},
 					},
+					SBOM: []string{"some-sbom-format"},
 				},
 				Stacks: []cargo.ConfigStack{
 					{
@@ -117,6 +118,7 @@ api = "0.6"
 	clear-env = true
 	description = "some-buildpack-description"
 	keywords = [ "some-buildpack-keyword" ]
+	sbom = [ "some-sbom-format" ]
 
 [[buildpack.licenses]]
   type = "some-license-type"
@@ -374,6 +376,7 @@ api = "0.6"
 	clear-env = true
 	description = "some-buildpack-description"
 	keywords = [ "some-buildpack-keyword" ]
+	sbom = [ "some-sbom-format" ]
 
 [[buildpack.licenses]]
 	type = "some-license-type"
@@ -443,6 +446,7 @@ api = "0.6"
 							URI:  "some-license-uri",
 						},
 					},
+					SBOM: []string{"some-sbom-format"},
 				},
 				Stacks: []cargo.ConfigStack{
 					{


### PR DESCRIPTION
Signed-off-by: Rob Dimsdale-Zucker <rdimsdale@vmware.com>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
As part of implementing the [RFC for Syft/CycloneDX](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0038-cdx-syft-sbom.md) we need to add a field to the buildpack.toml as described in the [upstream RFC](https://github.com/buildpacks/rfcs/blob/main/text/0095-sbom.md).
<!-- A short explanation of the proposed change -->

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
