### PR TITLE
Add AreChecksumsEqual

### DIFF
--- a/cargo/are_checksums_equal.go
+++ b/cargo/are_checksums_equal.go
@@ -1,0 +1,27 @@
+package cargo
+
+import "strings"
+
+// AreChecksumsEqual returns true only when the given checksums match, including algorithm.
+// The algorithm is given the same way that "cargo.ConfigMetadataDependency".Checksum expects,
+// as "algorithm:checksum". Only exact equality is allowed, although algorithm is only checked
+// if present in both of the given checksums.
+func AreChecksumsEqual(c1, c2 string) bool {
+	var algorithm1, algorithm2 string
+	split1 := strings.Split(c1, ":")
+	if len(split1) == 2 {
+		algorithm1 = split1[0]
+		c1 = split1[1]
+	} else if len(split1) > 2 {
+		return false
+	}
+	split2 := strings.Split(c2, ":")
+	if len(split2) == 2 {
+		algorithm2 = split2[0]
+		c2 = split2[1]
+	}
+	areAlgorithmsEqual := func(a1, a2 string) bool {
+		return a1 == "" || a2 == "" || a1 == a2
+	}
+	return areAlgorithmsEqual(algorithm1, algorithm2) && c1 == c2
+}

--- a/cargo/are_checksums_equal_test.go
+++ b/cargo/are_checksums_equal_test.go
@@ -1,0 +1,46 @@
+package cargo_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+)
+
+func testAreChecksumsEqual(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+	)
+
+	context("AreChecksumsEqual", func() {
+		type testCaseType struct {
+			c1       string
+			c2       string
+			expected bool
+		}
+
+		for _, testCase := range []testCaseType{
+			{"", "", true},
+			{"c", "c", true},
+			{"c", "c", true},
+			{"sha256:c", "c", true},
+			{"c", "sha256:c", true},
+			{"md5:c", "md5:c", true},
+			{":", ":", true},
+			{":c", ":c", true},
+			{"", "c", false},
+			{"c", "", false},
+			{"c", "z", false},
+			{"md5:c", "sha256:c", false},
+			{"md5:c:d", "md5:c:d", false},
+			{"md5:c", "md5:c:d", false},
+			{":", "::", false},
+			{":", ":::", false},
+		} {
+			it("will check result", func() {
+				Expect(cargo.AreChecksumsEqual(testCase.c1, testCase.c2)).To(Equal(testCase.expected))
+			})
+		}
+	})
+}

--- a/cargo/init_test.go
+++ b/cargo/init_test.go
@@ -15,6 +15,7 @@ func TestUnitCargo(t *testing.T) {
 	suite("DirectoryDuplicator", testDirectoryDuplicator)
 	suite("Transport", testTransport)
 	suite("ValidatedReader", testValidatedReader)
+	suite("AreChecksumsEqual", testAreChecksumsEqual)
 	suite.Run(t)
 }
 


### PR DESCRIPTION
## Summary
Add `AreChecksumsEqual`... so that buildpack authors can see if the SHAs match, for example when checking whether a cached layer should be reused.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
