### PR TITLE
Adds scribe.WithPrefix option for scribe.Writer

### DIFF
--- a/scribe/writer.go
+++ b/scribe/writer.go
@@ -27,12 +27,23 @@ func WithIndent(indent int) Option {
 	}
 }
 
+// WithPrefix takes a prefix string and returns an Option which can be passed
+// in while creating a new Writer to configure a prefix to be prepended to the
+// output of the Writer.
+func WithPrefix(prefix string) Option {
+	return func(l Writer) Writer {
+		l.prefix = prefix
+		return l
+	}
+}
+
 // A Writer conforms to the io.Writer interface and allows for configuration of
 // output from the writter such as the color or indentation through Options.
 type Writer struct {
 	writer    io.Writer
 	color     Color
 	indent    int
+	prefix    string
 	linestart bool
 }
 
@@ -72,6 +83,8 @@ func (w *Writer) Write(b []byte) (int, error) {
 	var indentedLines [][]byte
 	for index, line := range lines {
 		if !(index == 0 && !w.linestart) {
+			line = append([]byte(w.prefix), line...)
+
 			for i := 0; i < w.indent; i++ {
 				line = append([]byte("  "), line...)
 			}

--- a/scribe/writer_test.go
+++ b/scribe/writer_test.go
@@ -70,27 +70,54 @@ func testWriter(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 
+			context("when the writer has a prefix", func() {
+				it.Before(func() {
+					writer = scribe.NewWriter(buffer, scribe.WithPrefix("[some-prefix] "))
+				})
+
+				it("prints to the writer with the given prefix", func() {
+					_, err := writer.Write([]byte("some-text\nother-text"))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(buffer.String()).To(Equal("[some-prefix] some-text\n[some-prefix] other-text"))
+				})
+
+				context("when sequential write inputs are not newline terminated", func() {
+					it("handles the indentation correctly", func() {
+						_, err := writer.Write([]byte("some-text"))
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = writer.Write([]byte(" followed by other-text\n"))
+						Expect(err).NotTo(HaveOccurred())
+
+						_, err = writer.Write([]byte("followed by\neven-more-text\n"))
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(buffer.String()).To(Equal("[some-prefix] some-text followed by other-text\n[some-prefix] followed by\n[some-prefix] even-more-text\n"))
+					})
+				})
+			})
+
 			context("when the writer has a return prefix", func() {
 				it.Before(func() {
-					writer = scribe.NewWriter(buffer, scribe.WithColor(scribe.RedColor), scribe.WithIndent(2))
+					writer = scribe.NewWriter(buffer, scribe.WithColor(scribe.RedColor), scribe.WithIndent(2), scribe.WithPrefix("[some-prefix] "))
 				})
 
 				it("prints to the writer with the correct indentation", func() {
 					_, err := writer.Write([]byte("\rsome-text"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(buffer.String()).To(Equal("\r\x1b[0;38;5;1m    some-text\x1b[0m"))
+					Expect(buffer.String()).To(Equal("\r\x1b[0;38;5;1m    [some-prefix] some-text\x1b[0m"))
 				})
 			})
 
 			context("when the writer has a newline suffix", func() {
 				it.Before(func() {
-					writer = scribe.NewWriter(buffer, scribe.WithColor(scribe.RedColor), scribe.WithIndent(2))
+					writer = scribe.NewWriter(buffer, scribe.WithColor(scribe.RedColor), scribe.WithIndent(2), scribe.WithPrefix("[some-prefix] "))
 				})
 
 				it("prints to the writer with the correct indentation", func() {
 					_, err := writer.Write([]byte("some-text\n"))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(buffer.String()).To(Equal("\x1b[0;38;5;1m    some-text\x1b[0m\n"))
+					Expect(buffer.String()).To(Equal("\x1b[0;38;5;1m    [some-prefix] some-text\x1b[0m\n"))
 				})
 			})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Allows users to configure a `scribe.Writer` with a prefix.

## Use Cases
<!-- An explanation of the use cases your change enables -->
This will be useful in implementing https://github.com/paketo-buildpacks/jam/issues/83. We can use it to display interleaved log output from different `docker build` streams.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
