### PR TITLE
Support usage of `checksum` field in legacy sbom

### DIFF
--- a/paketosbom/sbom.go
+++ b/paketosbom/sbom.go
@@ -60,7 +60,7 @@ func GetBOMChecksumAlgorithm(alg string) (algorithm, error) {
 		}
 	}
 
-	return "", fmt.Errorf("failed to get supported BOM checksum algorithm: %s is not valid", alg)
+	return UNKNOWN, fmt.Errorf("failed to get supported BOM checksum algorithm: %s is not valid", alg)
 }
 
 const (
@@ -76,4 +76,5 @@ const (
 	BLAKE2B512 algorithm = "BLAKE2b-512"
 	BLAKE3     algorithm = "BLAKE3"
 	MD5        algorithm = "MD5"
+	UNKNOWN    algorithm = "UNKNOWN"
 )

--- a/paketosbom/sbom_test.go
+++ b/paketosbom/sbom_test.go
@@ -41,7 +41,8 @@ func testPaketoSBOM(t *testing.T, context spec.G, it spec.S) {
 		context("failure cases", func() {
 			context("when the attempted BOM checksum algorithm is not supported", func() {
 				it("persists a build.toml", func() {
-					_, err := paketosbom.GetBOMChecksumAlgorithm("RANDOM-ALG")
+					alg, err := paketosbom.GetBOMChecksumAlgorithm("RANDOM-ALG")
+					Expect(alg).To(Equal(paketosbom.UNKNOWN))
 					Expect(err).To(MatchError("failed to get supported BOM checksum algorithm: RANDOM-ALG is not valid"))
 				})
 			})

--- a/postal/service.go
+++ b/postal/service.go
@@ -257,20 +257,15 @@ func (s Service) GenerateBillOfMaterials(dependencies ...Dependency) []packit.BO
 }
 
 func determineChecksum(checksumField, sha256Field string) (string, string) {
-	var algorithm string
-	var hash string
-
-	if sha256Field != "" {
-		algorithm = "SHA256"
-		hash = sha256Field
-	}
-
 	// A well-formed checksum field (algorithm:hash) takes precedence over a SHA256 field
-	checksumParts := strings.Split(checksumField, ":")
-	if len(checksumParts) > 1 {
-		algorithm = checksumParts[0]
-		hash = checksumParts[1]
+	algorithm, hash, found := strings.Cut(checksumField, ":")
+	if found {
+		return algorithm, hash
 	}
 
-	return algorithm, hash
+	if len(sha256Field) > 0 {
+		return "SHA256", sha256Field
+	}
+
+	return "", ""
 }

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -871,24 +871,24 @@ version = "this is super not semver"
 		it("returns a list of BOMEntry values", func() {
 			entries := service.GenerateBillOfMaterials(
 				postal.Dependency{
-					ID:           "some-entry",
-					Name:         "Some Entry",
-					SHA256:       "some-sha",
-					Source:       "some-source",
-					SourceSHA256: "some-source-sha",
-					Stacks:       []string{"some-stack"},
-					URI:          "some-uri",
-					Version:      "1.2.3",
+					ID:             "some-entry",
+					Name:           "Some Entry",
+					Checksum:       "sha256:some-sha",
+					Source:         "some-source",
+					SourceChecksum: "sha256:some-source-sha",
+					Stacks:         []string{"some-stack"},
+					URI:            "some-uri",
+					Version:        "1.2.3",
 				},
 				postal.Dependency{
-					ID:           "other-entry",
-					Name:         "Other Entry",
-					SHA256:       "other-sha",
-					Source:       "other-source",
-					SourceSHA256: "other-source-sha",
-					Stacks:       []string{"other-stack"},
-					URI:          "other-uri",
-					Version:      "4.5.6",
+					ID:             "other-entry",
+					Name:           "Other Entry",
+					Checksum:       "sha256:other-sha",
+					Source:         "other-source",
+					SourceChecksum: "sha256:other-source-sha",
+					Stacks:         []string{"other-stack"},
+					URI:            "other-uri",
+					Version:        "4.5.6",
 				},
 			)
 			Expect(entries).To(Equal([]packit.BOMEntry{
@@ -937,15 +937,15 @@ version = "this is super not semver"
 			it("generates a BOM with the CPE", func() {
 				entries := service.GenerateBillOfMaterials(
 					postal.Dependency{
-						CPE:          "some-cpe",
-						ID:           "some-entry",
-						Name:         "Some Entry",
-						SHA256:       "some-sha",
-						Source:       "some-source",
-						SourceSHA256: "some-source-sha",
-						Stacks:       []string{"some-stack"},
-						URI:          "some-uri",
-						Version:      "1.2.3",
+						CPE:            "some-cpe",
+						ID:             "some-entry",
+						Name:           "Some Entry",
+						Checksum:       "sha256:some-sha",
+						Source:         "some-source",
+						SourceChecksum: "sha256:some-source-sha",
+						Stacks:         []string{"some-stack"},
+						URI:            "some-uri",
+						Version:        "1.2.3",
 					},
 				)
 
@@ -976,16 +976,16 @@ version = "this is super not semver"
 				it("uses CPE, ignores CPEs, for backward compatibility", func() {
 					entries := service.GenerateBillOfMaterials(
 						postal.Dependency{
-							CPE:          "some-cpe",
-							CPEs:         []string{"some-other-cpe"},
-							ID:           "some-entry",
-							Name:         "Some Entry",
-							SHA256:       "some-sha",
-							Source:       "some-source",
-							SourceSHA256: "some-source-sha",
-							Stacks:       []string{"some-stack"},
-							URI:          "some-uri",
-							Version:      "1.2.3",
+							CPE:            "some-cpe",
+							CPEs:           []string{"some-other-cpe"},
+							ID:             "some-entry",
+							Name:           "Some Entry",
+							Checksum:       "sha256:some-sha",
+							Source:         "some-source",
+							SourceChecksum: "sha256:some-source-sha",
+							Stacks:         []string{"some-stack"},
+							URI:            "some-uri",
+							Version:        "1.2.3",
 						},
 					)
 
@@ -1031,9 +1031,9 @@ version = "this is super not semver"
 						DeprecationDate: deprecationDate,
 						ID:              "some-entry",
 						Name:            "Some Entry",
-						SHA256:          "some-sha",
+						Checksum:        "sha256:some-sha",
 						Source:          "some-source",
-						SourceSHA256:    "some-source-sha",
+						SourceChecksum:  "sha256:some-source-sha",
 						Stacks:          []string{"some-stack"},
 						URI:             "some-uri",
 						Version:         "1.2.3",
@@ -1069,15 +1069,15 @@ version = "this is super not semver"
 			it("generates a BOM with the license information", func() {
 				entries := service.GenerateBillOfMaterials(
 					postal.Dependency{
-						ID:           "some-entry",
-						Licenses:     []string{"some-license"},
-						Name:         "Some Entry",
-						SHA256:       "some-sha",
-						Source:       "some-source",
-						SourceSHA256: "some-source-sha",
-						Stacks:       []string{"some-stack"},
-						URI:          "some-uri",
-						Version:      "1.2.3",
+						ID:             "some-entry",
+						Licenses:       []string{"some-license"},
+						Name:           "Some Entry",
+						Checksum:       "sha256:some-sha",
+						Source:         "some-source",
+						SourceChecksum: "sha256:some-source-sha",
+						Stacks:         []string{"some-stack"},
+						URI:            "some-uri",
+						Version:        "1.2.3",
 					},
 				)
 
@@ -1110,15 +1110,15 @@ version = "this is super not semver"
 			it("generates a BOM with the pURL", func() {
 				entries := service.GenerateBillOfMaterials(
 					postal.Dependency{
-						ID:           "some-entry",
-						Name:         "Some Entry",
-						PURL:         "some-purl",
-						SHA256:       "some-sha",
-						Source:       "some-source",
-						SourceSHA256: "some-source-sha",
-						Stacks:       []string{"some-stack"},
-						URI:          "some-uri",
-						Version:      "1.2.3",
+						ID:             "some-entry",
+						Name:           "Some Entry",
+						PURL:           "some-purl",
+						Checksum:       "sha256:some-sha",
+						Source:         "some-source",
+						SourceChecksum: "sha256:some-source-sha",
+						Stacks:         []string{"some-stack"},
+						URI:            "some-uri",
+						Version:        "1.2.3",
 					},
 				)
 
@@ -1135,6 +1135,123 @@ version = "this is super not semver"
 								Checksum: paketosbom.BOMChecksum{
 									Algorithm: paketosbom.SHA256,
 									Hash:      "some-source-sha",
+								},
+								URI: "some-source",
+							},
+
+							URI:     "some-uri",
+							Version: "1.2.3",
+						},
+					},
+				}))
+			})
+		})
+
+		context("when there is a SHA256 instead of Checksum", func() {
+			it("generates a BOM with the SHA256", func() {
+				entries := service.GenerateBillOfMaterials(
+					postal.Dependency{
+						ID:           "some-entry",
+						Name:         "Some Entry",
+						SHA256:       "some-sha",
+						Source:       "some-source",
+						SourceSHA256: "some-source-sha",
+						Stacks:       []string{"some-stack"},
+						URI:          "some-uri",
+						Version:      "1.2.3",
+					},
+				)
+
+				Expect(entries).To(Equal([]packit.BOMEntry{
+					{
+						Name: "Some Entry",
+						Metadata: paketosbom.BOMMetadata{
+							Checksum: paketosbom.BOMChecksum{
+								Algorithm: paketosbom.SHA256,
+								Hash:      "some-sha",
+							},
+							Source: paketosbom.BOMSource{
+								Checksum: paketosbom.BOMChecksum{
+									Algorithm: paketosbom.SHA256,
+									Hash:      "some-source-sha",
+								},
+								URI: "some-source",
+							},
+
+							URI:     "some-uri",
+							Version: "1.2.3",
+						},
+					},
+				}))
+			})
+		})
+
+		context("when there is a checksum and SHA256", func() {
+			it("generates a BOM with the checksum", func() {
+				entries := service.GenerateBillOfMaterials(
+					postal.Dependency{
+						ID:             "some-entry",
+						Name:           "Some Entry",
+						Checksum:       "sha512:checksum-sha",
+						SHA256:         "some-sha",
+						Source:         "some-source",
+						SourceChecksum: "sha512:source-checksum-sha",
+						SourceSHA256:   "some-source-sha",
+						Stacks:         []string{"some-stack"},
+						URI:            "some-uri",
+						Version:        "1.2.3",
+					},
+				)
+
+				Expect(entries).To(Equal([]packit.BOMEntry{
+					{
+						Name: "Some Entry",
+						Metadata: paketosbom.BOMMetadata{
+							Checksum: paketosbom.BOMChecksum{
+								Algorithm: paketosbom.SHA512,
+								Hash:      "checksum-sha",
+							},
+							Source: paketosbom.BOMSource{
+								Checksum: paketosbom.BOMChecksum{
+									Algorithm: paketosbom.SHA512,
+									Hash:      "source-checksum-sha",
+								},
+								URI: "some-source",
+							},
+
+							URI:     "some-uri",
+							Version: "1.2.3",
+						},
+					},
+				}))
+			})
+		})
+
+		context("when there is no checksum or SHA256", func() {
+			it("generates a BOM with the empty/unknown checksum", func() {
+				entries := service.GenerateBillOfMaterials(
+					postal.Dependency{
+						ID:      "some-entry",
+						Name:    "Some Entry",
+						Source:  "some-source",
+						Stacks:  []string{"some-stack"},
+						URI:     "some-uri",
+						Version: "1.2.3",
+					},
+				)
+
+				Expect(entries).To(Equal([]packit.BOMEntry{
+					{
+						Name: "Some Entry",
+						Metadata: paketosbom.BOMMetadata{
+							Checksum: paketosbom.BOMChecksum{
+								Algorithm: paketosbom.UNKNOWN,
+								Hash:      "",
+							},
+							Source: paketosbom.BOMSource{
+								Checksum: paketosbom.BOMChecksum{
+									Algorithm: paketosbom.UNKNOWN,
+									Hash:      "",
 								},
 								URI: "some-source",
 							},

--- a/sbom/sbom_test.go
+++ b/sbom/sbom_test.go
@@ -88,17 +88,17 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 	context("GenerateFromDependency", func() {
 		it("generates a SBOM from a dependency for latest schema versions", func() {
 			bom, err := sbom.GenerateFromDependency(postal.Dependency{
-				CPE:          "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
-				ID:           "go",
-				Licenses:     []string{"BSD-3-Clause"},
-				Name:         "Go",
-				PURL:         "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
-				Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
-				Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
-				URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
-				Version:      "1.16.9",
+				CPE:            "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
+				ID:             "go",
+				Licenses:       []string{"BSD-3-Clause"},
+				Name:           "Go",
+				PURL:           "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
+				Checksum:       "sha256:ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+				Source:         "https://dl.google.com/go/go1.16.9.src.tar.gz",
+				SourceChecksum: "sha256:0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+				Stacks:         []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+				URI:            "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+				Version:        "1.16.9",
 			}, "some-path")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -192,17 +192,17 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 
 		it("generates a SBOM from a dependency as syft2 JSON", func() {
 			bom, err := sbom.GenerateFromDependency(postal.Dependency{
-				CPE:          "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
-				ID:           "go",
-				Licenses:     []string{"BSD-3-Clause"},
-				Name:         "Go",
-				PURL:         "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
-				Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
-				Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
-				URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
-				Version:      "1.16.9",
+				CPE:            "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
+				ID:             "go",
+				Licenses:       []string{"BSD-3-Clause"},
+				Name:           "Go",
+				PURL:           "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
+				Checksum:       "sha256:ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+				Source:         "https://dl.google.com/go/go1.16.9.src.tar.gz",
+				SourceChecksum: "sha256:0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+				Stacks:         []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+				URI:            "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+				Version:        "1.16.9",
 			}, "some-path")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -238,17 +238,17 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 
 		it("generates a SBOM from a dependency in CycloneDX 1.4 JSON", func() {
 			bom, err := sbom.GenerateFromDependency(postal.Dependency{
-				CPE:          "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
-				ID:           "go",
-				Licenses:     []string{"BSD-3-Clause"},
-				Name:         "Go",
-				PURL:         "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
-				Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
-				SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
-				Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
-				URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
-				Version:      "1.16.9",
+				CPE:            "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
+				ID:             "go",
+				Licenses:       []string{"BSD-3-Clause"},
+				Name:           "Go",
+				PURL:           "pkg:generic/go@go1.16.9?checksum=0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d&download_url=https://dl.google.com/go/go1.16.9.src.tar.gz",
+				Checksum:       "sha256:ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+				Source:         "https://dl.google.com/go/go1.16.9.src.tar.gz",
+				SourceChecksum: "sha256:0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+				Stacks:         []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+				URI:            "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+				Version:        "1.16.9",
 			}, "some-path")
 			Expect(err).NotTo(HaveOccurred())
 
@@ -287,15 +287,15 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 		context("when the input dependency does not have a CPE or a PURL", func() {
 			it("succeeds in generating an SBOM without CPEs", func() {
 				bom, err := sbom.GenerateFromDependency(postal.Dependency{
-					ID:           "go",
-					Licenses:     []string{"BSD-3-Clause"},
-					Name:         "Go",
-					SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
-					Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
-					SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
-					Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
-					URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
-					Version:      "1.16.9",
+					ID:             "go",
+					Licenses:       []string{"BSD-3-Clause"},
+					Name:           "Go",
+					Checksum:       "sha256:ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+					Source:         "https://dl.google.com/go/go1.16.9.src.tar.gz",
+					SourceChecksum: "sha256:0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+					Stacks:         []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+					URI:            "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+					Version:        "1.16.9",
 				}, "some-path")
 				Expect(err).NotTo(HaveOccurred())
 
@@ -382,17 +382,17 @@ func testSBOM(t *testing.T, context spec.G, it spec.S) {
 		context("when the input dependency has CPEs and CPE", func() {
 			it("uses CPEs, not CPE", func() {
 				bom, err := sbom.GenerateFromDependency(postal.Dependency{
-					CPE:          "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
-					CPEs:         []string{"cpe:2.3:a:some:other:cpe:*:*:*:*:*:*:*", "cpe:2.3:a:another:cpe:to:include:*:*:*:*:*:*"},
-					ID:           "go",
-					Licenses:     []string{"BSD-3-Clause"},
-					Name:         "Go",
-					SHA256:       "ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
-					Source:       "https://dl.google.com/go/go1.16.9.src.tar.gz",
-					SourceSHA256: "0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
-					Stacks:       []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
-					URI:          "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
-					Version:      "1.16.9",
+					CPE:            "cpe:2.3:a:golang:go:1.16.9:*:*:*:*:*:*:*",
+					CPEs:           []string{"cpe:2.3:a:some:other:cpe:*:*:*:*:*:*:*", "cpe:2.3:a:another:cpe:to:include:*:*:*:*:*:*"},
+					ID:             "go",
+					Licenses:       []string{"BSD-3-Clause"},
+					Name:           "Go",
+					Checksum:       "sha256:ca9ef23a5db944b116102b87c1ae9344b27e011dae7157d2f1e501abd39e9829",
+					Source:         "https://dl.google.com/go/go1.16.9.src.tar.gz",
+					SourceChecksum: "sha256:0a1cc7fd7bd20448f71ebed64d846138850d5099b18cf5cc10a4fc45160d8c3d",
+					Stacks:         []string{"io.buildpacks.stacks.bionic", "io.paketo.stacks.tiny"},
+					URI:            "https://deps.paketo.io/go/go_go1.16.9_linux_x64_bionic_ca9ef23a.tgz",
+					Version:        "1.16.9",
 				}, "some-path")
 				Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Add support for the new `checksum` field in the legacy Paketo SBOM. 
If the value of the checksum is malformed (i.e. not in  format `algorithm`:`hash`), then the `algorithm` field will be set to `UNKNOWN`, and the `hash` value will be an empty string.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
