### PR TITLE
Adds sbom.NewSBOM

### DIFF
--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -21,6 +21,10 @@ type SBOM struct {
 	syft sbom.SBOM
 }
 
+func NewSBOM(syft sbom.SBOM) SBOM {
+	return SBOM{syft: syft}
+}
+
 // Generate returns a populated SBOM given a path to a directory to scan.
 func Generate(path string) (SBOM, error) {
 	info, err := os.Stat(path)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Allows users to construct an `sbom.SBOM` given that they already have a `syft.SBOM`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

There are cases where users might already have a `syft.SBOM` for whatever reason and they still want to take advantage of the formatting code that is provided in the `sbom` package. We should allow them to convert their `syft.SBOM` into an `sbom.SBOM` so that they can call into the formatting code paths.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
