### PR TITLE
Add debug logging for layer flags, build configuration

### DIFF
--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -231,4 +231,5 @@ func (e Emitter) BuildConfiguration(envVars map[string]string) {
 	formatted := NewFormattedMapFromEnvironment(envVars)
 	e.Debug.Process("Build configuration:")
 	e.Debug.Subprocess(formatted.String())
+	e.Debug.Break()
 }

--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -162,7 +162,7 @@ func (e Emitter) LaunchProcesses(processes []packit.Process, processEnvs ...map[
 	e.Break()
 }
 
-// EnvironmentVariables take a layer and prints out a formatted table of the
+// EnvironmentVariables takes a layer and prints out a formatted table of the
 // build and launch time environment variables set in the layer.
 func (e Emitter) EnvironmentVariables(layer packit.Layer) {
 	buildEnv := packit.Environment{}
@@ -197,6 +197,16 @@ func (e Emitter) EnvironmentVariables(layer packit.Layer) {
 	}
 }
 
+// LayerFlags takes a layer and prints out the state of the build, launch,
+// and cache layer flags in human-readable language.
+func (e Emitter) LayerFlags(layer packit.Layer) {
+	e.Debug.Process("Setting up layer '%s'", layer.Name)
+	e.Debug.Subprocess("Available at app launch: %t", layer.Launch)
+	e.Debug.Subprocess("Available to other buildpacks: %t", layer.Build)
+	e.Debug.Subprocess("Cached for rebuilds: %t", layer.Cache)
+	e.Debug.Break()
+}
+
 // GeneratingSBOM takes a path to a directory and logs that an SBOM is
 // being generated for that directory.
 func (e Emitter) GeneratingSBOM(path string) {
@@ -212,4 +222,13 @@ func (e Emitter) FormattingSBOM(formats ...string) {
 		e.Debug.Subprocess(f)
 	}
 	e.Debug.Break()
+}
+
+// BuildConfiguration takes a map representing environment variables
+// that will configure a buildpack build and prints them in a formatted
+// table.
+func (e Emitter) BuildConfiguration(envVars map[string]string) {
+	formatted := NewFormattedMapFromEnvironment(envVars)
+	e.Debug.Process("Build configuration:")
+	e.Debug.Subprocess(formatted.String())
 }

--- a/scribe/formatted_map.go
+++ b/scribe/formatted_map.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/paketo-buildpacks/packit/v2"
 )
 
 // A FormattedMap is a wrapper for map[string]interface{} to extend functionality.
@@ -46,10 +44,15 @@ func (m FormattedMap) String() string {
 
 // NewFormattedMapFromEnvironment take an environment and returns a
 // FormattedMap with the appropriate environment variable information added.
-func NewFormattedMapFromEnvironment(environment packit.Environment) FormattedMap {
+func NewFormattedMapFromEnvironment(environment map[string]string) FormattedMap {
 	envMap := FormattedMap{}
 	for key, value := range environment {
 		parts := strings.SplitN(key, ".", 2)
+
+		if len(parts) < 2 {
+			envMap[key] = value
+			continue
+		}
 
 		switch {
 		case parts[1] == "override" || parts[1] == "default":

--- a/scribe/formatted_map_test.go
+++ b/scribe/formatted_map_test.go
@@ -24,7 +24,7 @@ func testFormattedMap(t *testing.T, context spec.G, it spec.S) {
 	})
 
 	context("NewFormattedMapFromEnvironment", func() {
-		context("when the operation is override", func() {
+		context("for all packit env var operations", func() {
 			it("prints the env in a well formatted map", func() {
 				Expect(scribe.NewFormattedMapFromEnvironment(packit.Environment{
 					"OVERRIDE.override": "some-value",
@@ -38,6 +38,17 @@ func testFormattedMap(t *testing.T, context spec.G, it spec.S) {
 					"DEFAULT":  "some-value",
 					"PREPEND":  "some-value:$PREPEND",
 					"APPEND":   "$APPEND:some-value",
+				}))
+			})
+		})
+		context("for a standard string map", func() {
+			it("prints the env in a well formatted map", func() {
+				Expect(scribe.NewFormattedMapFromEnvironment(map[string]string{
+					"SOME_ENV_VAR":       "some-value",
+					"SOME_OTHER_ENV_VAR": "some-other-value",
+				})).To(Equal(scribe.FormattedMap{
+					"SOME_ENV_VAR":       "some-value",
+					"SOME_OTHER_ENV_VAR": "some-other-value",
 				}))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds two new methods to the `scribe.Emitter`: `LayerFlags()` and `BuildConfiguration()`.

### LayerFlags
It'd be helpful for buildpack authors to log whether a layer is marked for build, cache, or launch in the debug output. With this PR, authors can add
```go
layer.Get("layer-name")
layer.Launch = true
layer.Cache = false
layer.Build = true

logger.LayerFlags(layer)
```
and when debug logging is enabled, the buildpack will log:
```
  Setting up layer 'layer-name'
    Available at app launch: true
    Available to other buildpacks:true
    Cached for rebuilds: false
```
This will allow buildpack users to understand more clearly why layer contents is/isn't available at a given stage.

❓  **I'm looking for feedback on the wording of these logs. Does this language accurately capture the behaviour of the flags without being too technical?**

### BuildConfiguration
I've also added a function that will enumerate the build configuration for a given buildpack. This is helpful for users trying to establish whether a desired configuration reached the buildpack.
Buildpack authors can add
```go
logger.BuildConfiguration(map[string]string{
     "BP_SOME_CONFIGURATION" : "value",
     "BP_OTHER_CONFIGURATION_ENABLED": "false"
})
```
and when debug logging is enabled, the buildpack will log:
```bash
  Build configuration:
    BP_OTHER_CONFIGURATION_ENABLED -> "false"
    BP_SOME_CONFIGURATION          -> "value"
```

This functionality handshakes well with the https://github.com/Netflix/go-env package, which we have been using in some buildpacks to extract environment variables into a struct. For example, in a `build.go`
```go
type Configuration struct {
  LogLevel string `env:"BP_LOG_LEVEL"`
  OtherConfig string `env:"BP_OTHER_CONFIG"`
}

func Build(config Configuration, logger scribe.Emitter) packit.BuildFunc{
  return func(context packit.BuildContext) (packit.BuildResult, error) {
    envSet, err := env.Marshal(&config) // unpack the config into an EnvSet
    logger.BuildConfiguration(envSet)
  }
}
```
will log:
```
  Build configuration:
    BP_LOG_LEVEL    -> "DEBUG"
    BP_OTHER_CONFIG -> "value"
```
For more on `EnvSet` and `env.Marshal()`, see [Netflix/go-env reference docs](https://pkg.go.dev/github.com/Netflix/go-env?utm_source=godoc).

⚠️  Note: To reuse the `NewFormattedMapFromEnvironment()`, I generalized the implementation to accept any `map[string]string` and added a case for map entries that don't have suffixes like `.override` or `.default`.


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
