### PR TITLE
Add sbom.Autobom func to magic away some SBOM boilerplate

### DIFF
--- a/sbom/autobom.go
+++ b/sbom/autobom.go
@@ -1,0 +1,36 @@
+package sbom
+
+import (
+	"time"
+
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/chronos"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+)
+
+// Autobom will return a packit.SBOMFormatter containing the SBOM for the given path.
+// It will also log information about the SBOM generation, including how long it took.
+func Autobom(
+	path string,
+	SBOMFormats []string,
+	clock chronos.Clock,
+	logger scribe.Emitter) (packit.SBOMFormatter, error) {
+
+	logger.GeneratingSBOM(path)
+	var err error
+
+	var sbomContent SBOM
+	duration, err := clock.Measure(func() error {
+		sbomContent, err = Generate(path)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	logger.Action("Completed in %s", duration.Round(time.Millisecond))
+	logger.Break()
+
+	logger.FormattingSBOM(SBOMFormats...)
+
+	return sbomContent.InFormats(SBOMFormats...)
+}

--- a/sbom/autobom_test.go
+++ b/sbom/autobom_test.go
@@ -1,0 +1,100 @@
+package sbom_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/paketo-buildpacks/packit/v2/chronos"
+	"github.com/paketo-buildpacks/packit/v2/fs"
+	"github.com/paketo-buildpacks/packit/v2/sbom"
+	"github.com/paketo-buildpacks/packit/v2/scribe"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testAutobom(t *testing.T, context spec.G, it spec.S) {
+
+	var (
+		Expect = NewWithT(t).Expect
+
+		path        string
+		buffer      *bytes.Buffer
+		clock       chronos.Clock
+		logger      scribe.Emitter
+		sbomFormats []string
+	)
+
+	it.Before(func() {
+		var err error
+		path, err = os.MkdirTemp("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = fs.Copy(filepath.Join("testdata", "package-lock.json"), filepath.Join(path, "package-lock.json"))
+		Expect(err).NotTo(HaveOccurred())
+
+		buffer = bytes.NewBuffer(nil)
+		logger = scribe.NewEmitter(buffer)
+
+		clock = chronos.NewClock(func() time.Time {
+			return time.UnixMicro(998877)
+		})
+
+		sbomFormats = []string{"application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"}
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(path)).To(Succeed())
+	})
+
+	it("returns the SBOM for the path", func() {
+		sbomFormatter, err := sbom.Autobom(path, sbomFormats, clock, logger)
+		Expect(err).ToNot(HaveOccurred())
+
+		// NOTE sbom generation is NOT REPRODUCIBLE
+		// Use some checks here to gain confidence that the Autobom func did what it was supposed to do
+		Expect(len(sbomFormatter.Formats())).To(Equal(len(sbomFormats)))
+
+		var extensions []string
+		for _, item := range sbomFormatter.Formats() {
+			extensions = append(extensions, item.Extension)
+		}
+
+		Expect(extensions).To(Equal([]string{"cdx.json", "spdx.json", "syft.json"}))
+	})
+
+	it("logs information about the formats", func() {
+		_, err := sbom.Autobom(path, sbomFormats, clock, logger)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(buffer.String()).To(Equal(fmt.Sprintf(`  Generating SBOM for %s
+      Completed in 0s
+
+`, path)))
+	})
+
+	context("with debug logging", func() {
+		it.Before(func() {
+			logger = scribe.NewEmitter(buffer).WithLevel("DEBUG")
+		})
+
+		it("logs information about the formats", func() {
+			_, err := sbom.Autobom(path, sbomFormats, clock, logger)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(buffer.String()).To(Equal(fmt.Sprintf(`  Generating SBOM for %s
+      Completed in 0s
+
+  Writing SBOM in the following format(s):
+    application/vnd.cyclonedx+json
+    application/spdx+json
+    application/vnd.syft+json
+
+`, path)))
+		})
+	})
+}

--- a/sbom/init_test.go
+++ b/sbom/init_test.go
@@ -15,5 +15,6 @@ func TestSBOM(t *testing.T) {
 	suite("Formatter", testFormatter)
 	suite("FormattedReader", testFormattedReader)
 	suite("SBOM", testSBOM)
+	suite("Autobom", testAutobom)
 	suite.Run(t)
 }


### PR DESCRIPTION
Add `sbom.Autobom` func to magic away some boilerplate around SBOM generation

⚠️ This is mostly here to prompt some discussion. 
- Do we need this magic?
- Should we put this magic into the existing `sbom.Generate` func?
- Should we do something different with this magic? Perhaps we just tell the `Build` func that we want an SBOM and it does the magic.

See paketo-buildpacks/poetry-install#37 for an example of how this might simplify buildpack code.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
