### PR TITLE
Use a file source for SBOM when applicable

### DIFF
--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -200,7 +200,7 @@ func (e Emitter) EnvironmentVariables(layer packit.Layer) {
 // GeneratingSBOM takes a path to a directory and logs that an SBOM is
 // being generated for that directory.
 func (e Emitter) GeneratingSBOM(path string) {
-	e.Process("Generating SBOM for directory %s", path)
+	e.Process("Generating SBOM for %s", path)
 }
 
 // FormattingSBOM takes a list of SBOM formats and logs that an SBOM is

--- a/scribe/emitter_test.go
+++ b/scribe/emitter_test.go
@@ -399,27 +399,29 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			})
 		})
 	})
+
 	context("GeneratingSBOM", func() {
 		it("prints the correct log line with the inputted path", func() {
-			emitter.GeneratingSBOM("some-directory")
+			emitter.GeneratingSBOM("/some/path")
 
-			Expect(buffer.String()).To(ContainSubstring("Generating SBOM for directory some-directory"))
+			Expect(buffer.String()).To(ContainSubstring("Generating SBOM for /some/path"))
 		})
 	})
+
 	context("FormattingSBOM", func() {
 		context("when log level is INFO", func() {
 			it("does not print anything", func() {
 				emitter.FormattingSBOM("format1", "format2")
-
 				Expect(buffer.String()).To(BeEmpty())
 			})
+
 			context("when the log level is DEBUG", func() {
 				it.Before(func() {
 					emitter = scribe.NewEmitter(buffer).WithLevel("DEBUG")
 				})
+
 				it("lists the inputted SBOM formats", func() {
 					emitter.FormattingSBOM("format1", "format2")
-
 					Expect(buffer.String()).To(ContainLines(
 						"  Writing SBOM in the following format(s):",
 						"    format1",


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

There are cases where we will want to pass a single file into the `sbom.Generate` function. In these cases, we should use the "file resolver" to catalog the SBOM instead of the "directory resolver".

This PR also includes a change to the `scribe.Emitter` to not say "directory".

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
