### PR TITLE
Add SBOM logging to scribe.Emitter

### DIFF
--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -196,3 +196,20 @@ func (e Emitter) EnvironmentVariables(layer packit.Layer) {
 		e.Break()
 	}
 }
+
+// GeneratingSBOM takes a path to a directory and logs that an SBOM is
+// being generated for that directory.
+func (e Emitter) GeneratingSBOM(path string) {
+	e.Process("Generating SBOM for directory %s", path)
+}
+
+// FormattingSBOM takes a list of SBOM formats and logs that an SBOM is
+// generated in each format. Note: Only logs when the emitter is in DEBUG
+// mode.
+func (e Emitter) FormattingSBOM(formats ...string) {
+	e.Debug.Process("Writing SBOM in the following format(s):")
+	for _, f := range formats {
+		e.Debug.Subprocess(f)
+	}
+	e.Debug.Break()
+}

--- a/scribe/emitter_test.go
+++ b/scribe/emitter_test.go
@@ -399,4 +399,34 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+	context("GeneratingSBOM", func() {
+		it("prints the correct log line with the inputted path", func() {
+			emitter.GeneratingSBOM("some-directory")
+
+			Expect(buffer.String()).To(ContainSubstring("Generating SBOM for directory some-directory"))
+		})
+	})
+	context("FormattingSBOM", func() {
+		context("when log level is INFO", func() {
+			it("does not print anything", func() {
+				emitter.FormattingSBOM("format1", "format2")
+
+				Expect(buffer.String()).To(BeEmpty())
+			})
+			context("when the log level is DEBUG", func() {
+				it.Before(func() {
+					emitter = scribe.NewEmitter(buffer).WithLevel("DEBUG")
+				})
+				it("lists the inputted SBOM formats", func() {
+					emitter.FormattingSBOM("format1", "format2")
+
+					Expect(buffer.String()).To(ContainLines(
+						"  Writing SBOM in the following format(s):",
+						"    format1",
+						"    format2",
+					))
+				})
+			})
+		})
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Now that Paketo buildpacks are beginning to generating SBOM files, it's useful to have consistent logging. 

Note: Currently, the `FormattingSBOM` function is a debug-only logger. This is the first time a debug-only logging function has been introduced in the `scribe.Emitter`.

Another option could be to create a `LeveledEmitter` struct  in the way that we have a `LeveledLogger` one. With that change, a buildpack author could do something like
```
emitter.Debug.FormattingSBOM(dependency)
```

I've been playing with that implementation – it adds complexity to the emitter, which biases me against the change. I think it's ok for the emitter to be opinionated about whether lines are logged at the INFO or DEBUG level. However, open to others' thoughts on this.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
