### PR TITLE
Marshal CycloneDX/SPDX SBOM with indentation

### DIFF
--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -77,7 +77,9 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 
 			delete(cycloneDXOutput, "serialNumber")
 
-			output, err = json.MarshalIndent(cycloneDXOutput, "", "\t")
+			// Indent with a two spaces, as they do in CycloneDX:
+			// https://github.com/CycloneDX/cyclonedx-go/blob/429d353cfcdbfedf367f597cbdde2a840ebf29df/encode.go#L44
+			output, err = json.MarshalIndent(cycloneDXOutput, "", "  ")
 			if err != nil {
 				return 0, fmt.Errorf("failed to modify CycloneDX SBOM for reproducibility: %w", err)
 			}
@@ -133,7 +135,9 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 				spdxOutput["documentNamespace"] = uri.String()
 			}
 
-			output, err = json.MarshalIndent(spdxOutput, "", "\t")
+			// Indent with a single space, as they do in SPDX:
+			// https://github.com/anchore/syft/blob/1344889766743beb736aafdfb29266910b738fbb/internal/formats/spdx22json/encoder.go#L16
+			output, err = json.MarshalIndent(spdxOutput, "", " ")
 			if err != nil {
 				return 0, fmt.Errorf("failed to modify SPDX SBOM for reproducibility: %w", err)
 			}

--- a/sbom/formatted_reader.go
+++ b/sbom/formatted_reader.go
@@ -77,7 +77,7 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 
 			delete(cycloneDXOutput, "serialNumber")
 
-			output, err = json.Marshal(cycloneDXOutput)
+			output, err = json.MarshalIndent(cycloneDXOutput, "", "\t")
 			if err != nil {
 				return 0, fmt.Errorf("failed to modify CycloneDX SBOM for reproducibility: %w", err)
 			}
@@ -133,7 +133,7 @@ func (f *FormattedReader) Read(b []byte) (int, error) {
 				spdxOutput["documentNamespace"] = uri.String()
 			}
 
-			output, err = json.Marshal(spdxOutput)
+			output, err = json.MarshalIndent(spdxOutput, "", "\t")
 			if err != nil {
 				return 0, fmt.Errorf("failed to modify SPDX SBOM for reproducibility: %w", err)
 			}

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -39,9 +39,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 		// Ensures pretty printing
 		Expect(buffer.String()).To(ContainSubstring(`{
-	"bomFormat": "CycloneDX",
-	"components": [
-		{`))
+  "bomFormat": "CycloneDX",
+  "components": [
+    {`))
 
 		var cdxOutput cdxOutput
 
@@ -79,9 +79,9 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 		// Ensures pretty printing
 		Expect(buffer.String()).To(ContainSubstring(`{
-	"bomFormat": "CycloneDX",
-	"components": [
-		{`))
+  "bomFormat": "CycloneDX",
+  "components": [
+    {`))
 
 		var cdxOutput cdxOutput
 
@@ -119,8 +119,8 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 			// Ensures pretty printing
 			Expect(buffer.String()).To(ContainSubstring(`{
-	"SPDXID": "SPDXRef-DOCUMENT",
-	"creationInfo": {`))
+ "SPDXID": "SPDXRef-DOCUMENT",
+ "creationInfo": {`))
 
 			var spdxOutput spdxOutput
 

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -37,6 +37,12 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		format := syft.IdentifyFormat(buffer.Bytes())
 		Expect(format.ID()).To(Equal(syft.CycloneDxJSONFormatID))
 
+		// Ensures pretty printing
+		Expect(buffer.String()).To(ContainSubstring(`{
+	"bomFormat": "CycloneDX",
+	"components": [
+		{`))
+
 		var cdxOutput cdxOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &cdxOutput)
@@ -71,6 +77,12 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		format := syft.IdentifyFormat(buffer.Bytes())
 		Expect(format.ID()).To(Equal(syft.CycloneDxJSONFormatID))
 
+		// Ensures pretty printing
+		Expect(buffer.String()).To(ContainSubstring(`{
+	"bomFormat": "CycloneDX",
+	"components": [
+		{`))
+
 		var cdxOutput cdxOutput
 
 		err = json.Unmarshal(buffer.Bytes(), &cdxOutput)
@@ -104,6 +116,11 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 			format := syft.IdentifyFormat(buffer.Bytes())
 			Expect(format.ID()).To(Equal(syft.SPDXJSONFormatID))
+
+			// Ensures pretty printing
+			Expect(buffer.String()).To(ContainSubstring(`{
+	"SPDXID": "SPDXRef-DOCUMENT",
+	"creationInfo": {`))
 
 			var spdxOutput spdxOutput
 
@@ -226,6 +243,12 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 		buffer := bytes.NewBuffer(nil)
 		_, err := io.Copy(buffer, sbom.NewFormattedReader(bom, sbom.Format(syft2.ID)))
 		Expect(err).NotTo(HaveOccurred())
+
+		// Ensures pretty printing
+		Expect(buffer.String()).To(ContainSubstring(`{
+ "artifacts": [
+  {
+   "id":`))
 
 		var syftOutput syftOutput
 

--- a/sbom/sbom.go
+++ b/sbom/sbom.go
@@ -74,6 +74,8 @@ func Generate(path string) (SBOM, error) {
 // GenerateFromDependency returns a populated SBOM given a postal.Dependency
 // and the directory path where the dependency will be located within the
 // application image.
+
+//nolint Ignore SA1019, informed usage of deprecated package
 func GenerateFromDependency(dependency postal.Dependency, path string) (SBOM, error) {
 	if dependency.CPE == "" {
 		dependency.CPE = UnknownCPE


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The [latest packit release ](https://github.com/paketo-buildpacks/packit/releases/tag/v2.4.0) performs an extra modification step for the CycloneDX/SPDX SBOMs to make them reproducible. This change causes the output SBOMs to format without any indentation, all on one line. 

This PR changes the `json.Marshal` to `json.MarshalIndent` for purely cosmetic reasons, so that the output SBOMs match other SBOMs with spacing. 

The SBOM will come out looking like:
```
{
        "bomFormat": "CycloneDX",
        "components": [
                {
                        "cpe": "cpe:2.3:a:haxx:curl:7.84.0:*:*:*:*:*:*:*"
...
```
Instead of:
```
{"bomFormat":"CycloneDX","components":[{"cpe":"cpe:2.3:a:haxx:curl:7.84.0:*:*:*:*:*:*:*", ...
```

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
