### PR TITLE
Simplify SBOM test assertions

### DIFF
--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -3,7 +3,6 @@ package sbom_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
 
@@ -31,74 +30,37 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.CycloneDXFormat))
 		Expect(err).NotTo(HaveOccurred())
 
-		var output struct {
-			SerialNumber string `json:"serialNumber"`
-			Metadata     struct {
-				Timestamp string `json:"timestamp"`
-			} `json:"metadata"`
+		type component struct {
+			Name string `json:"name"`
 		}
-		err = json.Unmarshal(buffer.Bytes(), &output)
-		Expect(err).NotTo(HaveOccurred())
 
-		Expect(buffer.String()).To(MatchJSON(fmt.Sprintf(`{
-			"bomFormat": "CycloneDX",
-			"specVersion": "1.3",
-			"version": 1,
-			"serialNumber": "%s",
-			"metadata": {
-				"timestamp": "%s",
-				"tools": [
-					{
-						"vendor": "anchore",
-						"name": "syft",
-						"version": "[not provided]"
-					}
-				],
-				"component": {
-					"type": "file",
-					"name": "testdata/",
-					"version": ""
-				}
-			},
-			"components": [
-				{
-					"type": "library",
-					"name": "collapse-white-space",
-					"version": "2.0.0",
-					"purl": "pkg:npm/collapse-white-space@2.0.0"
-				},
-				{
-					"type": "library",
-					"name": "end-of-stream",
-					"version": "1.4.4",
-					"purl": "pkg:npm/end-of-stream@1.4.4"
-				},
-				{
-					"type": "library",
-					"name": "insert-css",
-					"version": "2.0.0",
-					"purl": "pkg:npm/insert-css@2.0.0"
-				},
-				{
-					"type": "library",
-					"name": "once",
-					"version": "1.4.0",
-					"purl": "pkg:npm/once@1.4.0"
-				},
-				{
-					"type": "library",
-					"name": "pump",
-					"version": "3.0.0",
-					"purl": "pkg:npm/pump@3.0.0"
-				},
-				{
-					"type": "library",
-					"name": "wrappy",
-					"version": "1.0.2",
-					"purl": "pkg:npm/wrappy@1.0.2"
-				}
-			]
-		}`, output.SerialNumber, output.Metadata.Timestamp)))
+		var cdxOutput struct {
+			BOMFormat   string `json:"bomFormat"`
+			SpecVersion string `json:"specVersion"`
+			Metadata    struct {
+				Component struct {
+					Type string `json:"type"`
+					Name string `json:"name"`
+				} `json:"component"`
+			} `json:"metadata"`
+			Components []component `json:"components"`
+		}
+
+		err = json.Unmarshal(buffer.Bytes(), &cdxOutput)
+		Expect(err).NotTo(HaveOccurred(), buffer.String())
+
+		Expect(cdxOutput.BOMFormat).To(Equal("CycloneDX"), buffer.String())
+		Expect(cdxOutput.SpecVersion).To(Equal("1.3"), buffer.String())
+		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
+		Expect(cdxOutput.Metadata.Component.Name).To(Equal("testdata/"), buffer.String())
+		Expect(cdxOutput.Components).To(ContainElements([]component{
+			{Name: "collapse-white-space"},
+			{Name: "end-of-stream"},
+			{Name: "insert-css"},
+			{Name: "once"},
+			{Name: "pump"},
+			{Name: "wrappy"},
+		}), buffer.String())
 	})
 
 	it("writes the SBOM in SPDX format", func() {
@@ -106,337 +68,27 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.SPDXFormat))
 		Expect(err).NotTo(HaveOccurred())
 
-		type packages struct {
-			SPDXID string `json:"SPDXID"`
+		type pkg struct {
+			Name string `json:"name"`
 		}
 
-		var output struct {
-			CreationInfo struct {
-				Created string `json:"created"`
-			} `json:"creationInfo"`
-			DocumentNamespace string     `json:"documentNamespace"`
-			Packages          []packages `json:"packages"`
+		var spdxOutput struct {
+			Packages    []pkg  `json:"packages"`
+			SPDXVersion string `json:"spdxVersion"`
 		}
-		err = json.Unmarshal(buffer.Bytes(), &output)
-		Expect(err).NotTo(HaveOccurred())
 
-		Expect(buffer.String()).To(MatchJSON(fmt.Sprintf(`{
-			"SPDXID": "SPDXRef-DOCUMENT",
-			"name": "testdata",
-			"spdxVersion": "SPDX-2.2",
-			"creationInfo": {
-				"created": "%s",
-				"creators": [
-					"Organization: Anchore, Inc",
-					"Tool: syft-[not provided]"
-				],
-				"licenseListVersion": "3.15"
-			},
-			"dataLicense": "CC0-1.0",
-			"documentNamespace": "%s",
-			"packages": [
-				{
-					"SPDXID": "%s",
-					"name": "collapse-white-space",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse-white-space:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse-white-space:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse_white_space:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse_white_space:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse-white:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse-white:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse_white:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse_white:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:collapse:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/collapse-white-space@2.0.0",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "2.0.0"
-				},
-				{
-					"SPDXID": "%s",
-					"name": "end-of-stream",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end-of-stream:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end-of-stream:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end_of_stream:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end_of_stream:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end-of:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end-of:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end_of:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end_of:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:end:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/end-of-stream@1.4.4",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "1.4.4"
-				},
-				{
-					"SPDXID": "%s",
-					"name": "insert-css",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert-css:insert-css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert-css:insert_css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert_css:insert-css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert_css:insert_css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert:insert-css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:insert:insert_css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:insert-css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:insert_css:2.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/insert-css@2.0.0",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "2.0.0"
-				},
-				{
-					"SPDXID": "%s",
-					"name": "once",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:once:once:1.4.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:once:1.4.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/once@1.4.0",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "1.4.0"
-				},
-				{
-					"SPDXID": "%s",
-					"name": "pump",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:pump:pump:3.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:pump:3.0.0:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/pump@3.0.0",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "3.0.0"
-				},
-				{
-					"SPDXID": "%s",
-					"name": "wrappy",
-					"licenseConcluded": "NONE",
-					"downloadLocation": "NOASSERTION",
-					"externalRefs": [
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:wrappy:wrappy:1.0.2:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "SECURITY",
-							"referenceLocator": "cpe:2.3:a:*:wrappy:1.0.2:*:*:*:*:*:*:*",
-							"referenceType": "cpe23Type"
-						},
-						{
-							"referenceCategory": "PACKAGE_MANAGER",
-							"referenceLocator": "pkg:npm/wrappy@1.0.2",
-							"referenceType": "purl"
-						}
-					],
-					"filesAnalyzed": false,
-					"licenseDeclared": "NONE",
-					"sourceInfo": "acquired package info from installed node module manifest file: package-lock.json",
-					"versionInfo": "1.0.2"
-				}
-			]
-		}`, output.CreationInfo.Created,
-			output.DocumentNamespace,
-			output.Packages[0].SPDXID,
-			output.Packages[1].SPDXID,
-			output.Packages[2].SPDXID,
-			output.Packages[3].SPDXID,
-			output.Packages[4].SPDXID,
-			output.Packages[5].SPDXID,
-		)))
+		err = json.Unmarshal(buffer.Bytes(), &spdxOutput)
+		Expect(err).NotTo(HaveOccurred(), buffer.String())
+
+		Expect(spdxOutput.SPDXVersion).To(Equal("SPDX-2.2"), buffer.String())
+		Expect(spdxOutput.Packages).To(ContainElements([]pkg{
+			{Name: "collapse-white-space"},
+			{Name: "end-of-stream"},
+			{Name: "insert-css"},
+			{Name: "once"},
+			{Name: "pump"},
+			{Name: "wrappy"},
+		}), buffer.String())
 	})
 
 	it("writes the SBOM in Syft format", func() {
@@ -445,196 +97,34 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred())
 
 		type artifact struct {
-			ID string `json:"id"`
+			Name string `json:"name"`
 		}
 
 		var syftOutput struct {
 			Artifacts []artifact `json:"artifacts"`
+			Source    struct {
+				Type   string `json:"type"`
+				Target string `json:"target"`
+			} `json:"source"`
+			Schema struct {
+				Version string `json:"version"`
+			} `json:"schema"`
 		}
 
 		err = json.Unmarshal(buffer.Bytes(), &syftOutput)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred(), buffer.String())
 
-		Expect(buffer.String()).To(MatchJSON(fmt.Sprintf(`{
-			"artifacts": [
-				{
-					"id": "%s",
-					"name": "collapse-white-space",
-					"version": "2.0.0",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:collapse-white-space:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse-white-space:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse_white_space:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse_white_space:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse-white:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse-white:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse_white:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse_white:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:collapse:collapse_white_space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:collapse-white-space:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:collapse_white_space:2.0.0:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/collapse-white-space@2.0.0",
-					"metadataType": "",
-					"metadata": null
-				},
-				{
-					"id": "%s",
-					"name": "end-of-stream",
-					"version": "1.4.4",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:end-of-stream:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end-of-stream:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end_of_stream:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end_of_stream:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end-of:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end-of:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end_of:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end_of:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:end:end_of_stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:end-of-stream:1.4.4:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:end_of_stream:1.4.4:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/end-of-stream@1.4.4",
-					"metadataType": "",
-					"metadata": null
-				},
-				{
-					"id": "%s",
-					"name": "insert-css",
-					"version": "2.0.0",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:insert-css:insert-css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:insert-css:insert_css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:insert_css:insert-css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:insert_css:insert_css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:insert:insert-css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:insert:insert_css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:insert-css:2.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:insert_css:2.0.0:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/insert-css@2.0.0",
-					"metadataType": "",
-					"metadata": null
-				},
-				{
-					"id": "%s",
-					"name": "once",
-					"version": "1.4.0",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:once:once:1.4.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:once:1.4.0:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/once@1.4.0",
-					"metadataType": "",
-					"metadata": null
-				},
-				{
-					"id": "%s",
-					"name": "pump",
-					"version": "3.0.0",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:pump:pump:3.0.0:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:pump:3.0.0:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/pump@3.0.0",
-					"metadataType": "",
-					"metadata": null
-				},
-				{
-					"id": "%s",
-					"name": "wrappy",
-					"version": "1.0.2",
-					"type": "npm",
-					"foundBy": "javascript-lock-cataloger",
-					"locations": [
-						{
-							"path": "package-lock.json"
-						}
-					],
-					"licenses": [],
-					"language": "javascript",
-					"cpes": [
-						"cpe:2.3:a:wrappy:wrappy:1.0.2:*:*:*:*:*:*:*",
-						"cpe:2.3:a:*:wrappy:1.0.2:*:*:*:*:*:*:*"
-					],
-					"purl": "pkg:npm/wrappy@1.0.2",
-					"metadataType": "",
-					"metadata": null
-				}
-			],
-			"artifactRelationships": [],
-			"source": {
-				"type": "directory",
-				"target": "testdata/"
-			},
-			"distro": {
-				"name": "",
-				"version": "",
-				"idLike": ""
-			},
-			"descriptor": {
-				"name": "",
-				"version": ""
-			},
-			"schema": {
-				"version": "2.0.1",
-				"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-2.0.1.json"
-			}
-		}`, syftOutput.Artifacts[0].ID,
-			syftOutput.Artifacts[1].ID,
-			syftOutput.Artifacts[2].ID,
-			syftOutput.Artifacts[3].ID,
-			syftOutput.Artifacts[4].ID,
-			syftOutput.Artifacts[5].ID,
-		)))
+		Expect(syftOutput.Schema.Version).To(MatchRegexp(`2\.0\.\d+`), buffer.String())
+		Expect(syftOutput.Source.Type).To(Equal("directory"), buffer.String())
+		Expect(syftOutput.Source.Target).To(Equal("testdata/"), buffer.String())
+		Expect(syftOutput.Artifacts).To(ContainElements([]artifact{
+			{Name: "collapse-white-space"},
+			{Name: "end-of-stream"},
+			{Name: "insert-css"},
+			{Name: "once"},
+			{Name: "pump"},
+			{Name: "wrappy"},
+		}), buffer.String())
 	})
 
 	context("Read", func() {

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -30,21 +30,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.CycloneDXFormat))
 		Expect(err).NotTo(HaveOccurred())
 
-		type component struct {
-			Name string `json:"name"`
-		}
-
-		var cdxOutput struct {
-			BOMFormat   string `json:"bomFormat"`
-			SpecVersion string `json:"specVersion"`
-			Metadata    struct {
-				Component struct {
-					Type string `json:"type"`
-					Name string `json:"name"`
-				} `json:"component"`
-			} `json:"metadata"`
-			Components []component `json:"components"`
-		}
+		var cdxOutput cdxOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &cdxOutput)
 		Expect(err).NotTo(HaveOccurred(), buffer.String())
@@ -53,14 +39,12 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		Expect(cdxOutput.SpecVersion).To(Equal("1.3"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Name).To(Equal("testdata/"), buffer.String())
-		Expect(cdxOutput.Components).To(ContainElements([]component{
-			{Name: "collapse-white-space"},
-			{Name: "end-of-stream"},
-			{Name: "insert-css"},
-			{Name: "once"},
-			{Name: "pump"},
-			{Name: "wrappy"},
-		}), buffer.String())
+		Expect(cdxOutput.Components[0].Name).To(Equal("collapse-white-space"), buffer.String())
+		Expect(cdxOutput.Components[1].Name).To(Equal("end-of-stream"), buffer.String())
+		Expect(cdxOutput.Components[2].Name).To(Equal("insert-css"), buffer.String())
+		Expect(cdxOutput.Components[3].Name).To(Equal("once"), buffer.String())
+		Expect(cdxOutput.Components[4].Name).To(Equal("pump"), buffer.String())
+		Expect(cdxOutput.Components[5].Name).To(Equal("wrappy"), buffer.String())
 	})
 
 	it("writes the SBOM in SPDX format", func() {
@@ -68,27 +52,18 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.SPDXFormat))
 		Expect(err).NotTo(HaveOccurred())
 
-		type pkg struct {
-			Name string `json:"name"`
-		}
-
-		var spdxOutput struct {
-			Packages    []pkg  `json:"packages"`
-			SPDXVersion string `json:"spdxVersion"`
-		}
+		var spdxOutput spdxOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &spdxOutput)
 		Expect(err).NotTo(HaveOccurred(), buffer.String())
 
 		Expect(spdxOutput.SPDXVersion).To(Equal("SPDX-2.2"), buffer.String())
-		Expect(spdxOutput.Packages).To(ContainElements([]pkg{
-			{Name: "collapse-white-space"},
-			{Name: "end-of-stream"},
-			{Name: "insert-css"},
-			{Name: "once"},
-			{Name: "pump"},
-			{Name: "wrappy"},
-		}), buffer.String())
+		Expect(spdxOutput.Packages[0].Name).To(Equal("collapse-white-space"), buffer.String())
+		Expect(spdxOutput.Packages[1].Name).To(Equal("end-of-stream"), buffer.String())
+		Expect(spdxOutput.Packages[2].Name).To(Equal("insert-css"), buffer.String())
+		Expect(spdxOutput.Packages[3].Name).To(Equal("once"), buffer.String())
+		Expect(spdxOutput.Packages[4].Name).To(Equal("pump"), buffer.String())
+		Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 	})
 
 	it("writes the SBOM in Syft format", func() {
@@ -96,20 +71,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.SyftFormat))
 		Expect(err).NotTo(HaveOccurred())
 
-		type artifact struct {
-			Name string `json:"name"`
-		}
-
-		var syftOutput struct {
-			Artifacts []artifact `json:"artifacts"`
-			Source    struct {
-				Type   string `json:"type"`
-				Target string `json:"target"`
-			} `json:"source"`
-			Schema struct {
-				Version string `json:"version"`
-			} `json:"schema"`
-		}
+		var syftOutput syftOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &syftOutput)
 		Expect(err).NotTo(HaveOccurred(), buffer.String())
@@ -117,14 +79,12 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		Expect(syftOutput.Schema.Version).To(MatchRegexp(`2\.0\.\d+`), buffer.String())
 		Expect(syftOutput.Source.Type).To(Equal("directory"), buffer.String())
 		Expect(syftOutput.Source.Target).To(Equal("testdata/"), buffer.String())
-		Expect(syftOutput.Artifacts).To(ContainElements([]artifact{
-			{Name: "collapse-white-space"},
-			{Name: "end-of-stream"},
-			{Name: "insert-css"},
-			{Name: "once"},
-			{Name: "pump"},
-			{Name: "wrappy"},
-		}), buffer.String())
+		Expect(syftOutput.Artifacts[0].Name).To(Equal("collapse-white-space"), buffer.String())
+		Expect(syftOutput.Artifacts[1].Name).To(Equal("end-of-stream"), buffer.String())
+		Expect(syftOutput.Artifacts[2].Name).To(Equal("insert-css"), buffer.String())
+		Expect(syftOutput.Artifacts[3].Name).To(Equal("once"), buffer.String())
+		Expect(syftOutput.Artifacts[4].Name).To(Equal("pump"), buffer.String())
+		Expect(syftOutput.Artifacts[5].Name).To(Equal("wrappy"), buffer.String())
 	})
 
 	context("Read", func() {

--- a/sbom/sbom_outputs_test.go
+++ b/sbom/sbom_outputs_test.go
@@ -1,0 +1,67 @@
+package sbom_test
+
+/* A set of structs that are used to unmarshal SBOM JSON output in tests */
+
+type license struct {
+	License struct {
+		Name string `json:"name"`
+	} `json:"license"`
+}
+
+type component struct {
+	Type     string    `json:"type"`
+	Name     string    `json:"name"`
+	Version  string    `json:"version"`
+	Licenses []license `json:"licenses"`
+	PURL     string    `json:"purl"`
+}
+
+type cdxOutput struct {
+	BOMFormat   string `json:"bomFormat"`
+	SpecVersion string `json:"specVersion"`
+	Metadata    struct {
+		Component struct {
+			Type string `json:"type"`
+			Name string `json:"name"`
+		} `json:"component"`
+	} `json:"metadata"`
+	Components []component `json:"components"`
+}
+
+type artifact struct {
+	Name     string   `json:"name"`
+	Version  string   `json:"version"`
+	Licenses []string `json:"licenses"`
+	CPEs     []string `json:"cpes"`
+	PURL     string   `json:"purl"`
+}
+
+type syftOutput struct {
+	Artifacts []artifact `json:"artifacts"`
+	Source    struct {
+		Type   string `json:"type"`
+		Target string `json:"target"`
+	} `json:"source"`
+	Schema struct {
+		Version string `json:"version"`
+	} `json:"schema"`
+}
+
+type externalRef struct {
+	Category string `json:"referenceCategory"`
+	Locator  string `json:"referenceLocator"`
+	Type     string `json:"referenceType"`
+}
+
+type pkg struct {
+	ExternalRefs     []externalRef `json:"externalRefs"`
+	LicenseConcluded string        `json:"licenseConcluded"`
+	LicenseDeclared  string        `json:"licenseDeclared"`
+	Name             string        `json:"name"`
+	Version          string        `json:"versionInfo"`
+}
+
+type spdxOutput struct {
+	Packages    []pkg  `json:"packages"`
+	SPDXVersion string `json:"spdxVersion"`
+}

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -46,24 +46,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				}
 			}
 
-			type artifact struct {
-				Name     string   `json:"name"`
-				Version  string   `json:"version"`
-				Licenses []string `json:"licenses"`
-				CPEs     []string `json:"cpes"`
-				PURL     string   `json:"purl"`
-			}
-
-			var syftOutput struct {
-				Artifacts []artifact `json:"artifacts"`
-				Source    struct {
-					Type   string `json:"type"`
-					Target string `json:"target"`
-				} `json:"source"`
-				Schema struct {
-					Version string `json:"version"`
-				} `json:"schema"`
-			}
+			var syftOutput syftOutput
 
 			err = json.Unmarshal(syft.Bytes(), &syftOutput)
 			Expect(err).NotTo(HaveOccurred(), syft.String())
@@ -100,17 +83,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				PURL     string    `json:"purl"`
 			}
 
-			var cdxOutput struct {
-				BOMFormat   string `json:"bomFormat"`
-				SpecVersion string `json:"specVersion"`
-				Metadata    struct {
-					Component struct {
-						Type string `json:"type"`
-						Name string `json:"name"`
-					} `json:"component"`
-				} `json:"metadata"`
-				Components []component `json:"components"`
-			}
+			var cdxOutput cdxOutput
 
 			err = json.Unmarshal(cdx.Bytes(), &cdxOutput)
 			Expect(err).NotTo(HaveOccurred(), cdx.String())
@@ -136,24 +109,8 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				}
 			}
 
-			type externalRef struct {
-				Category string `json:"referenceCategory"`
-				Locator  string `json:"referenceLocator"`
-				Type     string `json:"referenceType"`
-			}
+			var spdxOutput spdxOutput
 
-			type pkg struct {
-				ExternalRefs     []externalRef `json:"externalRefs"`
-				LicenseConcluded string        `json:"licenseConcluded"`
-				LicenseDeclared  string        `json:"licenseDeclared"`
-				Name             string        `json:"name"`
-				Version          string        `json:"versionInfo"`
-			}
-
-			var spdxOutput struct {
-				Packages    []pkg  `json:"packages"`
-				SPDXVersion string `json:"spdxVersion"`
-			}
 			err = json.Unmarshal(spdx.Bytes(), &spdxOutput)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(err).NotTo(HaveOccurred(), spdx.String())

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -69,20 +69,6 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				}
 			}
 
-			type license struct {
-				License struct {
-					Name string `json:"name"`
-				} `json:"license"`
-			}
-
-			type component struct {
-				Type     string    `json:"type"`
-				Name     string    `json:"name"`
-				Version  string    `json:"version"`
-				Licenses []license `json:"licenses"`
-				PURL     string    `json:"purl"`
-			}
-
 			var cdxOutput cdxOutput
 
 			err = json.Unmarshal(cdx.Bytes(), &cdxOutput)

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -3,7 +3,6 @@ package sbom_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"testing"
 
@@ -48,56 +47,36 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			}
 
 			type artifact struct {
-				ID string `json:"id"`
+				Name     string   `json:"name"`
+				Version  string   `json:"version"`
+				Licenses []string `json:"licenses"`
+				CPEs     []string `json:"cpes"`
+				PURL     string   `json:"purl"`
 			}
 
 			var syftOutput struct {
 				Artifacts []artifact `json:"artifacts"`
+				Source    struct {
+					Type   string `json:"type"`
+					Target string `json:"target"`
+				} `json:"source"`
+				Schema struct {
+					Version string `json:"version"`
+				} `json:"schema"`
 			}
 
 			err = json.Unmarshal(syft.Bytes(), &syftOutput)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), syft.String())
 
-			Expect(syft.String()).To(MatchJSON(fmt.Sprintf(`{
-				"artifacts": [
-					{
-						"id": "%s",
-						"name": "Go",
-						"version": "1.16.9",
-						"type": "",
-						"foundBy": "",
-						"locations": [],
-						"licenses": [
-							"BSD-3-Clause"
-						],
-						"language": "",
-						"cpes": [
-							"cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*"
-						],
-						"purl": "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
-						"metadataType": "",
-						"metadata": null
-					}
-				],
-				"artifactRelationships": [],
-				"source": {
-					"type": "directory",
-					"target": "some-path"
-				},
-				"distro": {
-					"name": "",
-					"version": "",
-					"idLike": ""
-				},
-				"descriptor": {
-					"name": "",
-					"version": ""
-				},
-				"schema": {
-					"version": "2.0.1",
-					"url": "https://raw.githubusercontent.com/anchore/syft/main/schema/json/schema-2.0.1.json"
-				}
-			}`, syftOutput.Artifacts[0].ID)))
+			goArtifact := syftOutput.Artifacts[0]
+			Expect(goArtifact.Name).To(Equal("Go"), syft.String())
+			Expect(goArtifact.Version).To(Equal("1.16.9"), syft.String())
+			Expect(goArtifact.Licenses).To(Equal([]string{"BSD-3-Clause"}), syft.String())
+			Expect(goArtifact.CPEs).To(Equal([]string{"cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*"}), syft.String())
+			Expect(goArtifact.PURL).To(Equal("pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz"), syft.String())
+			Expect(syftOutput.Source.Type).To(Equal("directory"), syft.String())
+			Expect(syftOutput.Source.Target).To(Equal("some-path"), syft.String())
+			Expect(syftOutput.Schema.Version).To(MatchRegexp(`2\.0\.\d+`), syft.String())
 
 			cdx := bytes.NewBuffer(nil)
 			for _, format := range formats {
@@ -107,51 +86,47 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				}
 			}
 
-			var cdxOutput struct {
-				SerialNumber string `json:"serialNumber"`
-				Metadata     struct {
-					Timestamp string `json:"timestamp"`
-				} `json:"metadata"`
+			type license struct {
+				License struct {
+					Name string `json:"name"`
+				} `json:"license"`
 			}
-			err = json.Unmarshal(cdx.Bytes(), &cdxOutput)
-			Expect(err).NotTo(HaveOccurred())
 
-			Expect(cdx.String()).To(MatchJSON(fmt.Sprintf(`{
-				"bomFormat": "CycloneDX",
-				"specVersion": "1.3",
-				"version": 1,
-				"serialNumber": "%s",
-				"metadata": {
-					"timestamp": "%s",
-					"tools": [
-						{
-							"vendor": "anchore",
-							"name": "syft",
-							"version": "[not provided]"
-						}
-					],
-					"component": {
-						"type": "file",
-						"name": "some-path",
-						"version": ""
-					}
-				},
-				"components": [
-					{
-						"type": "library",
-						"name": "Go",
-						"version": "1.16.9",
-						"licenses": [
-							{
-								"license": {
-									"name": "BSD-3-Clause"
-								}
-							}
-						],
-						"purl": "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz"
-					}
-				]
-			}`, cdxOutput.SerialNumber, cdxOutput.Metadata.Timestamp)))
+			type component struct {
+				Type     string    `json:"type"`
+				Name     string    `json:"name"`
+				Version  string    `json:"version"`
+				Licenses []license `json:"licenses"`
+				PURL     string    `json:"purl"`
+			}
+
+			var cdxOutput struct {
+				BOMFormat   string `json:"bomFormat"`
+				SpecVersion string `json:"specVersion"`
+				Metadata    struct {
+					Component struct {
+						Type string `json:"type"`
+						Name string `json:"name"`
+					} `json:"component"`
+				} `json:"metadata"`
+				Components []component `json:"components"`
+			}
+
+			err = json.Unmarshal(cdx.Bytes(), &cdxOutput)
+			Expect(err).NotTo(HaveOccurred(), cdx.String())
+
+			Expect(cdxOutput.BOMFormat).To(Equal("CycloneDX"))
+			Expect(cdxOutput.SpecVersion).To(Equal("1.3"))
+
+			goComponent := cdxOutput.Components[0]
+			Expect(goComponent.Name).To(Equal("Go"), cdx.String())
+			Expect(goComponent.Version).To(Equal("1.16.9"), cdx.String())
+			Expect(goComponent.Licenses).To(HaveLen(1), cdx.String())
+			Expect(goComponent.Licenses[0].License.Name).To(Equal("BSD-3-Clause"), cdx.String())
+			Expect(goComponent.PURL).To(Equal("pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz"), cdx.String())
+
+			Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), cdx.String())
+			Expect(cdxOutput.Metadata.Component.Name).To(Equal("some-path"), cdx.String())
 
 			spdx := bytes.NewBuffer(nil)
 			for _, format := range formats {
@@ -161,59 +136,45 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				}
 			}
 
-			type packages struct {
-				SPDXID string `json:"SPDXID"`
+			type externalRef struct {
+				Category string `json:"referenceCategory"`
+				Locator  string `json:"referenceLocator"`
+				Type     string `json:"referenceType"`
+			}
+
+			type pkg struct {
+				ExternalRefs     []externalRef `json:"externalRefs"`
+				LicenseConcluded string        `json:"licenseConcluded"`
+				LicenseDeclared  string        `json:"licenseDeclared"`
+				Name             string        `json:"name"`
+				Version          string        `json:"versionInfo"`
 			}
 
 			var spdxOutput struct {
-				CreationInfo struct {
-					Created string `json:"created"`
-				} `json:"creationInfo"`
-				DocumentNamespace string     `json:"documentNamespace"`
-				Packages          []packages `json:"packages"`
+				Packages    []pkg  `json:"packages"`
+				SPDXVersion string `json:"spdxVersion"`
 			}
 			err = json.Unmarshal(spdx.Bytes(), &spdxOutput)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred(), spdx.String())
 
-			Expect(spdx.String()).To(MatchJSON(fmt.Sprintf(`{
-				"SPDXID": "SPDXRef-DOCUMENT",
-				"name": "some-path",
-				"spdxVersion": "SPDX-2.2",
-				"creationInfo": {
-					"created": "%s",
-					"creators": [
-						"Organization: Anchore, Inc",
-						"Tool: syft-[not provided]"
-					],
-					"licenseListVersion": "3.15"
-				},
-				"dataLicense": "CC0-1.0",
-				"documentNamespace": "%s",
-				"packages": [
-					{
-						"SPDXID": "%s",
-						"name": "Go",
-						"licenseConcluded": "BSD-3-Clause",
-						"downloadLocation": "NOASSERTION",
-						"externalRefs": [
-							{
-								"referenceCategory": "SECURITY",
-								"referenceLocator": "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
-								"referenceType": "cpe23Type"
-							},
-							{
-								"referenceCategory": "PACKAGE_MANAGER",
-								"referenceLocator": "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
-								"referenceType": "purl"
-							}
-						],
-						"filesAnalyzed": false,
-						"licenseDeclared": "BSD-3-Clause",
-						"sourceInfo": "acquired package info from the following paths: ",
-						"versionInfo": "1.16.9"
-					}
-				]
-			}`, spdxOutput.CreationInfo.Created, spdxOutput.DocumentNamespace, spdxOutput.Packages[0].SPDXID)))
+			Expect(spdxOutput.SPDXVersion).To(Equal("SPDX-2.2"), spdx.String())
+
+			goPackage := spdxOutput.Packages[0]
+			Expect(goPackage.Name).To(Equal("Go"), spdx.String())
+			Expect(goPackage.Version).To(Equal("1.16.9"), spdx.String())
+			Expect(goPackage.LicenseConcluded).To(Equal("BSD-3-Clause"), spdx.String())
+			Expect(goPackage.LicenseDeclared).To(Equal("BSD-3-Clause"), spdx.String())
+			Expect(goPackage.ExternalRefs).To(ContainElement(externalRef{
+				Category: "SECURITY",
+				Locator:  "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
+				Type:     "cpe23Type",
+			}), spdx.String())
+			Expect(goPackage.ExternalRefs).To(ContainElement(externalRef{
+				Category: "PACKAGE_MANAGER",
+				Locator:  "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
+				Type:     "purl",
+			}), spdx.String())
 		})
 
 		context("failure cases", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
I have noticed over the past weeks that our SBOM tests were quite brittle – frequently requiring intervention when upgrading syft versions – despite there not being important changes to the outputted JSON. I took a shot at stripping down the assertions to minimize the amount we're just testing syft's functionality.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
