### PR TITLE
Add a WithLevel function to scribe.Emitter

### DIFF
--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -26,6 +26,13 @@ func NewEmitter(output io.Writer) Emitter {
 	}
 }
 
+// WithLevel takes in a log level string and configures the underlying Logger
+// log level. To enable debug logging the log level must be set to "DEBUG".
+func (e Emitter) WithLevel(level string) Emitter {
+	e.Logger = e.Logger.WithLevel(level)
+	return e
+}
+
 // SelectedDependency takes in a buildpack plan entry, a postal dependency, and
 // the current time, and prints out a message giving the name and version of
 // the dependency as well as the source of the request for that given

--- a/scribe/emitter_test.go
+++ b/scribe/emitter_test.go
@@ -149,6 +149,38 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("WithLevel", func() {
+		context("default", func() {
+			it("output includes debug level logs", func() {
+				emitter.Title("non-debug title")
+				emitter.Debug.Title("debug title")
+
+				Expect(buffer.String()).To(ContainLines(
+					"non-debug title",
+				))
+				Expect(buffer.String()).ToNot(ContainLines(
+					"debug title",
+				))
+			})
+		})
+
+		context("DEBUG", func() {
+			it.Before(func() {
+				emitter = emitter.WithLevel("DEBUG")
+			})
+
+			it("output includes debug level logs", func() {
+				emitter.Title("non-debug title")
+				emitter.Debug.Title("debug title")
+
+				Expect(buffer.String()).To(ContainLines(
+					"non-debug title",
+					"debug title",
+				))
+			})
+		})
+	})
+
 	context("Candidates", func() {
 		it("logs the candidate entries", func() {
 			emitter.Candidates([]packit.BuildpackPlanEntry{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #273 by adding a `WithLevel` function to `scribe.Emitter`

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
