### PR TITLE
Enable support for checksum in postal dependency mappings

### DIFF
--- a/postal/fakes/mapping_resolver.go
+++ b/postal/fakes/mapping_resolver.go
@@ -7,7 +7,7 @@ type MappingResolver struct {
 		mutex     sync.Mutex
 		CallCount int
 		Receives  struct {
-			SHA256      string
+			Checksum    string
 			PlatformDir string
 		}
 		Returns struct {
@@ -22,7 +22,7 @@ func (f *MappingResolver) FindDependencyMapping(param1 string, param2 string) (s
 	f.FindDependencyMappingCall.mutex.Lock()
 	defer f.FindDependencyMappingCall.mutex.Unlock()
 	f.FindDependencyMappingCall.CallCount++
-	f.FindDependencyMappingCall.Receives.SHA256 = param1
+	f.FindDependencyMappingCall.Receives.Checksum = param1
 	f.FindDependencyMappingCall.Receives.PlatformDir = param2
 	if f.FindDependencyMappingCall.Stub != nil {
 		return f.FindDependencyMappingCall.Stub(param1, param2)

--- a/postal/internal/dependency_mappings.go
+++ b/postal/internal/dependency_mappings.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/paketo-buildpacks/packit/v2/servicebindings"
 )
 
@@ -23,19 +24,31 @@ func NewDependencyMappingResolver(bindingResolver BindingResolver) DependencyMap
 }
 
 // FindDependencyMapping looks up if there is a matching dependency mapping
-func (d DependencyMappingResolver) FindDependencyMapping(sha256, platformDir string) (string, error) {
+// If the binding is given in the form of `hash`, assume it is of algorithm `sha256`
+// If the binding is given in the form of `algorithm:hash`, compare it to the full `checksum` input
+func (d DependencyMappingResolver) FindDependencyMapping(checksum, platformDir string) (string, error) {
 	bindings, err := d.bindingResolver.Resolve("dependency-mapping", "", platformDir)
 	if err != nil {
 		return "", fmt.Errorf("failed to resolve 'dependency-mapping' binding: %w", err)
 	}
 
+	hash := cargo.Checksum(checksum).Hash()
+
 	for _, binding := range bindings {
-		if uri, ok := binding.Entries[sha256]; ok {
+		// binding provided in the form `hash` (no algorithm provided)
+		// assumed to be of `sha256` algorithm
+		if uri, ok := binding.Entries[hash]; ok && cargo.Checksum(checksum).Algorithm() == "sha256" {
 			content, err := uri.ReadString()
 			if err != nil {
 				return "", err
 			}
-
+			return strings.TrimSpace(content), nil
+			// binding provided in the form `algorithm:hash`
+		} else if uri, ok := binding.Entries[checksum]; ok {
+			content, err := uri.ReadString()
+			if err != nil {
+				return "", err
+			}
 			return strings.TrimSpace(content), nil
 		}
 	}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Resolves #420 

Introduces support for the `checksum` field for postal dependency mappings.
The new behaviour is backwards compatible to work with the `sha256` field as well as the new `checksum` field we now support in the `buildpack.toml`.

`FindDependencyMapping` now has slightly different behaviour:
  - If a binding is given in the form of just a `hash` (no algorithm), it will assume it is of algorithm type `sha256` in order to be backwards compatible with how users expect to provide a `dependency-mapping` binding. **Binding lookup will fail if the dependency checksum from the `buildpack.toml` is not of type `sha256`.**
  - We now allow users to provide a binding in the form of `algorithm:hash` (like the checksum field we support), so that bindings can still be provided for dependencies that don't use the `sha256` algorithm.

### Open Question for @paketo-buildpacks/tooling-maintainers 
Do we need to make modifications to https://github.com/paketo-buildpacks/rfcs/blob/main/text/0010-dependency-mappings.md, since we now support non-sha256 checksums as the binding value?

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
