### PR TITLE
Assert that syft SBOM schema major version is fixed

### DIFF
--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -37,6 +37,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(cdxOutput.BOMFormat).To(Equal("CycloneDX"), buffer.String())
 		Expect(cdxOutput.SpecVersion).To(Equal("1.3"), buffer.String())
+
 		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Name).To(Equal("testdata/"), buffer.String())
 		Expect(cdxOutput.Components[0].Name).To(Equal("collapse-white-space"), buffer.String())
@@ -58,6 +59,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		Expect(err).NotTo(HaveOccurred(), buffer.String())
 
 		Expect(spdxOutput.SPDXVersion).To(Equal("SPDX-2.2"), buffer.String())
+
 		Expect(spdxOutput.Packages[0].Name).To(Equal("collapse-white-space"), buffer.String())
 		Expect(spdxOutput.Packages[1].Name).To(Equal("end-of-stream"), buffer.String())
 		Expect(spdxOutput.Packages[2].Name).To(Equal("insert-css"), buffer.String())
@@ -76,7 +78,8 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		err = json.Unmarshal(buffer.Bytes(), &syftOutput)
 		Expect(err).NotTo(HaveOccurred(), buffer.String())
 
-		Expect(syftOutput.Schema.Version).To(MatchRegexp(`\d+\.\d+\.\d+`), buffer.String())
+		Expect(syftOutput.Schema.Version).To(MatchRegexp(`3\.\d+\.\d+`), buffer.String())
+
 		Expect(syftOutput.Source.Type).To(Equal("directory"), buffer.String())
 		Expect(syftOutput.Source.Target).To(Equal("testdata/"), buffer.String())
 		Expect(syftOutput.Artifacts[0].Name).To(Equal("collapse-white-space"), buffer.String())

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -51,6 +51,8 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			err = json.Unmarshal(syft.Bytes(), &syftOutput)
 			Expect(err).NotTo(HaveOccurred(), syft.String())
 
+			Expect(syftOutput.Schema.Version).To(MatchRegexp(`3\.\d+\.\d+`), syft.String())
+
 			goArtifact := syftOutput.Artifacts[0]
 			Expect(goArtifact.Name).To(Equal("Go"), syft.String())
 			Expect(goArtifact.Version).To(Equal("1.16.9"), syft.String())
@@ -59,7 +61,6 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			Expect(goArtifact.PURL).To(Equal("pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz"), syft.String())
 			Expect(syftOutput.Source.Type).To(Equal("directory"), syft.String())
 			Expect(syftOutput.Source.Target).To(Equal("some-path"), syft.String())
-			Expect(syftOutput.Schema.Version).To(MatchRegexp(`\d+\.\d+\.\d+`), syft.String())
 
 			cdx := bytes.NewBuffer(nil)
 			for _, format := range formats {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Since the schema of the SBOMs that buildpacks produce are part of their API, it makes sense to assert that no backward-incompatible changes to the syft schema have been introduced. Checking that the major version of the schema remains the same ensures that breaking schema changes aren't introduced without a test failing in packit.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
