### PR TITLE
Fixes line continuations in indented writer streams

### DIFF
--- a/scribe/writer_test.go
+++ b/scribe/writer_test.go
@@ -16,7 +16,7 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 	context("Writer", func() {
 		var (
 			buffer *bytes.Buffer
-			writer scribe.Writer
+			writer *scribe.Writer
 		)
 
 		it.Before(func() {
@@ -52,6 +52,21 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 					_, err := writer.Write([]byte("some-text\nother-text"))
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buffer.String()).To(Equal("    some-text\n    other-text"))
+				})
+
+				context("when sequential write inputs are not newline terminated", func() {
+					it("handles the indentation correctly", func() {
+						_, err := writer.Write([]byte("some-text"))
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = writer.Write([]byte(" followed by other-text\n"))
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = writer.Write([]byte("followed by\neven-more-text\n"))
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(buffer.String()).To(Equal("    some-text followed by other-text\n    followed by\n    even-more-text\n"))
+					})
 				})
 			})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Now that we are exposing the `scribe.Writer` types in our logging infrastructure and allowing external tools to stream to them, its become clear that we have a minor bug in the `scribe.Writer` that mangles the output. Specifically, if the stream calls `Write` multiple times without including a newline, we insert extra indentation in between each of these calls. For example, assuming a set of calls that look like the following:

```go
writer := scribe.NewWriter(os.Stdout, scribe.WithIndent(1))
_, err := write.Write([]byte("Connecting"))
if err != nil {
  return err
}

for i := 0; i < 3; i++ {
  _, err = write.Write([]byte("."))
  if err != nil {
    return err
  }
}
```

We would expect the output to be `  Connecting...`. Instead, we see indentation between each of the subsequent `Write` calls, resulting in output like `  Connecting  .  .  .`

This PR modifies the `scribe.Writer` to better track when indentation should be applied so that it only appears at the beginning of a new line of text.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
