### PR TITLE
Trims whitespace around dependency-mapping values

### DIFF
--- a/postal/internal/dependency_mappings.go
+++ b/postal/internal/dependency_mappings.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/paketo-buildpacks/packit/v2/servicebindings"
 )
@@ -30,7 +31,12 @@ func (d DependencyMappingResolver) FindDependencyMapping(sha256, platformDir str
 
 	for _, binding := range bindings {
 		if uri, ok := binding.Entries[sha256]; ok {
-			return uri.ReadString()
+			content, err := uri.ReadString()
+			if err != nil {
+				return "", err
+			}
+
+			return strings.TrimSpace(content), nil
 		}
 	}
 

--- a/postal/internal/dependency_mappings_test.go
+++ b/postal/internal/dependency_mappings_test.go
@@ -25,7 +25,7 @@ func testDependencyMappings(t *testing.T, context spec.G, it spec.S) {
 	it.Before(func() {
 		tmpDir, err = os.MkdirTemp("", "dependency-mappings")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(os.WriteFile(filepath.Join(tmpDir, "entry-data"), []byte("dependency-mapping-entry.tgz"), os.ModePerm))
+		Expect(os.WriteFile(filepath.Join(tmpDir, "entry-data"), []byte("\n\tdependency-mapping-entry.tgz\n"), os.ModePerm))
 
 		bindingResolver = &fakes.BindingResolver{}
 		resolver = internal.NewDependencyMappingResolver(bindingResolver)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Removes extraneous whitespace from around the dependency mapping value so that it can be used safely as a URI when fetching the dependency.

## Use Cases
<!-- An explanation of the use cases your change enables -->
If you create a dependency mapping file where the contents of the sha-sum mapping file contains extraneous extra whitespace (commonly a trailing newline character often added by IDEs or editors), then the `postal.Service` will break trying to download the mapped file as the URL is malformed. You'll see an  error that looks like the following:

```
failed to fetch dependency: failed to parse request uri: parse "http://dependencies.example.com/my-dep.tgz\n": net/url: invalid control character in the URL
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
