### PR TITLE
Fixes error interpolation case where err is nil

### DIFF
--- a/postal/service.go
+++ b/postal/service.go
@@ -1,6 +1,7 @@
 package postal
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -179,7 +180,7 @@ func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath
 	}
 
 	if !ok {
-		return fmt.Errorf("checksum does not match: %s", err)
+		return errors.New("failed to validate dependency: checksum does not match")
 	}
 
 	return nil

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -616,7 +616,7 @@ version = "this is super not semver"
 						"",
 					)
 
-					Expect(err).To(MatchError(ContainSubstring("checksum does not match")))
+					Expect(err).To(MatchError("validation error: checksum does not match"))
 				})
 			})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In cases where the checksums for dependencies don't match, we were outputting an error message that looked broken:

```
[builder]   Executing build process
[builder]     Installing Node Engine 16.13.2
[builder] checksum does not match: %!s(<nil>)
```

This was caused by our attempt to interpolate `nil` as a string in the error message. We don't need this interpolation because we have already checked that the error is `nil` in prior statements.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
