### PR TITLE
Use packit.BuildpackInfo inside cargo.Config

### DIFF
--- a/buildpack_info.go
+++ b/buildpack_info.go
@@ -6,35 +6,39 @@ package packit
 type BuildpackInfo struct {
 	// ID is the identifier specified in the `buildpack.id` field of the
 	// buildpack.toml.
-	ID string `toml:"id"`
+	ID string `toml:"id"                    json:"id,omitempty"`
 
 	// Name is the identifier specified in the `buildpack.name` field of the
 	// buildpack.toml.
-	Name string `toml:"name"`
+	Name string `toml:"name"                  json:"name,omitempty"`
 
 	// Version is the identifier specified in the `buildpack.version` field of
 	// the buildpack.toml.
-	Version string `toml:"version"`
+	Version string `toml:"version"               json:"version,omitempty"`
 
 	// Homepage is the identifier specified in the `buildpack.homepage` field of
 	// the buildpack.toml.
-	Homepage string `toml:"homepage"`
+	Homepage string `toml:"homepage,omitempty"    json:"homepage,omitempty"`
+
+	// ClearEnv is the identifier specificed in the `buildpack.clen-env` field of
+	// the buildpack.toml.
+	ClearEnv bool `toml:"clear-env,omitempty"   json:"clear-env,omitempty"`
 
 	// Description is the identifier specified in the `buildpack.description`
 	// field of the buildpack.toml.
-	Description string `toml:"description"`
+	Description string `toml:"description,omitempty" json:"description,omitempty"`
 
 	// Keywords are the identifiers specified in the `buildpack.keywords` field
 	// of the buildpack.toml.
-	Keywords []string `toml:"keywords"`
+	Keywords []string `toml:"keywords,omitempty"    json:"keywords,omitempty"`
 
 	// Licenses are the list of licenses specified in the `buildpack.licenses`
 	// fields of the buildpack.toml.
-	Licenses []BuildpackInfoLicense
+	Licenses []BuildpackInfoLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
 
 	// SBOMFormats is the list of Software Bill of Materials media types that the buildpack
 	// produces (e.g. "application/spdx+json").
-	SBOMFormats []string `toml:"sbom-formats"`
+	SBOMFormats []string `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
 }
 
 // BuildpackInfoLicense is a representation of a license specified in the
@@ -43,9 +47,9 @@ type BuildpackInfo struct {
 type BuildpackInfoLicense struct {
 	// Type is the identifier specified in the `buildpack.licenses.type` field of
 	// the buildpack.toml.
-	Type string `toml:"type"`
+	Type string `toml:"type" json:"type"`
 
 	// URI is the identifier specified in the `buildpack.licenses.uri` field of
 	// the buildpack.toml.
-	URI string `toml:"uri"`
+	URI string `toml:"uri"  json:"uri"`
 }

--- a/cargo/buildpack_parser_test.go
+++ b/cargo/buildpack_parser_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/cargo"
 	"github.com/sclevine/spec"
 
@@ -65,7 +66,7 @@ pre-package = "some-pre-package-script.sh"
 			Expect(err).NotTo(HaveOccurred())
 			Expect(config).To(Equal(cargo.Config{
 				API: "0.2",
-				Buildpack: cargo.ConfigBuildpack{
+				Buildpack: packit.BuildpackInfo{
 					ID:      "some-buildpack-id",
 					Name:    "some-buildpack-name",
 					Version: "some-buildpack-version",

--- a/cargo/config.go
+++ b/cargo/config.go
@@ -7,40 +7,20 @@ import (
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/paketo-buildpacks/packit"
 )
 
 type Config struct {
-	API       string          `toml:"api"       json:"api,omitempty"`
-	Buildpack ConfigBuildpack `toml:"buildpack" json:"buildpack,omitempty"`
-	Metadata  ConfigMetadata  `toml:"metadata"  json:"metadata,omitempty"`
-	Stacks    []ConfigStack   `toml:"stacks"    json:"stacks,omitempty"`
-	Order     []ConfigOrder   `toml:"order"     json:"order,omitempty"`
+	API       string               `toml:"api"       json:"api,omitempty"`
+	Buildpack packit.BuildpackInfo `toml:"buildpack" json:"buildpack,omitempty"`
+	Metadata  ConfigMetadata       `toml:"metadata"  json:"metadata,omitempty"`
+	Stacks    []ConfigStack        `toml:"stacks"    json:"stacks,omitempty"`
+	Order     []ConfigOrder        `toml:"order"     json:"order,omitempty"`
 }
 
 type ConfigStack struct {
 	ID     string   `toml:"id"     json:"id,omitempty"`
 	Mixins []string `toml:"mixins" json:"mixins,omitempty"`
-}
-
-type ConfigBuildpack struct {
-	ID          string                   `toml:"id"                    json:"id,omitempty"`
-	Name        string                   `toml:"name"                  json:"name,omitempty"`
-	Version     string                   `toml:"version"               json:"version,omitempty"`
-	Homepage    string                   `toml:"homepage,omitempty"    json:"homepage,omitempty"`
-	ClearEnv    bool                     `toml:"clear-env,omitempty"   json:"clear-env,omitempty"`
-	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
-	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
-	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
-	SBOMFormats []string                 `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
-
-	// Deprecated: This field is not part of the official buildpack.toml spec and
-	// will therefore be removed in the next major release
-	SHA256 string `toml:"-" json:"-"`
-}
-
-type ConfigBuildpackLicense struct {
-	Type string `toml:"type" json:"type"`
-	URI  string `toml:"uri"  json:"uri"`
 }
 
 type ConfigMetadata struct {

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/paketo-buildpacks/packit"
 	"github.com/paketo-buildpacks/packit/cargo"
 	"github.com/sclevine/spec"
 
@@ -32,7 +33,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 
 			err = cargo.EncodeConfig(buffer, cargo.Config{
 				API: "0.6",
-				Buildpack: cargo.ConfigBuildpack{
+				Buildpack: packit.BuildpackInfo{
 					ID:          "some-buildpack-id",
 					Name:        "some-buildpack-name",
 					Version:     "some-buildpack-version",
@@ -40,7 +41,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 					ClearEnv:    true,
 					Description: "some-buildpack-description",
 					Keywords:    []string{"some-buildpack-keyword"},
-					Licenses: []cargo.ConfigBuildpackLicense{
+					Licenses: []packit.BuildpackInfoLicense{
 						{
 							Type: "some-license-type",
 							URI:  "some-license-uri",
@@ -179,12 +180,12 @@ api = "0.6"
 
 				err = cargo.EncodeConfig(buffer, cargo.Config{
 					API: "0.6",
-					Buildpack: cargo.ConfigBuildpack{
+					Buildpack: packit.BuildpackInfo{
 						ID:       "some-buildpack-id",
 						Name:     "some-buildpack-name",
 						Version:  "some-buildpack-version",
 						Homepage: "some-homepage-link",
-						Licenses: []cargo.ConfigBuildpackLicense{
+						Licenses: []packit.BuildpackInfoLicense{
 							{
 								Type: "some-license-type",
 								URI:  "some-license-uri",
@@ -214,11 +215,11 @@ api = "0.6"
 								DeprecationDate: &deprecationDate,
 								ID:              "some-dependency",
 								Licenses: []interface{}{
-									cargo.ConfigBuildpackLicense{
+									packit.BuildpackInfoLicense{
 										Type: "fancy-license",
 										URI:  "some-license-uri",
 									},
-									cargo.ConfigBuildpackLicense{
+									packit.BuildpackInfoLicense{
 										Type: "fancy-license-2",
 										URI:  "some-license-uri",
 									},
@@ -432,7 +433,7 @@ api = "0.6"
 			Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
 			Expect(config).To(Equal(cargo.Config{
 				API: "0.6",
-				Buildpack: cargo.ConfigBuildpack{
+				Buildpack: packit.BuildpackInfo{
 					ID:          "some-buildpack-id",
 					Name:        "some-buildpack-name",
 					Version:     "some-buildpack-version",
@@ -440,7 +441,7 @@ api = "0.6"
 					ClearEnv:    true,
 					Description: "some-buildpack-description",
 					Keywords:    []string{"some-buildpack-keyword"},
-					Licenses: []cargo.ConfigBuildpackLicense{
+					Licenses: []packit.BuildpackInfoLicense{
 						{
 							Type: "some-license-type",
 							URI:  "some-license-uri",
@@ -581,12 +582,12 @@ api = "0.2"
 				Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
 				Expect(config).To(Equal(cargo.Config{
 					API: "0.2",
-					Buildpack: cargo.ConfigBuildpack{
+					Buildpack: packit.BuildpackInfo{
 						ID:       "some-buildpack-id",
 						Name:     "some-buildpack-name",
 						Version:  "some-buildpack-version",
 						Homepage: "some-homepage-link",
-						Licenses: []cargo.ConfigBuildpackLicense{
+						Licenses: []packit.BuildpackInfoLicense{
 							{
 								Type: "some-license-type",
 								URI:  "some-license-uri",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

In https://github.com/paketo-buildpacks/packit/issues/179#issuecomment-983086623, @fg-j asks why we have duplication across `packit.BuildpackInfo` and `cargo.ConfigBuildpack`. 

I also can't see why we need to have both of these structs, so I have removed `cargo.ConfigBuildpack` and modified `packit.BuildpackInfo` to contain the appropriate `json` labels. 

If there is a reason for the duplication, I would like an explanation so we have that historical context in place going forward.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
