### PR TITLE
Add `Name()` getter for `pexec.Executable`

### DIFF
--- a/pexec/executable.go
+++ b/pexec/executable.go
@@ -22,6 +22,10 @@ func NewExecutable(name string) Executable {
 	}
 }
 
+func (e Executable) Name() string {
+	return e.name
+}
+
 // Execute invokes the executable with a set of Execution arguments.
 func (e Executable) Execute(execution Execution) error {
 	envPath := os.Getenv("PATH")

--- a/pexec/executable_test.go
+++ b/pexec/executable_test.go
@@ -21,7 +21,8 @@ func testPexec(t *testing.T, context spec.G, it spec.S) {
 		tmpDir         string
 		stdout, stderr *bytes.Buffer
 
-		executable pexec.Executable
+		executable     pexec.Executable
+		executableName string
 	)
 
 	it.Before(func() {
@@ -35,7 +36,8 @@ func testPexec(t *testing.T, context spec.G, it spec.S) {
 		stdout = bytes.NewBuffer(nil)
 		stderr = bytes.NewBuffer(nil)
 
-		executable = pexec.NewExecutable(filepath.Base(fakeCLI))
+		executableName = filepath.Base(fakeCLI)
+		executable = pexec.NewExecutable(executableName)
 	})
 
 	it.After(func() {
@@ -151,4 +153,9 @@ func testPexec(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
+	context("Name", func() {
+		it("returns the name", func() {
+			Expect(executable.Name()).To(Equal(executableName))
+		})
+	})
 }


### PR DESCRIPTION
Add `Name()` getter for `pexec.Executable`

So that we can do something like paketo-buildpacks/occam#130