### PR TITLE
Adds biome package

### DIFF
--- a/biome/biome.go
+++ b/biome/biome.go
@@ -1,0 +1,29 @@
+// Package biome provide useful enivonment variable parsing functionality
+package biome
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+// GetBool takes the name of an environment variable as an argument and returns
+// its boolean value if available or an error if it is unable to parse the
+// value from the environment variable into a bool.
+//
+// If the given environment variable is unset then the function will return
+// false.
+func GetBool(environmentVariable string) (bool, error) {
+	if val, ok := os.LookupEnv(environmentVariable); ok {
+		boolVal, err := strconv.ParseBool(val)
+		if err != nil {
+			return false, fmt.Errorf(
+				"invalid value '%s' for key '%s': expected one of [1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False]",
+				val,
+				environmentVariable,
+			)
+		}
+		return boolVal, nil
+	}
+	return false, nil
+}

--- a/biome/biome_test.go
+++ b/biome/biome_test.go
@@ -1,0 +1,75 @@
+package biome_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2/biome"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBiome(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("GetBool", func() {
+		it("returns false when the environemnt variable isn't set", func() {
+			ok, err := biome.GetBool("BOOL_VAR")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ok).To(BeFalse())
+		})
+
+		context("when the environment variable is set to something truthy", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BOOL_VAR", "TRUE")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BOOL_VAR")).To(Succeed())
+			})
+
+			it("returns true", func() {
+				ok, err := biome.GetBool("BOOL_VAR")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		context("when the environment variable is set to something falsey", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BOOL_VAR", "FALSE")).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BOOL_VAR")).To(Succeed())
+			})
+
+			it("returns false", func() {
+				ok, err := biome.GetBool("BOOL_VAR")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(ok).To(BeFalse())
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the environment variable is set to something invalid", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BOOL_VAR", "not-bool")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BOOL_VAR")).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := biome.GetBool("BOOL_VAR")
+					Expect(err).To(MatchError("invalid value 'not-bool' for key 'BOOL_VAR': expected one of [1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False]"))
+				})
+			})
+		})
+	})
+}

--- a/biome/init_test.go
+++ b/biome/init_test.go
@@ -1,0 +1,14 @@
+package biome_test
+
+import (
+	"testing"
+
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestUnitBiome(t *testing.T) {
+	suite := spec.New("packit/biome", spec.Report(report.Terminal{}))
+	suite("Biome", testBiome)
+	suite.Run(t)
+}


### PR DESCRIPTION
The initial implementation of this package includes functionality to dry
up a common pattern that I see in all buildpacks in Paketo that are
compatible with `watchexe`. The same function has propagated it's way
into almost every buildpack using `packit`. An example can be seen here
https://github.com/paketo-buildpacks/go-build/blob/e210480ead2699ea64b273578100b667f094e50c/detect.go#L57-L66

Given the switch to using environment variables as configuration is
almost complete across all buildpacks inside of the Paketo project it
seems like having a shared library for the parsing of environment
variable may come in handy.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
