### PR TITLE
Add support for wild-card stacks in dependencies

### DIFF
--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -73,7 +73,7 @@ func parseBuildpack(path, name string) ([]Dependency, string, error) {
 
 func stacksInclude(stacks []string, stack string) bool {
 	for _, s := range stacks {
-		if s == stack {
+		if s == stack || s == "*" {
 			return true
 		}
 	}

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -86,6 +86,14 @@ stacks = ["some-stack"]
 uri = "some-uri"
 version = "4.5.6"
 strip-components = 1
+
+[[metadata.dependencies]]
+id = "some-other-entry"
+sha256 = "some-sha"
+stacks = ["*"]
+uri = "some-uri"
+version = "4.5.6"
+strip-components = 1
 `)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -113,6 +121,21 @@ strip-components = 1
 				SHA256:          "some-sha",
 				Version:         "1.2.3",
 			}))
+		})
+
+		context("when the dependency has a wildcard stack", func() {
+			it("is compatible with all stack ids", func() {
+				dependency, err := service.Resolve(path, "some-other-entry", "", "random-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:              "some-other-entry",
+					Stacks:          []string{"*"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "4.5.6",
+					StripComponents: 1,
+				}))
+			})
 		})
 
 		context("when there is NOT a default version", func() {


### PR DESCRIPTION
Signed-off-by: Sambhav Kothari <skothari44@bloomberg.net>

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #375

## Use Cases
<!-- An explanation of the use cases your change enables -->

There are various binaries that are compatible with all linux stacks. We should add support for `*` stack id in metadata dependencies.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
