### PR TITLE
Add "application/octet-stream" as an allowed file type

### DIFF
--- a/vacation/archive.go
+++ b/vacation/archive.go
@@ -30,9 +30,13 @@ func NewArchive(inputReader io.Reader) Archive {
 // Decompress reads from Archive, determines the archive type of the input
 // stream, and writes files into the destination specified.
 //
-// Archive decompression will also handle files that are types "text/plain;
-// charset=utf-8" and write the contents of the input stream to a file name
-// specified by the `Archive.WithName()` option in the destination directory.
+// Archive decompression will also handle files that are types
+// - "application/x-executable"
+// - "text/plain; charset=utf-8"
+// - "application/jar"
+// - "application/octet-stream"
+// and write the contents of the input stream to a file name specified by the
+// `Archive.WithName()` option in the destination directory.
 func (a Archive) Decompress(destination string) error {
 	// Convert reader into a buffered read so that the header can be peeked to
 	// determine the type.
@@ -48,8 +52,7 @@ func (a Archive) Decompress(destination string) error {
 
 	mime := mimetype.Detect(header)
 
-	// This switch case is reponsible for determining what the decompression
-	// strategy should be.
+	// This switch case is responsible for determining the decompression strategy
 	var decompressor Decompressor
 	switch mime.String() {
 	case "application/x-tar":
@@ -62,10 +65,11 @@ func (a Archive) Decompress(destination string) error {
 		decompressor = NewBzip2Archive(bufferedReader).StripComponents(a.components).WithName(a.name)
 	case "application/zip":
 		decompressor = NewZipArchive(bufferedReader).StripComponents(a.components)
-	case "application/x-executable":
+	case "application/x-executable",
+		"text/plain; charset=utf-8",
+		"application/jar",
+		"application/octet-stream":
 		decompressor = NewExecutable(bufferedReader).WithName(a.name)
-	case "text/plain; charset=utf-8", "application/jar":
-		decompressor = NewNopArchive(bufferedReader).WithName(a.name)
 	default:
 		return fmt.Errorf("unsupported archive type: %s", mime.String())
 	}


### PR DESCRIPTION
## Summary
Add "application/octet-stream" as an allowed file type for `postal.NewService(cargo.NewTransport()).Deliver`

## Use Cases
This is required for `composer`, since the filetype is `application/octet-stream`.

Example: https://deps.paketo.io/composer/composer_2.2.8_linux_noarch_any-stack_e1e1c580.phar

From: https://github.com/paketo-buildpacks/php-composer/blob/859520c99fe5b783a3de283227c0c1fef72f4a03/buildpack.toml#L22


## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
