### PR TITLE
Makes CycloneDX SBOM Reproducible

### DIFF
--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -60,7 +60,7 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 			var cycloneDXOutput map[string]interface{}
 			err = json.Unmarshal(output, &cycloneDXOutput)
 			if err != nil {
-				return 0, fmt.Errorf("failed to modify SPDX SBOM for reproducibility: %w", err)
+				return 0, fmt.Errorf("failed to modify CycloneDX SBOM for reproducibility: %w", err)
 			}
 			for k := range cycloneDXOutput {
 				if k == "metadata" {

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -32,6 +32,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.CycloneDXFormat))
 		Expect(err).NotTo(HaveOccurred())
 
+		format := syft.IdentifyFormat(buffer.Bytes())
+		Expect(format.ID()).To(Equal(syft.CycloneDxJSONFormatID))
+
 		var cdxOutput cdxOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &cdxOutput)
@@ -57,6 +60,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		buffer := bytes.NewBuffer(nil)
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.Format(syft.CycloneDxJSONFormatID)))
 		Expect(err).NotTo(HaveOccurred())
+
+		format := syft.IdentifyFormat(buffer.Bytes())
+		Expect(format.ID()).To(Equal(syft.CycloneDxJSONFormatID))
 
 		var cdxOutput cdxOutput
 

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -39,7 +39,10 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(cdxOutput.BOMFormat).To(Equal("CycloneDX"), buffer.String())
 		Expect(cdxOutput.SpecVersion).To(Equal("1.3"), buffer.String())
+		Expect(cdxOutput.SerialNumber).To(Equal(""), buffer.String())
 
+		Expect(cdxOutput.Metadata.Timestamp).To(Equal(""), buffer.String())
+		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Name).To(Equal("testdata/"), buffer.String())
 		Expect(cdxOutput.Components[0].Name).To(Equal("collapse-white-space"), buffer.String())
@@ -62,7 +65,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(cdxOutput.BOMFormat).To(Equal("CycloneDX"), buffer.String())
 		Expect(cdxOutput.SpecVersion).To(Equal("1.4"), buffer.String())
+		Expect(cdxOutput.SerialNumber).To(Equal(""), buffer.String())
 
+		Expect(cdxOutput.Metadata.Timestamp).To(Equal(""), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Type).To(Equal("file"), buffer.String())
 		Expect(cdxOutput.Metadata.Component.Name).To(Equal("testdata/"), buffer.String())
 		Expect(cdxOutput.Components[0].Name).To(Equal("collapse-white-space"), buffer.String())

--- a/sbom/sbom_outputs_test.go
+++ b/sbom/sbom_outputs_test.go
@@ -17,9 +17,11 @@ type component struct {
 }
 
 type cdxOutput struct {
-	BOMFormat   string `json:"bomFormat"`
-	SpecVersion string `json:"specVersion"`
-	Metadata    struct {
+	BOMFormat    string `json:"bomFormat"`
+	SpecVersion  string `json:"specVersion"`
+	SerialNumber string `json:"serialNumber"`
+	Metadata     struct {
+		Timestamp string `json:"timestamp"`
 		Component struct {
 			Type string `json:"type"`
 			Name string `json:"name"`


### PR DESCRIPTION
- Removes the serial number and timestamp in the FormatterReader.Read()
  function

Resolves #367 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
