### PR TITLE
Makes SPDX SBOM Reproducible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.1
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
+	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/gomega v1.20.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sclevine/spec v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/gabriel-vasile/mimetype v1.4.1
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
-	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/onsi/gomega v1.20.0
 	github.com/pelletier/go-toml v1.9.5
 	github.com/sclevine/spec v1.4.0

--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -131,7 +131,7 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 						if err != nil {
 							return 0, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
 						}
-						creationInfo["created"] = time.Unix(sde, 0)
+						creationInfo["created"] = time.Unix(sde, 0).UTC()
 					}
 					spdxOutput[k] = creationInfo
 				}

--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -93,14 +93,14 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 				return 0, fmt.Errorf("failed to modify SPDX SBOM for reproducibility: %w", err)
 			}
 
-			// Makes the creationInfo reproducible to a hash can be taken for the
+			// Makes the creationInfo reproducible so a hash can be taken for the
 			// documentNamespace
 			if creationInfo, ok := spdxOutput["creationInfo"].(map[string]interface{}); ok {
 				creationInfo["created"] = time.Time{} // This is the zero-valued time
 
-				source_date_epoch := os.Getenv("SOURCE_DATE_EPOCH")
-				if source_date_epoch != "" {
-					sde, err := strconv.ParseInt(source_date_epoch, 10, 64)
+				sourceDateEpoch := os.Getenv("SOURCE_DATE_EPOCH")
+				if sourceDateEpoch != "" {
+					sde, err := strconv.ParseInt(sourceDateEpoch, 10, 64)
 					if err != nil {
 						return 0, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
 					}

--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -123,10 +123,10 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 				}
 				if k == "creationInfo" {
 					creationInfo := spdxOutput["creationInfo"].(map[string]interface{})
+                                         creationInfo["created"] = time.Time{} // This is the zero-valued time
+
 					source_date_epoch := os.Getenv("SOURCE_DATE_EPOCH")
-					if source_date_epoch == "" {
-						creationInfo["created"] = time.Time{} // This is the zero-valued time
-					} else {
+					if source_date_epoch != "" {
 						sde, err := strconv.ParseInt(source_date_epoch, 10, 64)
 						if err != nil {
 							// not tested

--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -123,13 +123,12 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 				}
 				if k == "creationInfo" {
 					creationInfo := spdxOutput["creationInfo"].(map[string]interface{})
-                                         creationInfo["created"] = time.Time{} // This is the zero-valued time
+					creationInfo["created"] = time.Time{} // This is the zero-valued time
 
 					source_date_epoch := os.Getenv("SOURCE_DATE_EPOCH")
 					if source_date_epoch != "" {
 						sde, err := strconv.ParseInt(source_date_epoch, 10, 64)
 						if err != nil {
-							// not tested
 							return 0, fmt.Errorf("failed to parse SOURCE_DATE_EPOCH: %w", err)
 						}
 						creationInfo["created"] = time.Unix(sde, 0)

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -120,7 +120,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 			Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 			// Ensure documentNamespace and creationInfo.created have reproducible values
-			Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-37a75df4-7cb2-5384-820a-d9ac961acccb"), buffer.String())
+			Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-04e37d2c-9d0c-54b0-ab88-8fa36abad217"), buffer.String())
 			Expect(spdxOutput.CreationInfo.Created).To(BeZero(), buffer.String())
 
 			rerunBuffer := bytes.NewBuffer(nil)
@@ -169,7 +169,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 					Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 					// Ensure documentNamespace and creationInfo.created have reproducible values
-					Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-37a75df4-7cb2-5384-820a-d9ac961acccb"), buffer.String())
+					Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-9b828127-aae0-54c2-bb2e-0f2f7a349906"), buffer.String())
 					Expect(spdxOutput.CreationInfo.Created).To(Equal(time.Unix(1659551872, 0).UTC()), buffer.String())
 
 					rerunBuffer := bytes.NewBuffer(nil)

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -102,6 +102,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 			_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.SPDXFormat))
 			Expect(err).NotTo(HaveOccurred())
 
+			format := syft.IdentifyFormat(buffer.Bytes())
+			Expect(format.ID()).To(Equal(syft.SPDXJSONFormatID))
+
 			var spdxOutput spdxOutput
 
 			err = json.Unmarshal(buffer.Bytes(), &spdxOutput)
@@ -152,6 +155,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 					err = json.Unmarshal(buffer.Bytes(), &spdxOutput)
 					Expect(err).NotTo(HaveOccurred(), buffer.String())
+
+					format := syft.IdentifyFormat(buffer.Bytes())
+					Expect(format.ID()).To(Equal(syft.SPDXJSONFormatID))
 
 					Expect(spdxOutput.SPDXVersion).To(Equal("SPDX-2.2"), buffer.String())
 

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -60,7 +60,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		rerunBuffer := bytes.NewBuffer(nil)
 		_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.CycloneDXFormat))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rerunBuffer).To(Equal(buffer))
+		Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 	})
 
 	it("writes the SBOM in the latest CycloneDX format (1.4)", func() {
@@ -93,7 +93,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		rerunBuffer := bytes.NewBuffer(nil)
 		_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.Format(syft.CycloneDxJSONFormatID)))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rerunBuffer).To(Equal(buffer))
+		Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 	})
 
 	context("writes the SBOM in SPDX format, with fields replaced for reproducibility", func() {
@@ -123,7 +123,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 			rerunBuffer := bytes.NewBuffer(nil)
 			_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.SPDXFormat))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rerunBuffer).To(Equal(buffer))
+			Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 		})
 
 		context("when SOURCE_DATE_EPOCH is set", func() {
@@ -169,11 +169,11 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 					rerunBuffer := bytes.NewBuffer(nil)
 					_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.SPDXFormat))
 					Expect(err).NotTo(HaveOccurred())
-					Expect(rerunBuffer).To(Equal(buffer))
+					Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 				})
 
 				context("failure cases", func() {
-					context("when the timestamp is valid", func() {
+					context("when the timestamp is not valid", func() {
 						it.Before(func() {
 							Expect(os.Setenv("SOURCE_DATE_EPOCH", "not-a-valid-timestamp")).To(Succeed())
 						})
@@ -213,7 +213,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		rerunBuffer := bytes.NewBuffer(nil)
 		_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.SyftFormat))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rerunBuffer).To(Equal(buffer))
+		Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 	})
 
 	it("writes the SBOM in Syft 2.0.2 format", func() {
@@ -240,7 +240,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		rerunBuffer := bytes.NewBuffer(nil)
 		_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.Format(syft2.ID)))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rerunBuffer).To(Equal(buffer))
+		Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 	})
 
 	it("writes the SBOM in the latest Syft format (3.*)", func() {
@@ -267,7 +267,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		rerunBuffer := bytes.NewBuffer(nil)
 		_, err = io.Copy(rerunBuffer, sbom.NewFormattedReader(bom, sbom.Format(syft.JSONFormatID)))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(rerunBuffer).To(Equal(buffer))
+		Expect(rerunBuffer.String()).To(Equal(buffer.String()))
 	})
 
 	context("Read", func() {

--- a/sbom/sbom_outputs_test.go
+++ b/sbom/sbom_outputs_test.go
@@ -1,5 +1,7 @@
 package sbom_test
 
+import "time"
+
 /* A set of structs that are used to unmarshal SBOM JSON output in tests */
 
 type license struct {
@@ -64,6 +66,10 @@ type pkg struct {
 }
 
 type spdxOutput struct {
-	Packages    []pkg  `json:"packages"`
-	SPDXVersion string `json:"spdxVersion"`
+	Packages          []pkg  `json:"packages"`
+	SPDXVersion       string `json:"spdxVersion"`
+	DocumentNamespace string `json:"documentNamespace"`
+	CreationInfo      struct {
+		Created time.Time `json:"created"`
+	} `json:"creationInfo"`
 }


### PR DESCRIPTION
- Writes custom documentNamespace and use SOURCE_DATE_EPOCH for created
  timestamp when available

Resolves #368 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
