### PR TITLE
GenerateFromDependency without CPE or PURL

### DIFF
--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -14,6 +14,8 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/postal"
 )
 
+const UnknownDependencyCPE = "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"
+
 // SBOM holds the internal representation of the generated software
 // bill-of-materials. This type can be combined with a FormattedReader to
 // output the SBoM in a number of file formats.
@@ -70,14 +72,13 @@ func Generate(path string) (SBOM, error) {
 // and the directory path where the dependency will be located within the
 // application image.
 func GenerateFromDependency(dependency postal.Dependency, path string) (SBOM, error) {
-	cpe := pkg.CPE{}
+	if dependency.CPE == "" {
+		dependency.CPE = UnknownDependencyCPE
+	}
 
-	if dependency.CPE != "" {
-		var err error
-		cpe, err = pkg.NewCPE(dependency.CPE)
-		if err != nil {
-			return SBOM{}, err
-		}
+	cpe, err := pkg.NewCPE(dependency.CPE)
+	if err != nil {
+		return SBOM{}, err
 	}
 
 	catalog := pkg.NewCatalog(pkg.Package{

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -14,6 +14,9 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/postal"
 )
 
+// UnknownCPE is a Common Platform Enumeration (CPE) that uses the NA (Not
+// applicable) logical operator for all components of its name. It is designed
+// not to match with other CPEs, to avoid false positive CPE matches.
 const UnknownCPE = "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"
 
 // SBOM holds the internal representation of the generated software

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -70,9 +70,14 @@ func Generate(path string) (SBOM, error) {
 // and the directory path where the dependency will be located within the
 // application image.
 func GenerateFromDependency(dependency postal.Dependency, path string) (SBOM, error) {
-	cpe, err := pkg.NewCPE(dependency.CPE)
-	if err != nil {
-		return SBOM{}, err
+	cpe := pkg.CPE{}
+
+	if dependency.CPE != "" {
+		var err error
+		cpe, err = pkg.NewCPE(dependency.CPE)
+		if err != nil {
+			return SBOM{}, err
+		}
 	}
 
 	catalog := pkg.NewCatalog(pkg.Package{

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -14,7 +14,7 @@ import (
 	"github.com/paketo-buildpacks/packit/v2/postal"
 )
 
-const UnknownDependencyCPE = "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"
+const UnknownCPE = "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"
 
 // SBOM holds the internal representation of the generated software
 // bill-of-materials. This type can be combined with a FormattedReader to
@@ -73,7 +73,7 @@ func Generate(path string) (SBOM, error) {
 // application image.
 func GenerateFromDependency(dependency postal.Dependency, path string) (SBOM, error) {
 	if dependency.CPE == "" {
-		dependency.CPE = UnknownDependencyCPE
+		dependency.CPE = UnknownCPE
 	}
 
 	cpe, err := pkg.NewCPE(dependency.CPE)

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -325,7 +325,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				Expect(syftDefaultOutput.Source.Type).To(Equal("directory"), syft.String())
 				Expect(syftDefaultOutput.Source.Target).To(Equal("some-path"), syft.String())
 				Expect(goArtifact.PURL).To(BeEmpty())
-				Expect(goArtifact.CPEs).To(Equal([]string{"cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"}))
+				Expect(goArtifact.CPEs).To(Equal([]string{"cpe:2.3:-:-:-:-:-:-:-:-:-:-:-"}))
 
 				cdx := bytes.NewBuffer(nil)
 				for _, format := range formats {
@@ -374,7 +374,7 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 				Expect(goPackage.LicenseDeclared).To(Equal("BSD-3-Clause"), spdx.String())
 				Expect(goPackage.ExternalRefs).To(Equal([]externalRef{{
 					Category: "SECURITY",
-					Locator:  "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					Locator:  "cpe:2.3:-:-:-:-:-:-:-:-:-:-:-",
 					Type:     "cpe23Type",
 				}}), spdx.String())
 			})

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -284,6 +284,102 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 			Expect(cdx14Output.Metadata.Component.Name).To(Equal("some-path"), cdx.String())
 		})
 
+		context("when the input dependency does not have a CPE or a PURL", func() {
+			it("succeeds in generating an SBOM without CPEs", func() {
+				bom, err := sbom.GenerateFromDependency(postal.Dependency{
+					ID:           "go",
+					Licenses:     []string{"BSD-3-Clause"},
+					Name:         "Go",
+					SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+					Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
+					SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+					Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+					URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+					Version:      "1.16.9",
+				}, "some-path")
+				Expect(err).NotTo(HaveOccurred())
+
+				formatter, err := bom.InFormats(sbom.SyftFormat, sbom.CycloneDXFormat, sbom.SPDXFormat)
+				Expect(err).NotTo(HaveOccurred())
+
+				formats := formatter.Formats()
+
+				syft := bytes.NewBuffer(nil)
+				for _, format := range formats {
+					if format.Extension == "syft.json" {
+						_, err = io.Copy(syft, format.Content)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				var syftDefaultOutput syftOutput
+				err = json.NewDecoder(syft).Decode(&syftDefaultOutput)
+				Expect(err).NotTo(HaveOccurred(), syft.String())
+
+				Expect(syftDefaultOutput.Schema.Version).To(Equal(`3.0.1`), syft.String())
+
+				goArtifact := syftDefaultOutput.Artifacts[0]
+				Expect(goArtifact.Name).To(Equal("Go"), syft.String())
+				Expect(goArtifact.Version).To(Equal("1.16.9"), syft.String())
+				Expect(goArtifact.Licenses).To(Equal([]string{"BSD-3-Clause"}), syft.String())
+				Expect(syftDefaultOutput.Source.Type).To(Equal("directory"), syft.String())
+				Expect(syftDefaultOutput.Source.Target).To(Equal("some-path"), syft.String())
+				Expect(goArtifact.PURL).To(BeEmpty())
+				Expect(goArtifact.CPEs).To(Equal([]string{"cpe:2.3:*:*:*:*:*:*:*:*:*:*:*"}))
+
+				cdx := bytes.NewBuffer(nil)
+				for _, format := range formats {
+					if format.Extension == "cdx.json" {
+						_, err = io.Copy(cdx, format.Content)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				var cdxDefaultOutput cdxOutput
+				err = json.Unmarshal(cdx.Bytes(), &cdxDefaultOutput)
+				Expect(err).NotTo(HaveOccurred(), cdx.String())
+
+				Expect(cdxDefaultOutput.BOMFormat).To(Equal("CycloneDX"))
+				Expect(cdxDefaultOutput.SpecVersion).To(Equal("1.3"))
+
+				goComponent := cdxDefaultOutput.Components[0]
+				Expect(goComponent.Name).To(Equal("Go"), cdx.String())
+				Expect(goComponent.Version).To(Equal("1.16.9"), cdx.String())
+				Expect(goComponent.Licenses).To(HaveLen(1), cdx.String())
+				Expect(goComponent.Licenses[0].License.ID).To(Equal("BSD-3-Clause"), cdx.String())
+				Expect(goComponent.PURL).To(BeEmpty())
+
+				Expect(cdxDefaultOutput.Metadata.Component.Type).To(Equal("file"), cdx.String())
+				Expect(cdxDefaultOutput.Metadata.Component.Name).To(Equal("some-path"), cdx.String())
+
+				spdx := bytes.NewBuffer(nil)
+				for _, format := range formats {
+					if format.Extension == "spdx.json" {
+						_, err = io.Copy(spdx, format.Content)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				}
+
+				var spdxDefaultOutput spdxOutput
+				err = json.Unmarshal(spdx.Bytes(), &spdxDefaultOutput)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(err).NotTo(HaveOccurred(), spdx.String())
+
+				Expect(spdxDefaultOutput.SPDXVersion).To(Equal("SPDX-2.2"), spdx.String())
+
+				goPackage := spdxDefaultOutput.Packages[0]
+				Expect(goPackage.Name).To(Equal("Go"), spdx.String())
+				Expect(goPackage.Version).To(Equal("1.16.9"), spdx.String())
+				Expect(goPackage.LicenseConcluded).To(Equal("BSD-3-Clause"), spdx.String())
+				Expect(goPackage.LicenseDeclared).To(Equal("BSD-3-Clause"), spdx.String())
+				Expect(goPackage.ExternalRefs).To(Equal([]externalRef{{
+					Category: "SECURITY",
+					Locator:  "cpe:2.3:*:*:*:*:*:*:*:*:*:*:*",
+					Type:     "cpe23Type",
+				}}), spdx.String())
+			})
+		})
+
 		context("failure cases", func() {
 			context("when the CPE is invalid", func() {
 				it("returns an error", func() {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Currently, it's not possible to use `GenerateFromDependency()` in  https://github.com/paketo-buildpacks/vsdbg/pull/1 because the `vsdbg` dependency has neither a CPE nor a PURL and 'GenerateFromDependency()' fails if the dependency lacks a CPE. With this change, the function generates an SBOM when the CPE is absent. The tests also assert that SBOM generation succeeds without a PURL.

#### ⚠️ Note
As you can see in the test assertions, for SPDX and Syft SBOMs, when the dependency CPE is empty, the SBOM output gets `cpe:2.3:-:-:-:-:-:-:-:-:-:-:-` for its CPE. As far as I can gather from the [CPE Naming Spec 2.3](https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7696.pdf), this means that every attribute of the software gets the value "NA" or Not Applicable.

My understanding is that consumers will compare CPEs in SBOMs to CPEs in published vulnerability notices. If the CPEs in an SBOM match the CPEs for a vulnerability, the software is deemed vulnerable. The [CPE Matching Spec 2.3](https://www.govinfo.gov/content/pkg/GOVPUB-C13-c213837a04c3bcc778ebfd420c6a3f2a/pdf/GOVPUB-C13-c213837a04c3bcc778ebfd420c6a3f2a.pdf) describes how tools are supposed to compare CPEs to understand whether a given piece of software contains a vulnerability.

From what I can tell in that document, assigning an "all N/A" CPE to dependencies with unknown CPEs is our best way to avoid false positives. We don't want a dependency with unknown CPE to set off alarms that it's vulnerable to CVEs in unrelated packages, (or, even worse, CVEs in _all_ packages.)

#### ✋ Help
The naming spec and matching spec are dense. I'd appreciate a second set of eyes to confirm if my choice of `UnknownCPE` makes sense.

Todo:
- [ ] Add godoc to `UnknownCPE` once its value is confirmed

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
