### PR TITLE
Reduce Watchexec boilerplate and standardize watchexec processes

### DIFF
--- a/reload/init_test.go
+++ b/reload/init_test.go
@@ -1,0 +1,17 @@
+package reload_test
+
+import (
+	"testing"
+
+	"github.com/onsi/gomega/format"
+	"github.com/sclevine/spec"
+	"github.com/sclevine/spec/report"
+)
+
+func TestReload(t *testing.T) {
+	format.MaxLength = 0
+
+	suite := spec.New("reload", spec.Report(report.Terminal{}))
+	suite("Reload", testReload)
+	suite.Run(t)
+}

--- a/reload/reload.go
+++ b/reload/reload.go
@@ -1,0 +1,92 @@
+package reload
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit/v2"
+)
+
+var LiveReloadEnabledEnvVar = "BP_LIVE_RELOAD_ENABLED"
+var WatchExecRequirement = packit.BuildPlanRequirement{
+	Name: "watchexec",
+	Metadata: map[string]interface{}{
+		"launch": true,
+	}}
+
+func ShouldEnableLiveReload() (bool, error) {
+	if reload, ok := os.LookupEnv(LiveReloadEnabledEnvVar); ok {
+		if shouldEnableReload, err := strconv.ParseBool(reload); err != nil {
+			return false, fmt.Errorf("failed to parse %s value %s: %w", LiveReloadEnabledEnvVar, reload, err)
+		} else if shouldEnableReload {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// ReloadableProcessSpec contains information to be translated directly into watchexec arguments
+type ReloadableProcessSpec struct {
+	// WatchPaths will translate into --watch args
+	// Optional. If len == 0, then no --watch args will be provided
+	WatchPaths []string
+
+	// IgnorePaths will translate into --ignore args
+	// Optional. If len == 0, then no --ignore args will be provided
+	IgnorePaths []string
+
+	// Shell will translate into --shell
+	// Optional. If not provided, will use "none"
+	Shell string
+
+	// VerbosityLevel will translate into -v
+	// If VerbosityLevel is 0, no -v arg will be provided.
+	// If VerbosityLevel is greater than 0, the appropriate number of v's will be added
+	// E.g. VerbosityLevel = 2 => -vv
+	// E.g. VerbosityLevel = 4 => -vvvv
+	VerbosityLevel int
+}
+
+func TransformReloadableProcesses(originalProcess packit.Process, spec ReloadableProcessSpec) (nonReloadable packit.Process, reloadable packit.Process) {
+	nonReloadable = originalProcess
+	nonReloadable.Default = false
+
+	reloadable = originalProcess
+	reloadable.Type = fmt.Sprintf("reload-%s", originalProcess.Type)
+	reloadable.Command = "watchexec"
+	reloadable.Args = buildArgs(originalProcess, spec)
+
+	return nonReloadable, reloadable
+}
+
+func buildArgs(originalProcess packit.Process, spec ReloadableProcessSpec) []string {
+	args := []string{
+		"--restart",
+	}
+
+	for _, watchPath := range spec.WatchPaths {
+		args = append(args, "--watch", watchPath)
+	}
+
+	for _, ignorePath := range spec.IgnorePaths {
+		args = append(args, "--ignore", ignorePath)
+	}
+
+	shell := "none"
+	if spec.Shell != "" {
+		shell = spec.Shell
+	}
+	args = append(args, "--shell", shell)
+
+	if spec.VerbosityLevel > 0 {
+		args = append(args, "-"+strings.Repeat("v", spec.VerbosityLevel))
+	}
+
+	args = append(args,
+		"--",
+		originalProcess.Command)
+	args = append(args, originalProcess.Args...)
+	return args
+}

--- a/reload/reload_test.go
+++ b/reload/reload_test.go
@@ -1,0 +1,393 @@
+package reload_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/reload"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testReload(t *testing.T, context spec.G, it spec.S) {
+	var Expect = NewWithT(t).Expect
+
+	context("ShouldEnableLiveReload", func() {
+		context("When it should enable live reload", func() {
+			context("when BP_LIVE_RELOAD_ENABLED is 'true'", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "true")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("should require watchexec at launch", func() {
+					require, err := reload.ShouldEnableLiveReload()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(require).To(Equal(true))
+				})
+			})
+
+			context("when BP_LIVE_RELOAD_ENABLED is '1'", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "1")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("should require watchexec at launch", func() {
+					require, err := reload.ShouldEnableLiveReload()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(require).To(Equal(true))
+				})
+			})
+
+			context("when BP_LIVE_RELOAD_ENABLED is 'T'", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "T")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("should require watchexec at launch", func() {
+					require, err := reload.ShouldEnableLiveReload()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(require).To(Equal(true))
+				})
+			})
+		})
+
+		context("when it should not enable live reload", func() {
+			context("when BP_LIVE_RELOAD_ENABLED is not set", func() {
+				it("should not require anything at launch", func() {
+					require, err := reload.ShouldEnableLiveReload()
+					Expect(require).To(Equal(false))
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
+			context("when BP_LIVE_RELOAD_ENABLED is 'F'", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "F")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("should not require anything at launch", func() {
+					require, err := reload.ShouldEnableLiveReload()
+					Expect(require).To(Equal(false))
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+		})
+
+		context("failure cases", func() {
+			context("when BP_LIVE_RELOAD_ENABLED is not a valid boolean value", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_LIVE_RELOAD_ENABLED", "hi")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_LIVE_RELOAD_ENABLED")).To(Succeed())
+				})
+
+				it("should return an error", func() {
+					_, err := reload.ShouldEnableLiveReload()
+					Expect(err.Error()).To(Equal(`failed to parse BP_LIVE_RELOAD_ENABLED value hi: strconv.ParseBool: parsing "hi": invalid syntax`))
+				})
+			})
+		})
+	})
+
+	context("TransformReloadableProcesses", func() {
+		var (
+			originalProcess       packit.Process
+			reloadableProcessSpec reload.ReloadableProcessSpec
+
+			expectecdNonReloadableProcess packit.Process
+			expectedReloadableProcess     packit.Process
+		)
+
+		it.Before(func() {
+			reloadableProcessSpec = reload.ReloadableProcessSpec{
+				WatchPaths: []string{
+					"watch-path0",
+					"watch-path1",
+				},
+				IgnorePaths: []string{
+					"ignore-path0",
+					"ignore-path1",
+				},
+				Shell:          "my-shell",
+				VerbosityLevel: 0,
+			}
+
+			originalProcess = packit.Process{
+				Type:    "my-type",
+				Command: "my-command",
+				Args: []string{
+					"original-arg0",
+					"original-arg1",
+				},
+				Direct:           false,
+				Default:          false,
+				WorkingDirectory: "my-working-directory",
+			}
+
+			expectecdNonReloadableProcess = packit.Process{
+				Type:    "my-type",
+				Command: "my-command",
+				Args: []string{
+					"original-arg0",
+					"original-arg1",
+				},
+				Direct:           false,
+				Default:          false,
+				WorkingDirectory: "my-working-directory",
+			}
+
+			expectedReloadableProcess = packit.Process{
+				Type:    "reload-my-type",
+				Command: "watchexec",
+				Args: []string{
+					"--restart",
+					"--watch", "watch-path0",
+					"--watch", "watch-path1",
+					"--ignore", "ignore-path0",
+					"--ignore", "ignore-path1",
+					"--shell", "my-shell",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				},
+				Direct:           false,
+				Default:          false,
+				WorkingDirectory: "my-working-directory",
+			}
+		})
+
+		it("should transform the original process into non-reloadable and reloadable processes", func() {
+			nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+			Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+			Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+		})
+
+		context("when WatchPaths is empty", func() {
+			it.Before(func() {
+				reloadableProcessSpec.WatchPaths = []string{}
+			})
+
+			it("should not contain --watch args", func() {
+				expectedReloadableProcess.Args = []string{
+					"--restart",
+					"--ignore", "ignore-path0",
+					"--ignore", "ignore-path1",
+					"--shell", "my-shell",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				}
+
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+				Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+			})
+		})
+
+		context("when IgnorePaths is empty", func() {
+			it.Before(func() {
+				reloadableProcessSpec.IgnorePaths = []string{}
+			})
+
+			it("should not contain --ignore args", func() {
+				expectedReloadableProcess.Args = []string{
+					"--restart",
+					"--watch", "watch-path0",
+					"--watch", "watch-path1",
+					"--shell", "my-shell",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				}
+
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+				Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+			})
+		})
+
+		context("when direct and default are false", func() {
+			it.Before(func() {
+				originalProcess.Direct = false
+				originalProcess.Default = false
+			})
+
+			it("should return indirect and non-default processes", func() {
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess.Direct).To(Equal(false))
+				Expect(nonReloadableProcess.Default).To(Equal(false))
+
+				Expect(reloadableProcess.Direct).To(Equal(false))
+				Expect(reloadableProcess.Default).To(Equal(false))
+			})
+		})
+
+		context("when default is true", func() {
+			it.Before(func() {
+				originalProcess.Direct = false
+				originalProcess.Default = true
+			})
+
+			it("should return a default reloadable process", func() {
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess.Direct).To(Equal(false))
+				Expect(nonReloadableProcess.Default).To(Equal(false))
+
+				Expect(reloadableProcess.Direct).To(Equal(false))
+				Expect(reloadableProcess.Default).To(Equal(true))
+			})
+		})
+
+		context("when direct is true", func() {
+			it.Before(func() {
+				originalProcess.Direct = true
+				originalProcess.Default = false
+			})
+
+			it("should return direct processes", func() {
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess.Direct).To(Equal(true))
+				Expect(nonReloadableProcess.Default).To(Equal(false))
+
+				Expect(reloadableProcess.Direct).To(Equal(true))
+				Expect(reloadableProcess.Default).To(Equal(false))
+			})
+		})
+
+		context("when direct and default are true", func() {
+			it.Before(func() {
+				originalProcess.Direct = true
+				originalProcess.Default = true
+			})
+
+			it("should return direct processes, with a default reloadable process", func() {
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess.Direct).To(Equal(true))
+				Expect(nonReloadableProcess.Default).To(Equal(false))
+
+				Expect(reloadableProcess.Direct).To(Equal(true))
+				Expect(reloadableProcess.Default).To(Equal(true))
+			})
+		})
+
+		context("when spec.VerbosityLevel is 1", func() {
+			it.Before(func() {
+				reloadableProcessSpec.VerbosityLevel = 1
+			})
+
+			it("should return args with 1 verbose flag", func() {
+				expectedReloadableProcess.Args = []string{
+					"--restart",
+					"--watch", "watch-path0",
+					"--watch", "watch-path1",
+					"--ignore", "ignore-path0",
+					"--ignore", "ignore-path1",
+					"--shell", "my-shell",
+					"-v",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				}
+
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+				Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+			})
+		})
+
+		context("when spec.VerbosityLevel is 4", func() {
+			it.Before(func() {
+				reloadableProcessSpec.VerbosityLevel = 4
+			})
+
+			it("should return args with 4 verbose flag", func() {
+				expectedReloadableProcess.Args = []string{
+					"--restart",
+					"--watch", "watch-path0",
+					"--watch", "watch-path1",
+					"--ignore", "ignore-path0",
+					"--ignore", "ignore-path1",
+					"--shell", "my-shell",
+					"-vvvv",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				}
+
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+				Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+			})
+		})
+
+		context("when spec.Shell is empty", func() {
+			it.Before(func() {
+				reloadableProcessSpec.Shell = ""
+			})
+
+			it("will default to --shell=none", func() {
+				expectedReloadableProcess.Args = []string{
+					"--restart",
+					"--watch", "watch-path0",
+					"--watch", "watch-path1",
+					"--ignore", "ignore-path0",
+					"--ignore", "ignore-path1",
+					"--shell", "none",
+					"--",
+					"my-command",
+					"original-arg0",
+					"original-arg1",
+				}
+
+				nonReloadableProcess, reloadableProcess := reload.TransformReloadableProcesses(originalProcess, reloadableProcessSpec)
+
+				Expect(nonReloadableProcess).To(Equal(expectecdNonReloadableProcess))
+				Expect(reloadableProcess).To(Equal(expectedReloadableProcess))
+			})
+		})
+	})
+
+	context("WatchExecRequirement", func() {
+		it("should require watchexec at launch", func() {
+			Expect(reload.WatchExecRequirement).To(Equal(packit.BuildPlanRequirement{
+				Name: "watchexec",
+				Metadata: map[string]interface{}{
+					"launch": true,
+				}}))
+		})
+	})
+}


### PR DESCRIPTION
This PR is meant to reduce boilerplate and standardize how to invoke a `watchexec`-flavored process.

There are a handful of buildpacks that all have the same logic to pull in `watchexec`. This means in order for a buildpack to `require watchexec`, there are often multiple snippets of code that have to be used in the right way.

See paketo-buildpacks/go-build#310 for how this could be used.

Questions:
- Is it worth hiding the implementation to reduce boilerplate?
- Should we use a fakeable func instead of a global func? This could help reduce testing boilerplate in consuming buildpacks.
- Should this logic really exist in the `watchexec` buidpack? Could make some sense for that buildpack to expose some sort of SDK so that other buildpacks could know how to consume it.