### PR TITLE
Adds checksum and source-checksum field in dependencies

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -49,14 +49,16 @@ type ConfigMetadata struct {
 }
 
 type ConfigMetadataDependency struct {
+	Checksum        string        `toml:"checksum"         json:"checksum,omitempty"`
 	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
-	PURL            string        `toml:"purl"              json:"purl,omitempty"`
+	PURL            string        `toml:"purl"             json:"purl,omitempty"`
 	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
 	ID              string        `toml:"id"               json:"id,omitempty"`
 	Licenses        []interface{} `toml:"licenses"         json:"licenses,omitempty"`
 	Name            string        `toml:"name"             json:"name,omitempty"`
 	SHA256          string        `toml:"sha256"           json:"sha256,omitempty"`
 	Source          string        `toml:"source"           json:"source,omitempty"`
+	SourceChecksum  string        `toml:"source-checksum"  json:"source-checksum,omitempty"`
 	SourceSHA256    string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
 	Stacks          []string      `toml:"stacks"           json:"stacks,omitempty"`
 	StripComponents int           `toml:"strip-components" json:"strip-components,omitempty"`

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -66,6 +66,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 					PrePackage:   "some-pre-package-script.sh",
 					Dependencies: []cargo.ConfigMetadataDependency{
 						{
+							Checksum:        "sha256:some-sum",
 							CPE:             "some-cpe",
 							PURL:            "some-purl",
 							DeprecationDate: &deprecationDate,
@@ -74,6 +75,7 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							Name:            "Some Dependency",
 							SHA256:          "shasum",
 							Source:          "source",
+							SourceChecksum:  "sha256:source-shasum",
 							SourceSHA256:    "source-shasum",
 							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
 							StripComponents: 1,
@@ -133,6 +135,7 @@ api = "0.6"
 	some-dependency = "1.2.x"
 
 [[metadata.dependencies]]
+	checksum = "sha256:some-sum"
   cpe = "some-cpe"
   purl = "some-purl"
   deprecation_date = "2020-06-01T00:00:00Z"
@@ -141,6 +144,7 @@ api = "0.6"
   name = "Some Dependency"
   sha256 = "shasum"
 	source = "source"
+	source-checksum = "sha256:source-shasum"
   source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   strip-components = 1
@@ -211,6 +215,7 @@ api = "0.6"
 						PrePackage:   "some-pre-package-script.sh",
 						Dependencies: []cargo.ConfigMetadataDependency{
 							{
+								Checksum:        "sha256:some-sum",
 								CPE:             "some-cpe",
 								PURL:            "some-purl",
 								DeprecationDate: &deprecationDate,
@@ -225,13 +230,14 @@ api = "0.6"
 										URI:  "some-license-uri",
 									},
 								},
-								Name:         "Some Dependency",
-								SHA256:       "shasum",
-								Source:       "source",
-								SourceSHA256: "source-shasum",
-								Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-								URI:          "http://some-url",
-								Version:      "1.2.3",
+								Name:           "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
 							},
 						},
 						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
@@ -282,6 +288,7 @@ api = "0.6"
 	some-dependency = "1.2.x"
 
 [[metadata.dependencies]]
+	checksum = "sha256:some-sum"
   cpe = "some-cpe"
   purl = "some-purl"
   deprecation_date = "2020-06-01T00:00:00Z"
@@ -289,6 +296,7 @@ api = "0.6"
   name = "Some Dependency"
   sha256 = "shasum"
 	source = "source"
+	source-checksum = "sha256:source-shasum"
   source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   uri = "http://some-url"
@@ -395,13 +403,15 @@ api = "0.6"
   key = "value"
 
 [[metadata.dependencies]]
+	checksum = "sha256:some-sum"
   cpe = "some-cpe"
   purl = "some-purl"
   id = "some-dependency"
 	licenses = ["fancy-license", "fancy-license-2"]
   name = "Some Dependency"
   sha256 = "shasum"
-	source = "source"
+  source = "source"
+  source-checksum = "sha256:source-shasum"
   source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
 	strip-components = 1
@@ -469,6 +479,7 @@ api = "0.6"
 					PrePackage: "some-pre-package-script.sh",
 					Dependencies: []cargo.ConfigMetadataDependency{
 						{
+							Checksum:        "sha256:some-sum",
 							CPE:             "some-cpe",
 							PURL:            "some-purl",
 							ID:              "some-dependency",
@@ -476,6 +487,7 @@ api = "0.6"
 							Name:            "Some Dependency",
 							SHA256:          "shasum",
 							Source:          "source",
+							SourceChecksum:  "sha256:source-shasum",
 							SourceSHA256:    "source-shasum",
 							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
 							StripComponents: 1,
@@ -539,12 +551,14 @@ api = "0.2"
   key = "value"
 
 [[metadata.dependencies]]
+	checksum = "sha256:some-sum"
   cpe = "some-cpe"
   purl = "some-purl"
   id = "some-dependency"
   name = "Some Dependency"
   sha256 = "shasum"
-	source = "source"
+  source = "source"
+  source-checksum = "sha256:source-shasum"
   source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
   uri = "http://some-url"
@@ -615,9 +629,10 @@ api = "0.2"
 						PrePackage: "some-pre-package-script.sh",
 						Dependencies: []cargo.ConfigMetadataDependency{
 							{
-								CPE:  "some-cpe",
-								PURL: "some-purl",
-								ID:   "some-dependency",
+								Checksum: "sha256:some-sum",
+								CPE:      "some-cpe",
+								PURL:     "some-purl",
+								ID:       "some-dependency",
 								Licenses: []interface{}{
 									map[string]interface{}{
 										"type": "fancy-license",
@@ -628,13 +643,14 @@ api = "0.2"
 										"uri":  "some-license-uri",
 									},
 								},
-								Name:         "Some Dependency",
-								SHA256:       "shasum",
-								Source:       "source",
-								SourceSHA256: "source-shasum",
-								Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-								URI:          "http://some-url",
-								Version:      "1.2.3",
+								Name:           "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
 							},
 						},
 						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{

--- a/cargo/validated_reader_test.go
+++ b/cargo/validated_reader_test.go
@@ -15,30 +15,35 @@ import (
 func testValidatedReader(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
-		vr     cargo.ValidatedReader
 	)
 
-	it.Before(func() {
-		vr = cargo.NewValidatedReader(strings.NewReader("some-contents"), "6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
-	})
-
 	context("Read", func() {
+		var buffer *bytes.Buffer
+		it.Before(func() {
+			buffer = bytes.NewBuffer(nil)
+		})
 
 		it("reads the contents of the internal reader", func() {
-			buffer := bytes.NewBuffer(nil)
+			vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "sha256:6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
 
 			_, err := io.Copy(buffer, vr)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(buffer.String()).To(Equal("some-contents"))
 		})
 
-		context("when the checksum does not match", func() {
-			it.Before(func() {
-				vr = cargo.NewValidatedReader(strings.NewReader("some-contents"), "this checksum does not match")
-			})
+		context("when running with a different algorithm", func() {
+			it("reads the contents of the internal reader", func() {
+				vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "sha512:b7b2b9e0a4d7f84985a720d1273166bb00132a60ac45388a7d3090a7d4c9692f38d019f807a02750f810f52c623362f977040231c2bbf5947170fe83686cfd9d")
 
+				_, err := io.Copy(buffer, vr)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(buffer.String()).To(Equal("some-contents"))
+			})
+		})
+
+		context("when the checksum does not match", func() {
 			it("returns an error", func() {
-				buffer := bytes.NewBuffer(nil)
+				vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "sha256:this checksum does not match")
 
 				_, err := io.Copy(buffer, vr)
 				Expect(err).To(MatchError("validation error: checksum does not match"))
@@ -46,15 +51,31 @@ func testValidatedReader(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when the internal reader cannot be read", func() {
-			it.Before(func() {
-				vr = cargo.NewValidatedReader(errorReader{}, "6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
-			})
-
 			it("returns an error", func() {
-				buffer := bytes.NewBuffer(nil)
+				vr := cargo.NewValidatedReader(errorReader{}, "sha256:6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
 
 				_, err := io.Copy(buffer, vr)
 				Expect(err).To(MatchError("failed to read"))
+			})
+		})
+
+		context("failure cases", func() {
+			context("there is a malformed checksum", func() {
+				it("returns an error", func() {
+					vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "malformed checksum")
+
+					_, err := io.Copy(buffer, vr)
+					Expect(err).To(MatchError(`malformed checksum "malformed checksum": checksum should be formatted "algorithm:hash"`))
+				})
+			})
+
+			context("there is an unsupported algorithm", func() {
+				it("returns an error", func() {
+					vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "magic:6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
+
+					_, err := io.Copy(buffer, vr)
+					Expect(err).To(MatchError(`unsupported algorithm "magic": the following algorithms are support [sha256, sha512]`))
+				})
 			})
 		})
 	})
@@ -62,6 +83,8 @@ func testValidatedReader(t *testing.T, context spec.G, it spec.S) {
 	context("Valid", func() {
 		context("when the checksums match", func() {
 			it("returns true", func() {
+				vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "sha256:6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
+
 				ok, err := vr.Valid()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok).To(BeTrue())
@@ -69,11 +92,9 @@ func testValidatedReader(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when the checksums do not match", func() {
-			it.Before(func() {
-				vr = cargo.NewValidatedReader(strings.NewReader("some-contents"), "this checksum does not match")
-			})
-
 			it("returns false", func() {
+				vr := cargo.NewValidatedReader(strings.NewReader("some-contents"), "sha256:this checksum does not match")
+
 				ok, err := vr.Valid()
 				Expect(err).NotTo(HaveOccurred())
 				Expect(ok).To(BeFalse())
@@ -82,11 +103,9 @@ func testValidatedReader(t *testing.T, context spec.G, it spec.S) {
 
 		context("failure cases", func() {
 			context("when the internal reader cannot be read", func() {
-				it.Before(func() {
-					vr = cargo.NewValidatedReader(errorReader{}, "6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
-				})
-
 				it("returns an error", func() {
+					vr := cargo.NewValidatedReader(errorReader{}, "sha256:6e32ea34db1b3755d7dec972eb72c705338f0dd8e0be881d966963438fb2e800")
+
 					ok, err := vr.Valid()
 					Expect(err).To(MatchError("failed to read"))
 					Expect(ok).To(BeFalse())

--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -23,6 +23,11 @@ type Dependency struct {
 	// DeprecationDate is the data upon which this dependency is considered deprecated.
 	DeprecationDate time.Time `toml:"deprecation_date"`
 
+	// Checksum is a string that includes an algorithm and the hex-encoded hash
+	// of the built dependency separated by a colon. Example
+	// sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.
+	Checksum string `toml:"checksum"`
+
 	// ID is the identifier used to specify the dependency.
 	ID string `toml:"id"`
 
@@ -41,7 +46,13 @@ type Dependency struct {
 	// Source is the uri location of the source-code representation of the dependency.
 	Source string `toml:"source"`
 
-	// SourceSHA256 is the hex-encoded SHA256 checksum of the source-code representation of the dependency.
+	// SourceChecksum is a string that includes an algorithm and the hex-encoded
+	// hash of the source representation of the dependency separated by a colon.
+	// Example sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855.
+	SourceChecksum string `toml:"source-checksum"`
+
+	// SourceSHA256 is the hex-encoded SHA256 checksum of the source-code
+	// representation of the dependency.
 	SourceSHA256 string `toml:"source_sha256"`
 
 	// Stacks is a list of stacks for which the dependency is built.

--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -41,6 +41,8 @@ type Dependency struct {
 	PURL string `toml:"purl"`
 
 	// SHA256 is the hex-encoded SHA256 checksum of the built dependency.
+	//
+	// Deprecated: use Checksum instead.
 	SHA256 string `toml:"sha256"`
 
 	// Source is the uri location of the source-code representation of the dependency.
@@ -53,6 +55,8 @@ type Dependency struct {
 
 	// SourceSHA256 is the hex-encoded SHA256 checksum of the source-code
 	// representation of the dependency.
+	//
+	// Deprecated: use SourceChecksum instead.
 	SourceSHA256 string `toml:"source_sha256"`
 
 	// Stacks is a list of stacks for which the dependency is built.

--- a/postal/service.go
+++ b/postal/service.go
@@ -163,7 +163,12 @@ func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath
 	}
 	defer bundle.Close()
 
-	validatedReader := cargo.NewValidatedReader(bundle, dependency.SHA256)
+	var validatedReader cargo.ValidatedReader
+	if dependency.SHA256 != "" {
+		validatedReader = cargo.NewValidatedReader(bundle, fmt.Sprintf("sha256:%s", dependency.SHA256))
+	} else {
+		validatedReader = cargo.NewValidatedReader(bundle, dependency.Checksum)
+	}
 
 	name := dependency.Name
 	if name == "" {


### PR DESCRIPTION
Given the move a federated buildpack dependencies it seems like it might be prudent for us to allow for different checksum algorithms to be used so that we can better adapt to checksums given by upstream providers. I have put together a quick POC to gauge the interest as well as prove out the possibility of the approach. I would love feedback on this!