### PR TITLE
Return a typed error when no dependencies are found during resolution.

### DIFF
--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -420,8 +420,10 @@ version = "1.2.3"
 			})
 
 			context("when the entry version constraint cannot be satisfied", func() {
-				it("returns an error with all the supported versions listed", func() {
+				it("returns a typed error with all the supported versions listed", func() {
+					expectedErr := &postal.ErrNoDeps{}
 					_, err := service.Resolve(path, "some-entry", "9.9.9", "some-stack")
+					Expect(errors.As(err, &expectedErr)).To(BeTrue())
 					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-stack\" stack. Supported versions are: [1.2.3, 4.5.6]")))
 				})
 			})


### PR DESCRIPTION
## Summary

This PR adds a typed error to be returned when no dependencies are found during dependency resolution. This is a backwards-compatible change that allows callers to introspect on the error type (via `errors.As()`) in order to handle this case separately from other failures. See #415 for more details on when this case arises.

Callers who do not care about handling this failure mode will continue to see the existing behavior - the error message is unchanged.

## Use Cases

Resolves #415 

## Design/Architecture discussion

There are two ways to achieve the goal of returning specific, typed, errors agreed upon in #415:
1. a sentinel error (similar to [`os.ErrNotExist`](https://cs.opensource.google/go/go/+/refs/tags/go1.19.3:src/os/error.go;l=24))
2. a new instantiation of a custom error type.

I opted for the second option - returning an instantiation of a custom error type, despite the fact that the sentinel pattern is more familiar. I chose this because I wanted to be able to instantiate the error with specific data (like the discovered supported versions) in order to preserve the existing error message. The sentinel value pattern would force us to return the same error message in all cases, which I felt was less useful.

The main difference for callers is the first option would require using `errors.Is` and the second option would require using `errors.As`.

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
