### PR TITLE
WIP: explore refactor of dependency resolution (simple).

### DIFF
--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -3,9 +3,13 @@ package postal
 import (
 	"fmt"
 	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/BurntSushi/toml"
+	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 )
 
@@ -103,4 +107,135 @@ func stacksInclude(stacks []string, stack string) bool {
 		}
 	}
 	return false
+}
+
+// Resolve will pick the best matching dependency given a path to a
+// buildpack.toml file, and the id, version, and stack value of a dependency.
+// The version value is treated as a SemVer constraint and will pick the
+// version that matches that constraint best. If the version is given as
+// "default", the default version for the dependency with the given id will be
+// used. If there is no default version for that dependency, a wildcard
+// constraint will be used.
+func ResolveDependency(path, id, version, stack string) (Dependency, error) {
+	dependencies, defaultVersion, err := parseBuildpack(path, id)
+	if err != nil {
+		return Dependency{}, err
+	}
+
+	if version == "" {
+		version = "default"
+	}
+
+	if version == "default" {
+		version = "*"
+		if defaultVersion != "" {
+			version = defaultVersion
+		}
+	}
+
+	// Handle the pessmistic operator (~>)
+	var re = regexp.MustCompile(`~>`)
+	if re.MatchString(version) {
+		res := re.ReplaceAllString(version, "")
+		parts := strings.Split(res, ".")
+
+		// if the version contains a major, minor, and patch use "~" Tilde Range Comparison
+		// if the version contains a major and minor only, or a major version only use "^" Caret Range Comparison
+		if len(parts) == 3 {
+			version = "~" + res
+		} else {
+			version = "^" + res
+		}
+	}
+
+	var compatibleVersions []Dependency
+	versionConstraint, err := semver.NewConstraint(version)
+	if err != nil {
+		return Dependency{}, err
+	}
+
+	var supportedVersions []string
+	for _, dependency := range dependencies {
+		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) {
+			continue
+		}
+
+		sVersion, err := semver.NewVersion(dependency.Version)
+		if err != nil {
+			return Dependency{}, err
+		}
+
+		if versionConstraint.Check(sVersion) {
+			compatibleVersions = append(compatibleVersions, dependency)
+		}
+
+		supportedVersions = append(supportedVersions, dependency.Version)
+	}
+
+	if len(compatibleVersions) == 0 {
+		return Dependency{}, fmt.Errorf(
+			"failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
+			id,
+			version,
+			stack,
+			strings.Join(supportedVersions, ", "),
+		)
+	}
+
+	stacksForVersion := map[string][]string{}
+
+	for _, dep := range compatibleVersions {
+		stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
+	}
+
+	for version, stacks := range stacksForVersion {
+		count := stringSliceElementCount(stacks, "*")
+		if count > 1 {
+			return Dependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
+		}
+	}
+
+	sort.Slice(compatibleVersions, func(i, j int) bool {
+		iDep := compatibleVersions[i]
+		jDep := compatibleVersions[j]
+
+		jVersion := semver.MustParse(jDep.Version)
+		iVersion := semver.MustParse(iDep.Version)
+
+		if !iVersion.Equal(jVersion) {
+			return iVersion.GreaterThan(jVersion)
+		}
+
+		iStacks := iDep.Stacks
+		jStacks := jDep.Stacks
+
+		// If either dependency supports the wildcard stack, it has lower
+		// priority than a dependency that only supports a more specific stack.
+		// This is true regardless of whether or not the dependency with
+		// wildcard stack support also supports other stacks
+		//
+		// If is an error to have multiple dependencies with the same version
+		// and wildcard stack support.
+		// This is tested for above, and we would not enter this sort function
+		// in this case
+
+		if stringSliceContains(iStacks, "*") {
+			return false
+		}
+
+		if stringSliceContains(jStacks, "*") {
+			return true
+		}
+
+		// As mentioned above, this isn't a valid path to encounter because
+		// only one dependency may have support for wildcard stacks for a given
+		// version. We could panic, but it is preferable to return an invalid
+		// sort order instead.
+		//
+		// This is untested as this path is not possible to encounter.
+		return true
+	})
+
+	return compatibleVersions[0], nil
+
 }

--- a/postal/buildpack_test.go
+++ b/postal/buildpack_test.go
@@ -1,0 +1,401 @@
+package postal_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/packit/v2/postal"
+	"github.com/sclevine/spec"
+)
+
+func testBuildpack(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		path string
+	)
+
+	it.Before(func() {
+		file, err := os.CreateTemp("", "buildpack.toml")
+		Expect(err).NotTo(HaveOccurred())
+
+		path = file.Name()
+		_, err = file.WriteString(`
+[[metadata.dependencies]]
+deprecation_date = 2022-04-01T00:00:00Z
+cpe = "some-cpe"
+cpes = ["some-cpe", "other-cpe"]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "1.2.3"
+
+[[metadata.dependencies]]
+id = "some-other-entry"
+cpes = ["some-cpe", "other-cpe"]
+sha256 = "some-other-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "1.2.4"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["other-stack"]
+uri = "some-uri"
+version = "1.2.5"
+
+[[metadata.dependencies]]
+id = "some-random-entry"
+cpe = "some-cpe"
+cpes = ["some-cpe", "other-cpe"]
+sha256 = "some-random-sha"
+stacks = ["other-random-stack"]
+uri = "some-uri"
+version = "1.3.0"
+
+[[metadata.dependencies]]
+id = "some-random-other-entry"
+sha256 = "some-random-other-sha"
+stacks = ["some-other-random-stack"]
+uri = "some-uri"
+version = "2.0.0"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "4.5.6"
+strip-components = 1
+
+[[metadata.dependencies]]
+id = "some-other-entry"
+sha256 = "some-sha"
+stacks = ["*"]
+uri = "some-uri"
+version = "4.5.6"
+strip-components = 1
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(file.Close()).To(Succeed())
+	})
+
+	it("finds the best matching dependency given a plan entry", func() {
+		deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+		Expect(err).NotTo(HaveOccurred())
+
+		dependency, err := postal.ResolveDependency(path, "some-entry", "1.2.*", "some-stack")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dependency).To(Equal(postal.Dependency{
+			CPE:             "some-cpe",
+			CPEs:            []string{"some-cpe", "other-cpe"},
+			DeprecationDate: deprecationDate,
+			ID:              "some-entry",
+			Stacks:          []string{"some-stack"},
+			URI:             "some-uri",
+			SHA256:          "some-sha",
+			Version:         "1.2.3",
+		}))
+	})
+
+	context("when the dependency has a wildcard stack", func() {
+		it("is compatible with all stack ids", func() {
+			dependency, err := postal.ResolveDependency(path, "some-other-entry", "", "random-stack")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(postal.Dependency{
+				ID:              "some-other-entry",
+				Stacks:          []string{"*"},
+				URI:             "some-uri",
+				SHA256:          "some-sha",
+				Version:         "4.5.6",
+				StripComponents: 1,
+			}))
+		})
+	})
+
+	context("when there is NOT a default version", func() {
+		context("when the entry version is empty", func() {
+			it("picks the dependency with the highest semantic version number", func() {
+				dependency, err := postal.ResolveDependency(path, "some-entry", "", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:              "some-entry",
+					Stacks:          []string{"some-stack"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "4.5.6",
+					StripComponents: 1,
+				}))
+			})
+		})
+
+		context("when the entry version is default", func() {
+			it("picks the dependency with the highest semantic version number", func() {
+				dependency, err := postal.ResolveDependency(path, "some-entry", "default", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:              "some-entry",
+					Stacks:          []string{"some-stack"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "4.5.6",
+					StripComponents: 1,
+				}))
+			})
+		})
+
+		context("when there is a version with a major, minor, patch, and pessimistic operator (~>)", func() {
+			it("picks the dependency >= version and < major.minor+1", func() {
+				deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+				Expect(err).NotTo(HaveOccurred())
+
+				dependency, err := postal.ResolveDependency(path, "some-entry", "~> 1.2.0", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					DeprecationDate: deprecationDate,
+					CPE:             "some-cpe",
+					CPEs:            []string{"some-cpe", "other-cpe"},
+					ID:              "some-entry",
+					Stacks:          []string{"some-stack"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "1.2.3",
+				}))
+			})
+		})
+
+		context("when there is a version with a major, minor, and pessimistic operator (~>)", func() {
+			it("picks the dependency >= version and < major+1", func() {
+				deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+				Expect(err).NotTo(HaveOccurred())
+
+				dependency, err := postal.ResolveDependency(path, "some-entry", "~> 1.1", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					CPE:             "some-cpe",
+					CPEs:            []string{"some-cpe", "other-cpe"},
+					DeprecationDate: deprecationDate,
+					ID:              "some-entry",
+					Stacks:          []string{"some-stack"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "1.2.3",
+				}))
+			})
+		})
+
+		context("when there is a version with a major line only and pessimistic operator (~>)", func() {
+			it("picks the dependency >= version.0.0 and < major+1.0.0", func() {
+				deprecationDate, err := time.Parse(time.RFC3339, "2022-04-01T00:00:00Z")
+				Expect(err).NotTo(HaveOccurred())
+
+				dependency, err := postal.ResolveDependency(path, "some-entry", "~> 1", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					CPE:             "some-cpe",
+					CPEs:            []string{"some-cpe", "other-cpe"},
+					DeprecationDate: deprecationDate,
+					ID:              "some-entry",
+					Stacks:          []string{"some-stack"},
+					URI:             "some-uri",
+					SHA256:          "some-sha",
+					Version:         "1.2.3",
+				}))
+			})
+		})
+	})
+
+	context("when there is a default version", func() {
+		it.Before(func() {
+			err := os.WriteFile(path, []byte(`
+[metadata]
+[metadata.default-versions]
+some-entry = "1.2.x"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "1.2.3"
+
+[[metadata.dependencies]]
+id = "some-other-entry"
+sha256 = "some-other-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "1.2.4"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["other-stack"]
+uri = "some-uri"
+version = "1.2.5"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "4.5.6"
+`), 0600)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		context("when the entry version is empty", func() {
+			it("picks the dependency that best matches the default version", func() {
+				dependency, err := postal.ResolveDependency(path, "some-entry", "", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:      "some-entry",
+					Stacks:  []string{"some-stack"},
+					URI:     "some-uri",
+					SHA256:  "some-sha",
+					Version: "1.2.3",
+				}))
+			})
+		})
+
+		context("when the entry version is default", func() {
+			it("picks the dependency that best matches the default version", func() {
+				dependency, err := postal.ResolveDependency(path, "some-entry", "default", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:      "some-entry",
+					Stacks:  []string{"some-stack"},
+					URI:     "some-uri",
+					SHA256:  "some-sha",
+					Version: "1.2.3",
+				}))
+			})
+		})
+	})
+
+	context("when both a wildcard stack constraint and a specific stack constraint exist for the same dependency version", func() {
+		it.Before(func() {
+			err := os.WriteFile(path, []byte(`
+[metadata]
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri-specific-stack"
+version = "1.2.1"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["*"]
+uri = "some-uri-only-wildcard"
+version = "1.2.1"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack","*"]
+uri = "some-uri-only-wildcard"
+version = "1.2.3"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri-specific-stack"
+version = "1.2.3"
+`), 0600)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it("selects the more specific stack constraint", func() {
+			dependency, err := postal.ResolveDependency(path, "some-entry", "*", "some-stack")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dependency).To(Equal(postal.Dependency{
+				ID:      "some-entry",
+				Stacks:  []string{"some-stack"},
+				URI:     "some-uri-specific-stack",
+				SHA256:  "some-sha",
+				Version: "1.2.3",
+			}))
+		})
+	})
+
+	context("failure cases", func() {
+		context("when the buildpack.toml is malformed", func() {
+			it.Before(func() {
+				err := os.WriteFile(path, []byte("this is not toml"), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns an error", func() {
+				_, err := postal.ResolveDependency(path, "some-entry", "1.2.3", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring("failed to parse buildpack.toml")))
+			})
+		})
+
+		context("when the entry version constraint is not valid", func() {
+			it("returns an error", func() {
+				_, err := postal.ResolveDependency(path, "some-entry", "this-is-not-semver", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring("improper constraint")))
+			})
+		})
+
+		context("when the dependency version is not valid", func() {
+			it.Before(func() {
+				err := os.WriteFile(path, []byte(`
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha"
+stacks = ["some-stack"]
+uri = "some-uri"
+version = "this is super not semver"
+`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns an error", func() {
+				_, err := postal.ResolveDependency(path, "some-entry", "1.2.3", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring("Invalid Semantic Version")))
+			})
+		})
+
+		context("when multiple dependencies have a wildcard stack for the same version", func() {
+			it.Before(func() {
+				err := os.WriteFile(path, []byte(`
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha-A"
+stacks = ["some-stack","*"]
+uri = "some-uri-A"
+version = "1.2.3"
+
+[[metadata.dependencies]]
+id = "some-entry"
+sha256 = "some-sha-B"
+stacks = ["some-stack","some-other-stack","*"]
+uri = "some-uri-B"
+version = "1.2.3"
+`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("returns an error", func() {
+				_, err := postal.ResolveDependency(path, "some-entry", "1.2.3", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring(`multiple dependencies support wildcard stack for version: "1.2.3"`)))
+			})
+		})
+
+		context("when the entry version constraint cannot be satisfied", func() {
+			it("returns an error with all the supported versions listed", func() {
+				_, err := postal.ResolveDependency(path, "some-entry", "9.9.9", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-stack\" stack. Supported versions are: [1.2.3, 4.5.6]")))
+			})
+		})
+	})
+}

--- a/postal/init_test.go
+++ b/postal/init_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestUnitPostal(t *testing.T) {
 	suite := spec.New("packit/postal", spec.Report(report.Terminal{}))
+	suite("Buildpack", testBuildpack)
 	suite("Service", testService)
 
 	suite.Run(t)

--- a/postal/service.go
+++ b/postal/service.go
@@ -5,12 +5,8 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"regexp"
-	"sort"
-	"strings"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/postal/internal"
@@ -66,127 +62,10 @@ func (s Service) WithDependencyMappingResolver(mappingResolver MappingResolver) 
 // "default", the default version for the dependency with the given id will be
 // used. If there is no default version for that dependency, a wildcard
 // constraint will be used.
+//
+// Deprecated: use postal.ResolveDependency insted
 func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
-	dependencies, defaultVersion, err := parseBuildpack(path, id)
-	if err != nil {
-		return Dependency{}, err
-	}
-
-	if version == "" {
-		version = "default"
-	}
-
-	if version == "default" {
-		version = "*"
-		if defaultVersion != "" {
-			version = defaultVersion
-		}
-	}
-
-	// Handle the pessmistic operator (~>)
-	var re = regexp.MustCompile(`~>`)
-	if re.MatchString(version) {
-		res := re.ReplaceAllString(version, "")
-		parts := strings.Split(res, ".")
-
-		// if the version contains a major, minor, and patch use "~" Tilde Range Comparison
-		// if the version contains a major and minor only, or a major version only use "^" Caret Range Comparison
-		if len(parts) == 3 {
-			version = "~" + res
-		} else {
-			version = "^" + res
-		}
-	}
-
-	var compatibleVersions []Dependency
-	versionConstraint, err := semver.NewConstraint(version)
-	if err != nil {
-		return Dependency{}, err
-	}
-
-	var supportedVersions []string
-	for _, dependency := range dependencies {
-		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) {
-			continue
-		}
-
-		sVersion, err := semver.NewVersion(dependency.Version)
-		if err != nil {
-			return Dependency{}, err
-		}
-
-		if versionConstraint.Check(sVersion) {
-			compatibleVersions = append(compatibleVersions, dependency)
-		}
-
-		supportedVersions = append(supportedVersions, dependency.Version)
-	}
-
-	if len(compatibleVersions) == 0 {
-		return Dependency{}, fmt.Errorf(
-			"failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
-			id,
-			version,
-			stack,
-			strings.Join(supportedVersions, ", "),
-		)
-	}
-
-	stacksForVersion := map[string][]string{}
-
-	for _, dep := range compatibleVersions {
-		stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
-	}
-
-	for version, stacks := range stacksForVersion {
-		count := stringSliceElementCount(stacks, "*")
-		if count > 1 {
-			return Dependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
-		}
-	}
-
-	sort.Slice(compatibleVersions, func(i, j int) bool {
-		iDep := compatibleVersions[i]
-		jDep := compatibleVersions[j]
-
-		jVersion := semver.MustParse(jDep.Version)
-		iVersion := semver.MustParse(iDep.Version)
-
-		if !iVersion.Equal(jVersion) {
-			return iVersion.GreaterThan(jVersion)
-		}
-
-		iStacks := iDep.Stacks
-		jStacks := jDep.Stacks
-
-		// If either dependency supports the wildcard stack, it has lower
-		// priority than a dependency that only supports a more specific stack.
-		// This is true regardless of whether or not the dependency with
-		// wildcard stack support also supports other stacks
-		//
-		// If is an error to have multiple dependencies with the same version
-		// and wildcard stack support.
-		// This is tested for above, and we would not enter this sort function
-		// in this case
-
-		if stringSliceContains(iStacks, "*") {
-			return false
-		}
-
-		if stringSliceContains(jStacks, "*") {
-			return true
-		}
-
-		// As mentioned above, this isn't a valid path to encounter because
-		// only one dependency may have support for wildcard stacks for a given
-		// version. We could panic, but it is preferable to return an invalid
-		// sort order instead.
-		//
-		// This is untested as this path is not possible to encounter.
-		return true
-	})
-
-	return compatibleVersions[0], nil
+	return ResolveDependency(path, id, version, stack)
 }
 
 func stringSliceContains(slice []string, str string) bool {


### PR DESCRIPTION
## Summary

This PR is another implementation of #387 

This is much simpler, as it avoids deprecating the `postal.Dependency` type.

However, there are a couple of downsides to this simplicity:
* It introduces a new exported method on the `postal` package, which in turn will have to be deprecated if we choose to pursue a refactor that ultimately leverages the `cargo.ConfigMetadataDependency` type instead of the `postal.Dependency` type. This leads to more dead code, not less.
* It does nothing to address the duplication of `Dependency` types in `cargo` and `postal` or the proliferation of `postal.Dependency` throughout the various packages (e.g. `sbom`, `scribe`).

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
