### PR TITLE
Draft: explore refactor of dependency resolution.

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -51,6 +51,7 @@ type ConfigMetadata struct {
 type ConfigMetadataDependency struct {
 	Checksum        string        `toml:"checksum"         json:"checksum,omitempty"`
 	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
+	CPEs            []string      `toml:"cpes"             json:"cpes,omitempty"`
 	PURL            string        `toml:"purl"             json:"purl,omitempty"`
 	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
 	ID              string        `toml:"id"               json:"id,omitempty"`

--- a/cargo/dependency_resolver.go
+++ b/cargo/dependency_resolver.go
@@ -1,0 +1,157 @@
+package cargo
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/Masterminds/semver/v3"
+)
+
+// ResolveDependency will pick the best matching dependency given a path to a
+// buildpack.toml file, and the id, version, and stack value of a dependency.
+// The version value is treated as a SemVer constraint and will pick the
+// version that matches that constraint best. If the version is given as
+// "default", the default version for the dependency with the given id will be
+// used. If there is no default version for that dependency, a wildcard
+// constraint will be used.
+func ResolveDependency(config Config, id, version, stack string) (ConfigMetadataDependency, error) {
+	if version == "" || version == "default" {
+		version = "*"
+		defaultVersion := config.Metadata.DefaultVersions[id]
+		if defaultVersion != "" {
+			version = defaultVersion
+		}
+	}
+
+	// Handle the pessmistic operator (~>)
+	var re = regexp.MustCompile(`~>`)
+	if re.MatchString(version) {
+		res := re.ReplaceAllString(version, "")
+		parts := strings.Split(res, ".")
+
+		// if the version contains a major, minor, and patch use "~" Tilde Range Comparison
+		// if the version contains a major and minor only, or a major version only use "^" Caret Range Comparison
+		if len(parts) == 3 {
+			version = "~" + res
+		} else {
+			version = "^" + res
+		}
+	}
+
+	versionConstraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return ConfigMetadataDependency{}, err
+	}
+
+	var compatibleVersions []ConfigMetadataDependency
+	var supportedVersions []string
+	for _, dependency := range config.Metadata.Dependencies {
+		if dependency.ID != id {
+			continue
+		}
+
+		if !(dependency.HasStack(stack) || dependency.HasStack("*")) {
+			continue
+		}
+
+		sVersion, err := semver.NewVersion(dependency.Version)
+		if err != nil {
+			return ConfigMetadataDependency{}, err
+		}
+
+		if versionConstraint.Check(sVersion) {
+			compatibleVersions = append(compatibleVersions, dependency)
+		}
+
+		supportedVersions = append(supportedVersions, dependency.Version)
+	}
+
+	if len(compatibleVersions) == 0 {
+		return ConfigMetadataDependency{}, fmt.Errorf(
+			"failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
+			id,
+			version,
+			stack,
+			strings.Join(supportedVersions, ", "),
+		)
+	}
+
+	stacksForVersion := map[string][]string{}
+
+	for _, dep := range compatibleVersions {
+		stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
+	}
+
+	for version, stacks := range stacksForVersion {
+		count := stringSliceElementCount(stacks, "*")
+		if count > 1 {
+			return ConfigMetadataDependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
+		}
+	}
+
+	sort.Slice(compatibleVersions, func(i, j int) bool {
+		iDep := compatibleVersions[i]
+		jDep := compatibleVersions[j]
+
+		jVersion := semver.MustParse(jDep.Version)
+		iVersion := semver.MustParse(iDep.Version)
+
+		if !iVersion.Equal(jVersion) {
+			return iVersion.GreaterThan(jVersion)
+		}
+
+		iStacks := iDep.Stacks
+		jStacks := jDep.Stacks
+
+		// If either dependency supports the wildcard stack, it has lower
+		// priority than a dependency that only supports a more specific stack.
+		// This is true regardless of whether or not the dependency with
+		// wildcard stack support also supports other stacks
+		//
+		// If is an error to have multiple dependencies with the same version
+		// and wildcard stack support.
+		// This is tested for above, and we would not enter this sort function
+		// in this case
+
+		if stringSliceContains(iStacks, "*") {
+			return false
+		}
+
+		if stringSliceContains(jStacks, "*") {
+			return true
+		}
+
+		// As mentioned above, this isn't a valid path to encounter because
+		// only one dependency may have support for wildcard stacks for a given
+		// version. We could panic, but it is preferable to return an invalid
+		// sort order instead.
+		//
+		// This is untested as this path is not possible to encounter.
+		return true
+	})
+
+	return compatibleVersions[0], nil
+}
+
+func stringSliceElementCount(slice []string, str string) int {
+	count := 0
+	for _, s := range slice {
+		if s == str {
+			count++
+		}
+	}
+
+	return count
+}
+
+func stringSliceContains(slice []string, str string) bool {
+	for _, s := range slice {
+		if s == str {
+			return true
+		}
+	}
+
+	return false
+}

--- a/cargo/dependency_resolver_test.go
+++ b/cargo/dependency_resolver_test.go
@@ -1,0 +1,278 @@
+package cargo_test
+
+import (
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testDependencyResolver(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		config cargo.Config
+	)
+
+	it.Before(func() {
+		config = cargo.Config{
+			Metadata: cargo.ConfigMetadata{
+				Dependencies: []cargo.ConfigMetadataDependency{
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-1"},
+						Version: "1.2.2",
+					},
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-1"},
+						Version: "1.2.3",
+					},
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-1"},
+						Version: "2.3.4",
+					},
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-2"},
+						Version: "1.2.3",
+					},
+					{
+						ID:      "some-ignored-dependency",
+						Stacks:  []string{"some-ignored-stack"},
+						Version: "1.3.0",
+					},
+					{
+						ID:      "dependency-B",
+						Stacks:  []string{"stack-1"},
+						Version: "1.2.4",
+					},
+					{
+						ID:      "dependency-B",
+						Stacks:  []string{"*"},
+						Version: "2.3.4",
+					},
+				},
+			},
+		}
+	})
+
+	it("finds the exact matching dependency", func() {
+		dependency, err := cargo.ResolveDependency(config, "dependency-A", "1.2.2", "stack-1")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+			ID:      "dependency-A",
+			Stacks:  []string{"stack-1"},
+			Version: "1.2.2",
+		}))
+	})
+
+	context("when the dependency has a wildcard stack", func() {
+		it("finds the highest matching version across all stack ids", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-B", "*", "unrecognized-stack")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-B",
+				Stacks:  []string{"*"},
+				Version: "2.3.4",
+			}))
+		})
+	})
+
+	context("when the dependency version is empty", func() {
+		it("picks the dependency with the highest semantic version number", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "2.3.4",
+			}))
+		})
+	})
+
+	context("when the entry version is 'default'", func() {
+		it("picks the dependency with the highest semantic version number", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "default", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "2.3.4",
+			}))
+		})
+	})
+
+	context("when there is a version with a major, minor, patch, and pessimistic operator (~>)", func() {
+		it("picks the dependency >= version and < major.minor+1", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "~> 1.2.0", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "1.2.3",
+			}))
+		})
+	})
+
+	context("when there is a version with a major, minor, and pessimistic operator (~>)", func() {
+		it("picks the dependency >= version and < major+1", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "~> 1.1", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "1.2.3",
+			}))
+		})
+	})
+
+	context("when there is a version with a major line only and pessimistic operator (~>)", func() {
+		it("picks the dependency >= version.0.0 and < major+1.0.0", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "~> 1", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "1.2.3",
+			}))
+		})
+	})
+
+	context("when there is a default version in the config", func() {
+		it.Before(func() {
+			config.Metadata.DefaultVersions = map[string]string{"dependency-A": "1.2.x"}
+		})
+
+		context("when the dependency version is empty", func() {
+			it("picks the highest-versioned dependency that matches the default version", func() {
+				dependency, err := cargo.ResolveDependency(config, "dependency-A", "", "stack-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1"},
+					Version: "1.2.3",
+				}))
+			})
+		})
+
+		context("when the dependency version is 'default'", func() {
+			it("picks the highest-versioned dependency that matches the default version", func() {
+				dependency, err := cargo.ResolveDependency(config, "dependency-A", "default", "stack-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1"},
+					Version: "1.2.3",
+				}))
+			})
+		})
+
+		context("when the dependency version is provided", func() {
+			it("picks the dependency that best matches the provided version instead of the default", func() {
+				dependency, err := cargo.ResolveDependency(config, "dependency-A", "2.*", "stack-1")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1"},
+					Version: "2.3.4",
+				}))
+			})
+		})
+	})
+
+	context("when both a wildcard stack constraint and a specific stack constraint exist for the same dependency version", func() {
+		it.Before(func() {
+			config.Metadata.Dependencies = []cargo.ConfigMetadataDependency{
+				{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1"},
+					Version: "1.2.1",
+				},
+				{
+					ID:      "dependency-A",
+					Stacks:  []string{"*"},
+					Version: "1.2.1",
+				},
+				{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1", "*"},
+					Version: "1.2.3",
+				},
+				{
+					ID:      "dependency-A",
+					Stacks:  []string{"stack-1"},
+					Version: "1.2.3",
+				},
+			}
+		})
+
+		it("selects the more specific stack constraint", func() {
+			dependency, err := cargo.ResolveDependency(config, "dependency-A", "*", "stack-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(cargo.ConfigMetadataDependency{
+				ID:      "dependency-A",
+				Stacks:  []string{"stack-1"},
+				Version: "1.2.3",
+			}))
+		})
+	})
+
+	context("failure cases", func() {
+		context("when the entry version constraint is not valid", func() {
+			it("returns an error", func() {
+				_, err := cargo.ResolveDependency(config, "dependency-A", "this-is-not-semver", "stack-1")
+				Expect(err).To(MatchError(ContainSubstring("improper constraint")))
+			})
+		})
+
+		context("when the dependency version is not valid", func() {
+			it.Before(func() {
+				config.Metadata.Dependencies = []cargo.ConfigMetadataDependency{
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-1"},
+						Version: "not semver",
+					},
+				}
+			})
+
+			it("returns an error", func() {
+				_, err := cargo.ResolveDependency(config, "dependency-A", "1.2.3", "stack-1")
+				Expect(err).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+			})
+		})
+
+		context("when multiple dependencies have a wildcard stack for the same version", func() {
+			it.Before(func() {
+				config.Metadata.Dependencies = []cargo.ConfigMetadataDependency{
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-1", "*"},
+						Version: "1.2.3",
+					},
+					{
+						ID:      "dependency-A",
+						Stacks:  []string{"stack-2", "*"},
+						Version: "1.2.3",
+					},
+				}
+			})
+
+			it("returns an error", func() {
+				_, err := cargo.ResolveDependency(config, "dependency-A", "1.2.3", "stack-1")
+				Expect(err).To(MatchError(ContainSubstring(`multiple dependencies support wildcard stack for version: "1.2.3"`)))
+			})
+		})
+
+		context("when the entry version constraint cannot be satisfied", func() {
+			it("returns an error with all the supported versions listed", func() {
+				_, err := cargo.ResolveDependency(config, "dependency-A", "9.9.9", "stack-1")
+				Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"dependency-A\" dependency version constraint \"9.9.9\": no compatible versions on \"stack-1\" stack. Supported versions are: [1.2.2, 1.2.3, 2.3.4]")))
+			})
+		})
+	})
+}

--- a/cargo/init_test.go
+++ b/cargo/init_test.go
@@ -12,6 +12,7 @@ func TestUnitCargo(t *testing.T) {
 	suite := spec.New("cargo", spec.Report(report.Terminal{}))
 	suite("BuildpackParser", testBuildpackParser)
 	suite("Config", testConfig)
+	suite("DependencyResolver", testDependencyResolver)
 	suite("DirectoryDuplicator", testDirectoryDuplicator)
 	suite("Transport", testTransport)
 	suite("ValidatedReader", testValidatedReader)

--- a/postal/service.go
+++ b/postal/service.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"regexp"
-	"sort"
-	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/postal/internal"
@@ -66,148 +62,20 @@ func (s Service) WithDependencyMappingResolver(mappingResolver MappingResolver) 
 // "default", the default version for the dependency with the given id will be
 // used. If there is no default version for that dependency, a wildcard
 // constraint will be used.
+//
+// Deprecated: use cargo.ResolveDependency instead.
 func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
-	dependencies, defaultVersion, err := parseBuildpack(path, id)
+	config, err := cargo.NewBuildpackParser().Parse(path)
+	if err != nil {
+		return Dependency{}, fmt.Errorf("failed to parse buildpack.toml: %w", err)
+	}
+
+	dep, err := cargo.ResolveDependency(config, id, version, stack)
 	if err != nil {
 		return Dependency{}, err
 	}
 
-	if version == "" {
-		version = "default"
-	}
-
-	if version == "default" {
-		version = "*"
-		if defaultVersion != "" {
-			version = defaultVersion
-		}
-	}
-
-	// Handle the pessmistic operator (~>)
-	var re = regexp.MustCompile(`~>`)
-	if re.MatchString(version) {
-		res := re.ReplaceAllString(version, "")
-		parts := strings.Split(res, ".")
-
-		// if the version contains a major, minor, and patch use "~" Tilde Range Comparison
-		// if the version contains a major and minor only, or a major version only use "^" Caret Range Comparison
-		if len(parts) == 3 {
-			version = "~" + res
-		} else {
-			version = "^" + res
-		}
-	}
-
-	var compatibleVersions []Dependency
-	versionConstraint, err := semver.NewConstraint(version)
-	if err != nil {
-		return Dependency{}, err
-	}
-
-	var supportedVersions []string
-	for _, dependency := range dependencies {
-		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) {
-			continue
-		}
-
-		sVersion, err := semver.NewVersion(dependency.Version)
-		if err != nil {
-			return Dependency{}, err
-		}
-
-		if versionConstraint.Check(sVersion) {
-			compatibleVersions = append(compatibleVersions, dependency)
-		}
-
-		supportedVersions = append(supportedVersions, dependency.Version)
-	}
-
-	if len(compatibleVersions) == 0 {
-		return Dependency{}, fmt.Errorf(
-			"failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
-			id,
-			version,
-			stack,
-			strings.Join(supportedVersions, ", "),
-		)
-	}
-
-	stacksForVersion := map[string][]string{}
-
-	for _, dep := range compatibleVersions {
-		stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
-	}
-
-	for version, stacks := range stacksForVersion {
-		count := stringSliceElementCount(stacks, "*")
-		if count > 1 {
-			return Dependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
-		}
-	}
-
-	sort.Slice(compatibleVersions, func(i, j int) bool {
-		iDep := compatibleVersions[i]
-		jDep := compatibleVersions[j]
-
-		jVersion := semver.MustParse(jDep.Version)
-		iVersion := semver.MustParse(iDep.Version)
-
-		if !iVersion.Equal(jVersion) {
-			return iVersion.GreaterThan(jVersion)
-		}
-
-		iStacks := iDep.Stacks
-		jStacks := jDep.Stacks
-
-		// If either dependency supports the wildcard stack, it has lower
-		// priority than a dependency that only supports a more specific stack.
-		// This is true regardless of whether or not the dependency with
-		// wildcard stack support also supports other stacks
-		//
-		// If is an error to have multiple dependencies with the same version
-		// and wildcard stack support.
-		// This is tested for above, and we would not enter this sort function
-		// in this case
-
-		if stringSliceContains(iStacks, "*") {
-			return false
-		}
-
-		if stringSliceContains(jStacks, "*") {
-			return true
-		}
-
-		// As mentioned above, this isn't a valid path to encounter because
-		// only one dependency may have support for wildcard stacks for a given
-		// version. We could panic, but it is preferable to return an invalid
-		// sort order instead.
-		//
-		// This is untested as this path is not possible to encounter.
-		return true
-	})
-
-	return compatibleVersions[0], nil
-}
-
-func stringSliceContains(slice []string, str string) bool {
-	for _, s := range slice {
-		if s == str {
-			return true
-		}
-	}
-
-	return false
-}
-
-func stringSliceElementCount(slice []string, str string) int {
-	count := 0
-	for _, s := range slice {
-		if s == str {
-			count++
-		}
-	}
-
-	return count
+	return DependencyFrom(dep), nil
 }
 
 // Deliver will fetch and expand a dependency into a layer path location. The
@@ -217,7 +85,7 @@ func stringSliceElementCount(slice []string, str string) int {
 // the given dependency mapping URI to fetch the dependency. The dependency is
 // validated against the checksum value provided on the Dependency and will
 // error if there are inconsistencies in the fetched result.
-func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath string) error {
+func (s Service) DeliverDependency(dependency cargo.ConfigMetadataDependency, cnbPath, layerPath, platformPath string) error {
 	dependencyMappingURI, err := s.mappingResolver.FindDependencyMapping(dependency.SHA256, platformPath)
 	if err != nil {
 		return fmt.Errorf("failure checking for dependency mappings: %s", err)
@@ -259,6 +127,19 @@ func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath
 	}
 
 	return nil
+}
+
+// Deliver will fetch and expand a dependency into a layer path location. The
+// location of the CNBPath is given so that dependencies that may be included
+// in a buildpack when packaged for offline consumption can be retrieved. If
+// there is a dependency mapping for the specified dependency, Deliver will use
+// the given dependency mapping URI to fetch the dependency. The dependency is
+// validated against the checksum value provided on the Dependency and will
+// error if there are inconsistencies in the fetched result.
+//
+// Deprecated: use DeliverDependency instead
+func (s Service) Deliver(dependency Dependency, cnbPath, layerPath, platformPath string) error {
+	return s.DeliverDependency(cargoDependencyFrom(dependency), cnbPath, layerPath, platformPath)
 }
 
 // GenerateBillOfMaterials will generate a list of BOMEntry values given a


### PR DESCRIPTION
## Summary

This is an initial exploration into #387 .

I don't love the direction that this is going in.

In replacing `postal.Dependency` with `cargo.ConfigMetadataDependency` it is becoming clear that `postal.Dependency` is the default type used in other parts of `packit` beyond `postal`. Specifically, it is used in `sbom` and `scribe` packages.

Deprecating `postal.Dependency` in a non-breaking manner requires us to create shadow methods and functions that take the replacement `cargo.ConfigMetadataDependency` type, which also requires us to identify new names for all these functions and methods. I've implemented this renaming for the `postal` package, but I did not continue to do this for the `sbom` and `scribe` packages.

Additionally, while the long type name of `cargo.ConfigMetadataDependency` makes sense within the `cargo` package, as it is parsing the buildpack config, it feels like a clumsy type to be passing around everywhere.

I think I will create another PR which just extracts `postal.Service.Resolve()` into `postal.ResolveDependency()` without deprecating the `postal.Dependency` type.

An example consumer of this refactor in its current state can be found in: https://github.com/paketo-buildpacks/cpython/pull/432

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
