### PR TITLE
fix(servicebindings): trim provider/type whitespace

### DIFF
--- a/servicebindings/resolver.go
+++ b/servicebindings/resolver.go
@@ -165,6 +165,7 @@ func loadBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Type = strings.TrimSpace(binding.Type)
 	delete(entries, "type")
 
 	provider, ok := entries["provider"]
@@ -173,6 +174,7 @@ func loadBinding(bindingRoot, name string) (Binding, error) {
 		if err != nil {
 			return Binding{}, err
 		}
+		binding.Provider = strings.TrimSpace(binding.Provider)
 		delete(entries, "provider")
 	}
 
@@ -202,6 +204,7 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Type = strings.TrimSpace(binding.Type)
 	delete(metadata, "kind")
 
 	provider, ok := metadata["provider"]
@@ -212,6 +215,7 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Provider = strings.TrimSpace(binding.Provider)
 	delete(metadata, "provider")
 
 	binding.Entries = metadata

--- a/servicebindings/resolver_test.go
+++ b/servicebindings/resolver_test.go
@@ -205,6 +205,19 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 
 			err = os.WriteFile(filepath.Join(bindingRoot, "binding-2", "password"), nil, os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
+
+			err = os.MkdirAll(filepath.Join(bindingRoot, "binding-3"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "type"), []byte("\n type-3\n"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "provider"), []byte("\tprovider-3\n"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "value"), nil, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		it.After(func() {
@@ -254,6 +267,23 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 						Entries: map[string]*servicebindings.Entry{
 							"username": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-1B", "username")),
 							"password": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-1B", "password")),
+						},
+					},
+				))
+			})
+
+			it("resolves by type/provider files that contains whitespace", func() {
+				bindings, err := resolver.Resolve("type-3", "provider-3", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(ConsistOf(
+					servicebindings.Binding{
+						Name:     "binding-3",
+						Path:     filepath.Join(bindingRoot, "binding-3"),
+						Type:     "type-3",
+						Provider: "provider-3",
+						Entries: map[string]*servicebindings.Entry{
+							"value": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-3", "value")),
 						},
 					},
 				))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Closes #275 

Currently, the `servicebindings.Resolve(...)` function does not trim
whitespace when comparing the requested type/providers with what's on the
filesystem. This change ensures that the type/providers read from disk
are sanitized before they are used.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
