### PR TITLE
Use semver labels to calculate release version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version of the release to cut (e.g. 1.2.3)'
+        required: false
+
+concurrency: release
 
 jobs:
   unit:
@@ -37,11 +44,21 @@ jobs:
       with:
         repo: ${{ github.repository }}
         token: ${{ github.token }}
-    - name: Tag
-      id: tag
-      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
+    - name: Calculate Semver Tag
+      if: github.event.inputs.version == ''
+      id: semver
+      uses: paketo-buildpacks/github-config/actions/tag/calculate-semver@main
       with:
-        current_version: ${{ steps.reset.outputs.current_version }}
+        repo: ${{ github.repository }}
+        token: ${{ github.token }}
+    - name: Set Release Tag
+      id: tag
+      run: |
+        tag="${{ github.event.inputs.version }}"
+        if [ -z "${tag}" ]; then
+          tag="${{ steps.semver.outputs.tag }}"
+        fi
+        echo "::set-output name=tag::${tag}"
     - name: Create Draft Release
       uses: paketo-buildpacks/github-config/actions/release/create@main
       with:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

We are using [PR labeling workflows](https://github.com/paketo-buildpacks/packit/commit/fcbdcfdfaaba6862fc0be339cfadd9dd31dcb5ce), but we're not leveraging those labels to auto-generate the semantic version on packit releases. This PR adds that to the Create Release workflow.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Makes maintainers' lives easier by auto-generating the release version based off of labels.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
