### PR TITLE
Fallback to id if idLike doesn't exist

### DIFF
--- a/sbom/internal/formats/syft2/to_format_model.go
+++ b/sbom/internal/formats/syft2/to_format_model.go
@@ -225,10 +225,15 @@ func toDistroModel(d *linux.Release) model.Distro {
 		return model.Distro{}
 	}
 
+	idLike := d.ID
+	if len(d.IDLike) > 0 {
+		// TODO: (packit) Is picking the 1st from this list the right thing to do?
+		idLike = d.IDLike[0]
+	}
+
 	return model.Distro{
 		Name:    d.ID,
 		Version: d.Version,
-		// TODO: (packit) Is picking the 1st from this list the right thing to do?
-		IDLike: d.IDLike[0],
+		IDLike:  idLike,
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In some distros (alpine at least), the `idLike` array is empty and indexing into it crashes the program. We can fallback to using the ID in the case that the array is empty.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
