### PR TITLE
Add stack extension support

### DIFF
--- a/buildpack_info.go
+++ b/buildpack_info.go
@@ -1,9 +1,13 @@
 package packit
 
-// BuildpackInfo is a representation of the basic information for a buildpack
+// BuildpackInfo
+// Deprecated: use Info instead
+type BuildpackInfo = Info
+
+// Info is a representation of the basic information for a buildpack
 // provided in its buildpack.toml file as described in the specification:
 // https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpacktoml-toml.
-type BuildpackInfo struct {
+type Info struct {
 	// ID is the identifier specified in the `buildpack.id` field of the
 	// buildpack.toml.
 	ID string `toml:"id"`
@@ -30,17 +34,21 @@ type BuildpackInfo struct {
 
 	// Licenses are the list of licenses specified in the `buildpack.licenses`
 	// fields of the buildpack.toml.
-	Licenses []BuildpackInfoLicense
+	Licenses []InfoLicense
 
 	// SBOMFormats is the list of Software Bill of Materials media types that the buildpack
 	// produces (e.g. "application/spdx+json").
 	SBOMFormats []string `toml:"sbom-formats"`
 }
 
-// BuildpackInfoLicense is a representation of a license specified in the
+// type BuildpackInfoLicense
+// Deprecated: use InfoLicense instead
+type BuildpackInfoLicense = InfoLicense
+
+// InfoLicense is a representation of a license specified in the
 // buildpack.toml as described in the specification:
 // https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpacktoml-toml.
-type BuildpackInfoLicense struct {
+type InfoLicense struct {
 	// Type is the identifier specified in the `buildpack.licenses.type` field of
 	// the buildpack.toml.
 	Type string `toml:"type"`

--- a/detect_test.go
+++ b/detect_test.go
@@ -18,8 +18,8 @@ import (
 
 func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
-		Expect = NewWithT(t).Expect
-
+		Expect      = NewWithT(t).Expect
+		err         error
 		workingDir  string
 		tmpDir      string
 		platformDir string
@@ -33,7 +33,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 	)
 
 	it.Before(func() {
-		var err error
 		workingDir, err = os.Getwd()
 		Expect(err).NotTo(HaveOccurred())
 
@@ -56,21 +55,6 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 		binaryPath = filepath.Join(cnbDir, "bin", "detect")
 
-		bpTOMLContent := []byte(`
-api = "0.5"
-[buildpack]
-  id = "some-id"
-  name = "some-name"
-  version = "some-version"
-  clear-env = false
-`)
-		Expect(os.WriteFile(filepath.Join(cnbDir, "buildpack.toml"), bpTOMLContent, 0600)).To(Succeed())
-
-		planDir, err = os.MkdirTemp("", "buildplan.toml")
-		Expect(err).NotTo(HaveOccurred())
-
-		planPath = filepath.Join(planDir, "buildplan.toml")
-
 		exitHandler = &fakes.ExitHandler{}
 	})
 
@@ -78,61 +62,146 @@ api = "0.5"
 		Expect(os.Chdir(workingDir)).To(Succeed())
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		Expect(os.RemoveAll(cnbDir)).To(Succeed())
-		Expect(os.RemoveAll(planDir)).To(Succeed())
 		Expect(os.RemoveAll(platformDir)).To(Succeed())
 		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
 	})
 
-	context("when providing the detect context to the given DetectFunc", func() {
-		it("succeeds", func() {
-			var context packit.DetectContext
+	context("when detect within an extension", func() {
 
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				context = ctx
+		it.Before(func() {
+			extTOMLContent := []byte(`
+api = "0.9"
+[extension]
+  id = "some-id"
+  name = "some-name"
+  version = "some-version"
+`)
+			Expect(os.WriteFile(filepath.Join(cnbDir, "extension.toml"), extTOMLContent, 0600)).To(Succeed())
+			Expect(os.Setenv("CNB_EXTENSION_DIR", cnbDir))
+			planDir, err = os.MkdirTemp("", "buildplan.toml")
+			Expect(err).NotTo(HaveOccurred())
 
-				return packit.DetectResult{}, nil
-			}, packit.WithArgs([]string{binaryPath, platformDir, planPath}))
+			planPath = filepath.Join(planDir, "buildplan.toml")
 
-			Expect(context).To(Equal(packit.DetectContext{
-				WorkingDir: tmpDir,
-				CNBPath:    cnbDir,
-				Platform: packit.Platform{
-					Path: platformDir,
-				},
-				BuildpackInfo: packit.BuildpackInfo{
-					ID:      "some-id",
-					Name:    "some-name",
-					Version: "some-version",
-				},
-				Stack: stackID,
-			}))
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(planDir)).To(Succeed())
+			Expect(os.Unsetenv("CNB_EXTENSION_DIR")).To(Succeed())
+		})
+
+		context("when providing the detect context to the given DetectFunc", func() {
+			it("succeeds", func() {
+				var context packit.DetectContext
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					context = ctx
+
+					return packit.DetectResult{}, nil
+				}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+				Expect(context).To(Equal(packit.DetectContext{
+					WorkingDir: tmpDir,
+					CNBPath:    cnbDir,
+					Platform: packit.Platform{
+						Path: platformDir,
+					},
+					BuildpackInfo: packit.BuildpackInfo{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Info: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Stack: stackID,
+				}))
+			})
 		})
 	})
 
-	it("writes out the buildplan.toml", func() {
-		packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
-			return packit.DetectResult{
-				Plan: packit.BuildPlan{
-					Provides: []packit.BuildPlanProvision{
-						{Name: "some-provision"},
+	context("when detect within a buildpack", func() {
+		it.Before(func() {
+			bpTOMLContent := []byte(`
+api = "0.5"
+[buildpack]
+  id = "some-id"
+  name = "some-name"
+  version = "some-version"
+  clear-env = false
+`)
+			Expect(os.WriteFile(filepath.Join(cnbDir, "buildpack.toml"), bpTOMLContent, 0600)).To(Succeed())
+
+			planDir, err = os.MkdirTemp("", "buildplan.toml")
+			Expect(err).NotTo(HaveOccurred())
+
+			planPath = filepath.Join(planDir, "buildplan.toml")
+		})
+
+		it.After(func() {
+			Expect(os.RemoveAll(planDir)).To(Succeed())
+		})
+
+		context("when providing the detect context to the given DetectFunc", func() {
+			it("succeeds", func() {
+				var context packit.DetectContext
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					context = ctx
+
+					return packit.DetectResult{}, nil
+				}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+				Expect(context).To(Equal(packit.DetectContext{
+					WorkingDir: tmpDir,
+					CNBPath:    cnbDir,
+					Platform: packit.Platform{
+						Path: platformDir,
 					},
-					Requires: []packit.BuildPlanRequirement{
-						{
-							Name: "some-requirement",
-							Metadata: map[string]string{
-								"version":  "some-version",
-								"some-key": "some-value",
+					BuildpackInfo: packit.BuildpackInfo{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Info: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Stack: stackID,
+				}))
+			})
+		})
+
+		it("writes out the buildplan.toml", func() {
+			packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+				return packit.DetectResult{
+					Plan: packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: "some-provision"},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "some-requirement",
+								Metadata: map[string]string{
+									"version":  "some-version",
+									"some-key": "some-value",
+								},
 							},
 						},
 					},
-				},
-			}, nil
-		}, packit.WithArgs([]string{binaryPath, platformDir, planPath}))
+				}, nil
+			}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
 
-		contents, err := os.ReadFile(planPath)
-		Expect(err).NotTo(HaveOccurred())
+			Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+			contents, err := os.ReadFile(planPath)
+			Expect(err).NotTo(HaveOccurred())
 
-		Expect(string(contents)).To(MatchTOML(`
+			Expect(string(contents)).To(MatchTOML(`
 [[provides]]
   name = "some-provision"
 
@@ -143,62 +212,63 @@ api = "0.5"
   version = "some-version"
   some-key = "some-value"
 `))
-	})
+		})
 
-	it("writes out the buildplan.toml with multiple plans", func() {
-		packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
-			return packit.DetectResult{
-				Plan: packit.BuildPlan{
-					Provides: []packit.BuildPlanProvision{
-						{Name: "some-provision"},
-					},
-					Requires: []packit.BuildPlanRequirement{
-						{
-							Name: "some-requirement",
-							Metadata: map[string]string{
-								"version":  "some-version",
-								"some-key": "some-value",
+		it("writes out the buildplan.toml with multiple plans", func() {
+			packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+				return packit.DetectResult{
+					Plan: packit.BuildPlan{
+						Provides: []packit.BuildPlanProvision{
+							{Name: "some-provision"},
+						},
+						Requires: []packit.BuildPlanRequirement{
+							{
+								Name: "some-requirement",
+								Metadata: map[string]string{
+									"version":  "some-version",
+									"some-key": "some-value",
+								},
 							},
 						},
-					},
-					Or: []packit.BuildPlan{
-						{
-							Provides: []packit.BuildPlanProvision{
-								{Name: "some-other-provision"},
+						Or: []packit.BuildPlan{
+							{
+								Provides: []packit.BuildPlanProvision{
+									{Name: "some-other-provision"},
+								},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "some-other-requirement",
+										Metadata: map[string]string{
+											"version":        "some-other-version",
+											"some-other-key": "some-other-value",
+										},
+									},
+								},
 							},
-							Requires: []packit.BuildPlanRequirement{
-								{
-									Name: "some-other-requirement",
-									Metadata: map[string]string{
-										"version":        "some-other-version",
-										"some-other-key": "some-other-value",
+							{
+								Provides: []packit.BuildPlanProvision{
+									{Name: "some-another-provision"},
+								},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "some-another-requirement",
+										Metadata: map[string]string{
+											"version":          "some-another-version",
+											"some-another-key": "some-another-value",
+										},
 									},
 								},
 							},
 						},
-						{
-							Provides: []packit.BuildPlanProvision{
-								{Name: "some-another-provision"},
-							},
-							Requires: []packit.BuildPlanRequirement{
-								{
-									Name: "some-another-requirement",
-									Metadata: map[string]string{
-										"version":          "some-another-version",
-										"some-another-key": "some-another-value",
-									},
-								},
-							},
-						},
 					},
-				},
-			}, nil
-		}, packit.WithArgs([]string{binaryPath, platformDir, planPath}))
+				}, nil
+			}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+			Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
 
-		contents, err := os.ReadFile(planPath)
-		Expect(err).NotTo(HaveOccurred())
+			contents, err := os.ReadFile(planPath)
+			Expect(err).NotTo(HaveOccurred())
 
-		Expect(string(contents)).To(MatchTOML(`
+			Expect(string(contents)).To(MatchTOML(`
 [[provides]]
   name = "some-provision"
 
@@ -232,193 +302,103 @@ api = "0.5"
 		version = "some-another-version"
 	  some-another-key = "some-another-value"
 `))
-	})
-
-	context("when CNB_BUILDPACK_DIR is set", func() {
-		it.Before(func() {
-			Expect(os.Setenv("CNB_BUILDPACK_DIR", cnbDir)).To(Succeed())
 		})
 
-		it.After(func() {
-			Expect(os.Unsetenv("CNB_BUILDPACK_DIR")).To(Succeed())
-		})
-
-		it("the Detect context receives the correct value", func() {
-			var context packit.DetectContext
-
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				context = ctx
-
-				return packit.DetectResult{}, nil
-			}, packit.WithArgs([]string{"env-var-override", platformDir, planPath}))
-
-			Expect(context).To(Equal(packit.DetectContext{
-				WorkingDir: tmpDir,
-				CNBPath:    cnbDir,
-				Platform: packit.Platform{
-					Path: platformDir,
-				},
-				BuildpackInfo: packit.BuildpackInfo{
-					ID:      "some-id",
-					Name:    "some-name",
-					Version: "some-version",
-				},
-				Stack: stackID,
-			}))
-		})
-	})
-
-	context("when CNB_PLATFORM_DIR is set", func() {
-		it.Before(func() {
-			Expect(os.Setenv("CNB_PLATFORM_DIR", platformDir)).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("CNB_PLATFORM_DIR")).To(Succeed())
-		})
-
-		it("the Detect context receives the correct value", func() {
-			var context packit.DetectContext
-
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				context = ctx
-
-				return packit.DetectResult{}, nil
-			}, packit.WithArgs([]string{binaryPath, "env-var-override", planPath}))
-
-			Expect(context).To(Equal(packit.DetectContext{
-				WorkingDir: tmpDir,
-				CNBPath:    cnbDir,
-				Platform: packit.Platform{
-					Path: platformDir,
-				},
-				BuildpackInfo: packit.BuildpackInfo{
-					ID:      "some-id",
-					Name:    "some-name",
-					Version: "some-version",
-				},
-				Stack: stackID,
-			}))
-		})
-	})
-
-	context("when CNB_BUILD_PLAN_PATH is set", func() {
-		it.Before(func() {
-			Expect(os.Setenv("CNB_BUILD_PLAN_PATH", planPath)).To(Succeed())
-		})
-
-		it.After(func() {
-			Expect(os.Unsetenv("CNB_BUILD_PLAN_PATH")).To(Succeed())
-		})
-
-		it("the Detect context receives the correct value", func() {
-			var context packit.DetectContext
-
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				context = ctx
-
-				return packit.DetectResult{
-					Plan: packit.BuildPlan{
-						Provides: []packit.BuildPlanProvision{
-							{Name: "some-provision"},
-						},
-						Requires: []packit.BuildPlanRequirement{
-							{
-								Name: "some-requirement",
-								Metadata: map[string]string{
-									"version":  "some-version",
-									"some-key": "some-value",
-								},
-							},
-						},
-					},
-				}, nil
-			}, packit.WithArgs([]string{binaryPath, platformDir, "env-var-override"}))
-
-			Expect(context).To(Equal(packit.DetectContext{
-				WorkingDir: tmpDir,
-				CNBPath:    cnbDir,
-				Platform: packit.Platform{
-					Path: platformDir,
-				},
-				BuildpackInfo: packit.BuildpackInfo{
-					ID:      "some-id",
-					Name:    "some-name",
-					Version: "some-version",
-				},
-				Stack: stackID,
-			}))
-
-			contents, err := os.ReadFile(planPath)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(string(contents)).To(MatchTOML(`
-[[provides]]
-  name = "some-provision"
-
-[[requires]]
-  name = "some-requirement"
-
-[requires.metadata]
-  version = "some-version"
-  some-key = "some-value"
-`))
-		})
-	})
-
-	context("when the DetectFunc returns an error", func() {
-		it("calls the ExitHandler with that error", func() {
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				return packit.DetectResult{}, errors.New("failed to detect")
-			}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
-
-			Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError("failed to detect"))
-		})
-	})
-
-	context("when the DetectFunc fails", func() {
-		it("calls the ExitHandler with the correct exit code", func() {
-			var exitCode int
-			buffer := bytes.NewBuffer(nil)
-
-			packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
-				return packit.DetectResult{}, packit.Fail.WithMessage("failure message")
-			},
-				packit.WithArgs([]string{binaryPath, platformDir, planPath}),
-				packit.WithExitHandler(
-					internal.NewExitHandler(
-						internal.WithExitHandlerExitFunc(func(code int) {
-							exitCode = code
-						}),
-						internal.WithExitHandlerStderr(buffer),
-					),
-				),
-			)
-
-			Expect(exitCode).To(Equal(100))
-			Expect(buffer.String()).To(Equal("failure message\n"))
-		})
-	})
-
-	context("failure cases", func() {
-		context("when the buildpack.toml cannot be read", func() {
-			it("returns an error", func() {
-				packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
-					return packit.DetectResult{}, nil
-				}, packit.WithArgs([]string{binaryPath, platformDir, "/no/such/plan/path"}), packit.WithExitHandler(exitHandler))
-
-				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("no such file or directory")))
-			})
-		})
-
-		context("when the buildplan.toml cannot be opened", func() {
+		context("when CNB_BUILDPACK_DIR is set", func() {
 			it.Before(func() {
-				_, err := os.OpenFile(planPath, os.O_CREATE|os.O_RDWR, 0000)
-				Expect(err).NotTo(HaveOccurred())
+				Expect(os.Setenv("CNB_BUILDPACK_DIR", cnbDir)).To(Succeed())
 			})
 
-			it("returns an error", func() {
-				packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+			it.After(func() {
+				Expect(os.Unsetenv("CNB_BUILDPACK_DIR")).To(Succeed())
+			})
+
+			it("the Detect context receives the correct value", func() {
+				var context packit.DetectContext
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					context = ctx
+
+					return packit.DetectResult{}, nil
+				}, packit.WithArgs([]string{"env-var-override", platformDir, planPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+				Expect(context).To(Equal(packit.DetectContext{
+					WorkingDir: tmpDir,
+					CNBPath:    cnbDir,
+					Platform: packit.Platform{
+						Path: platformDir,
+					},
+					BuildpackInfo: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Info: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Stack: stackID,
+				}))
+			})
+		})
+
+		context("when CNB_PLATFORM_DIR is set", func() {
+			it.Before(func() {
+				Expect(os.Setenv("CNB_PLATFORM_DIR", platformDir)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("CNB_PLATFORM_DIR")).To(Succeed())
+			})
+
+			it("the Detect context receives the correct value", func() {
+				var context packit.DetectContext
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					context = ctx
+
+					return packit.DetectResult{}, nil
+				}, packit.WithArgs([]string{binaryPath, "env-var-override", planPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+				Expect(context).To(Equal(packit.DetectContext{
+					WorkingDir: tmpDir,
+					CNBPath:    cnbDir,
+					Platform: packit.Platform{
+						Path: platformDir,
+					},
+					BuildpackInfo: packit.BuildpackInfo{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Info: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Stack: stackID,
+				}))
+			})
+		})
+
+		context("when CNB_BUILD_PLAN_PATH is set", func() {
+			it.Before(func() {
+				Expect(os.Setenv("CNB_BUILD_PLAN_PATH", planPath)).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("CNB_BUILD_PLAN_PATH")).To(Succeed())
+			})
+
+			it("the Detect context receives the correct value", func() {
+				var context packit.DetectContext
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					context = ctx
+
 					return packit.DetectResult{
 						Plan: packit.BuildPlan{
 							Provides: []packit.BuildPlanProvision{
@@ -435,31 +415,140 @@ api = "0.5"
 							},
 						},
 					}, nil
-				}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+				}, packit.WithArgs([]string{binaryPath, platformDir, "env-var-override"}), packit.WithExitHandler(exitHandler))
 
-				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("permission denied")))
+				Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+				Expect(context).To(Equal(packit.DetectContext{
+					WorkingDir: tmpDir,
+					CNBPath:    cnbDir,
+					Platform: packit.Platform{
+						Path: platformDir,
+					},
+					BuildpackInfo: packit.BuildpackInfo{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Info: packit.Info{
+						ID:      "some-id",
+						Name:    "some-name",
+						Version: "some-version",
+					},
+					Stack: stackID,
+				}))
+
+				contents, err := os.ReadFile(planPath)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(string(contents)).To(MatchTOML(`
+[[provides]]
+  name = "some-provision"
+
+[[requires]]
+  name = "some-requirement"
+
+[requires.metadata]
+  version = "some-version"
+  some-key = "some-value"
+`))
 			})
 		})
 
-		context("when the buildplan.toml cannot be encoded", func() {
-			it("returns an error", func() {
-				packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
-					return packit.DetectResult{
-						Plan: packit.BuildPlan{
-							Provides: []packit.BuildPlanProvision{
-								{Name: "some-provision"},
-							},
-							Requires: []packit.BuildPlanRequirement{
-								{
-									Name:     "some-requirement",
-									Metadata: map[int]int{},
-								},
-							},
-						},
-					}, nil
+		context("when the DetectFunc returns an error", func() {
+			it("calls the ExitHandler with that error", func() {
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					return packit.DetectResult{}, errors.New("failed to detect")
 				}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
 
-				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("cannot encode a map with non-string key type")))
+				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError("failed to detect"))
+			})
+		})
+
+		context("when the DetectFunc fails", func() {
+			it("calls the ExitHandler with the correct exit code", func() {
+				var exitCode int
+				buffer := bytes.NewBuffer(nil)
+
+				packit.Detect(func(ctx packit.DetectContext) (packit.DetectResult, error) {
+					return packit.DetectResult{}, packit.Fail.WithMessage("failure message")
+				},
+					packit.WithArgs([]string{binaryPath, platformDir, planPath}),
+					packit.WithExitHandler(
+						internal.NewExitHandler(
+							internal.WithExitHandlerExitFunc(func(code int) {
+								exitCode = code
+							}),
+							internal.WithExitHandlerStderr(buffer),
+						),
+					),
+				)
+
+				Expect(exitCode).To(Equal(100))
+				Expect(buffer.String()).To(Equal("failure message\n"))
+			})
+		})
+
+		context("failure cases", func() {
+			context("when the buildpack.toml cannot be read", func() {
+				it("returns an error", func() {
+					packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+						return packit.DetectResult{}, nil
+					}, packit.WithArgs([]string{binaryPath, platformDir, "/no/such/plan/path"}), packit.WithExitHandler(exitHandler))
+
+					Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("no such file or directory")))
+				})
+			})
+
+			context("when the buildplan.toml cannot be opened", func() {
+				it.Before(func() {
+					_, err := os.OpenFile(planPath, os.O_CREATE|os.O_RDWR, 0000)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it("returns an error", func() {
+					packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+						return packit.DetectResult{
+							Plan: packit.BuildPlan{
+								Provides: []packit.BuildPlanProvision{
+									{Name: "some-provision"},
+								},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name: "some-requirement",
+										Metadata: map[string]string{
+											"version":  "some-version",
+											"some-key": "some-value",
+										},
+									},
+								},
+							},
+						}, nil
+					}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+
+					Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("permission denied")))
+				})
+			})
+
+			context("when the buildplan.toml cannot be encoded", func() {
+				it("returns an error", func() {
+					packit.Detect(func(packit.DetectContext) (packit.DetectResult, error) {
+						return packit.DetectResult{
+							Plan: packit.BuildPlan{
+								Provides: []packit.BuildPlanProvision{
+									{Name: "some-provision"},
+								},
+								Requires: []packit.BuildPlanRequirement{
+									{
+										Name:     "some-requirement",
+										Metadata: map[int]int{},
+									},
+								},
+							},
+						}, nil
+					}, packit.WithArgs([]string{binaryPath, platformDir, planPath}), packit.WithExitHandler(exitHandler))
+
+					Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("cannot encode a map with non-string key type")))
+				})
 			})
 		})
 	})

--- a/generate.go
+++ b/generate.go
@@ -1,0 +1,159 @@
+package packit
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/paketo-buildpacks/packit/v2/internal"
+)
+
+// GenerateFunc is the definition of a callback that can be invoked when the Generate
+// function is executed. Extension authors should implement a GenerateFunc that
+// performs the specific generate phase operations for that extension.
+type GenerateFunc func(GenerateContext) (GenerateResult, error)
+
+// GenerateContext provides the contextual details that are made available by the
+// extension lifecycle during the generate phase. This context is populated by the
+// Generate function and passed to GenerateFunc during execution.
+type GenerateContext struct {
+	// Info includes the details of the buildpack parsed from the
+	// extension.toml included in the extension contents.
+	Info Info
+
+	// CNBPath is the absolute path location of the buildpack contents.
+	// This path is useful for finding the buildpack.toml or any other
+	// files included in the buildpack.
+	CNBPath string
+
+	// Platform includes the platform context according to the specification:
+	// https://github.com/buildpacks/spec/blob/main/buildpack.md#build
+	Platform Platform
+
+	// Plan includes the BuildpackPlan provided by the lifecycle as specified in
+	// the specification:
+	// https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpack-plan-toml.
+	Plan BuildpackPlan
+
+	// Stack is the value of the chosen stack. This value is populated from the
+	// $CNB_STACK_ID environment variable.
+	Stack string
+
+	// WorkingDir is the location of the application source code as provided by
+	// the lifecycle.
+	WorkingDir string
+}
+
+// GenerateResult allows extension authors to indicate the result of the generate
+// phase for a given extension. This result, returned in a GenerateFunc callback,
+// will be parsed and persisted by the Generate function and returned to the
+// lifecycle at the end of the generate phase execution.
+type GenerateResult struct {
+	// ExtendConfig contains the config of an extension
+	ExtendConfig ExtendConfig
+
+	// BuildDockerfile the Dockerfile to define the build image
+	BuildDockerfile io.Reader
+	// RunDockerfile the Dockerfile to define the run image
+	RunDockerfile io.Reader
+}
+
+type ExtendConfig struct {
+	Build ExtendImageConfig `toml:"build"`
+}
+
+type ExtendImageConfig struct {
+	Args []ExtendImageConfigArg `toml:"args"`
+}
+
+type ExtendImageConfigArg struct {
+	Name  string `toml:"name"`
+	Value string `toml:"value"`
+}
+
+// Generate is an implementation of the generate phase according to the Cloud Native
+// Buildpacks specification. Calling this function with a GenerateFunc will
+// perform the generate phase process of an extension.
+func Generate(f GenerateFunc, options ...Option) {
+	config := OptionConfig{
+		exitHandler: internal.NewExitHandler(),
+		args:        os.Args,
+		tomlWriter:  internal.NewTOMLWriter(),
+		envWriter:   internal.NewEnvironmentWriter(),
+		fileWriter:  internal.NewFileWriter(),
+	}
+
+	for _, option := range options {
+		config = option(config)
+	}
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		config.exitHandler.Error(err)
+		return
+	}
+
+	planPath := os.Getenv("CNB_BP_PLAN_PATH")
+
+	var plan BuildpackPlan
+	_, err = toml.DecodeFile(planPath, &plan)
+	if err != nil {
+		config.exitHandler.Error(err)
+		return
+	}
+
+	cnbPath := os.Getenv("CNB_EXTENSION_DIR")
+	outputPath := os.Getenv("CNB_OUTPUT_DIR")
+	platformPath := os.Getenv("CNB_PLATFORM_DIR")
+
+	var info struct {
+		APIVersion string `toml:"api"`
+		Info       Info   `toml:"extension"`
+	}
+
+	extensionTOML := filepath.Join(cnbPath, "extension.toml")
+	_, err = toml.DecodeFile(extensionTOML, &info)
+	if err != nil {
+		config.exitHandler.Error(fmt.Errorf("could not parse %q: %w", extensionTOML, err))
+		return
+	}
+
+	result, err := f(GenerateContext{
+		CNBPath: cnbPath,
+		Platform: Platform{
+			Path: platformPath,
+		},
+		Stack:      os.Getenv("CNB_STACK_ID"),
+		WorkingDir: pwd,
+		Plan:       plan,
+		Info:       info.Info,
+	})
+	if err != nil {
+		config.exitHandler.Error(err)
+		return
+	}
+
+	if result.BuildDockerfile != nil {
+		err = config.fileWriter.Write(filepath.Join(outputPath, "build.Dockerfile"), result.BuildDockerfile)
+		if err != nil {
+			config.exitHandler.Error(err)
+			return
+		}
+	}
+	if result.RunDockerfile != nil {
+		err = config.fileWriter.Write(filepath.Join(outputPath, "run.Dockerfile"), result.RunDockerfile)
+		if err != nil {
+			config.exitHandler.Error(err)
+			return
+		}
+	}
+
+	err = config.tomlWriter.Write(filepath.Join(outputPath, "extend-config.toml"), result.ExtendConfig)
+	if err != nil {
+		config.exitHandler.Error(err)
+		return
+	}
+
+}

--- a/generate_test.go
+++ b/generate_test.go
@@ -1,0 +1,193 @@
+package packit_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2"
+	"github.com/paketo-buildpacks/packit/v2/fakes"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testGenerate(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		workingDir  string
+		platformDir string
+		tmpDir      string
+		planPath    string
+		cnbDir      string
+		binaryPath  string
+		exitHandler *fakes.ExitHandler
+	)
+
+	it.Before(func() {
+		var err error
+		workingDir, err = os.Getwd()
+		Expect(err).NotTo(HaveOccurred())
+
+		tmpDir, err = os.MkdirTemp("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
+
+		tmpDir, err = filepath.EvalSymlinks(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.Chdir(tmpDir)).To(Succeed())
+
+		platformDir, err = os.MkdirTemp("", "platform")
+		Expect(err).NotTo(HaveOccurred())
+
+		file, err := os.CreateTemp("", "plan.toml")
+		Expect(err).NotTo(HaveOccurred())
+		defer file.Close()
+
+		_, err = file.WriteString(`
+[[entries]]
+  name = "some-entry"
+
+[entries.metadata]
+  version = "some-version"
+  some-key = "some-value"
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		planPath = file.Name()
+
+		cnbDir, err = os.MkdirTemp("", "cnb")
+		Expect(err).NotTo(HaveOccurred())
+
+		extTOML := []byte(`
+api = "0.9"
+[extension]
+  id = "some-id"
+  name = "some-name"
+  version = "some-version"
+  homepage = "some-homepage"
+  description = "some-description"
+  keywords = ["some-keyword"]
+
+  [[extension.licenses]]
+	type = "some-license-type"
+	uri = "some-license-uri"
+`)
+		Expect(os.WriteFile(filepath.Join(cnbDir, "extension.toml"), extTOML, 0600)).To(Succeed())
+
+		binaryPath = filepath.Join(cnbDir, "bin", "generate")
+
+		Expect(os.Setenv("CNB_STACK_ID", "some-stack")).To(Succeed())
+		Expect(os.Setenv("CNB_BP_PLAN_PATH", planPath)).To(Succeed())
+		Expect(os.Setenv("CNB_PLATFORM_DIR", platformDir)).To(Succeed())
+		Expect(os.Setenv("CNB_EXTENSION_DIR", cnbDir)).To(Succeed())
+
+		exitHandler = &fakes.ExitHandler{}
+		exitHandler.ErrorCall.Stub = func(err error) {
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+	})
+
+	it.After(func() {
+		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
+		Expect(os.Unsetenv("CNB_BP_PLAN_PATH")).To(Succeed())
+		Expect(os.Unsetenv("CNB_PLATFORM_DIR")).To(Succeed())
+		Expect(os.Unsetenv("CNB_EXTENSION_DIR")).To(Succeed())
+
+		Expect(os.Chdir(workingDir)).To(Succeed())
+		Expect(os.RemoveAll(tmpDir)).To(Succeed())
+		Expect(os.RemoveAll(platformDir)).To(Succeed())
+	})
+
+	it("provides the generate context to the given GenerateFunc", func() {
+		var context packit.GenerateContext
+		packit.Generate(func(ctx packit.GenerateContext) (packit.GenerateResult, error) {
+			context = ctx
+
+			return packit.GenerateResult{}, nil
+		}, packit.WithArgs([]string{binaryPath}), packit.WithExitHandler(exitHandler))
+
+		Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+		Expect(context).To(Equal(packit.GenerateContext{
+			CNBPath: cnbDir,
+			Stack:   "some-stack",
+			Platform: packit.Platform{
+				Path: platformDir,
+			},
+			WorkingDir: tmpDir,
+			Plan: packit.BuildpackPlan{
+				Entries: []packit.BuildpackPlanEntry{
+					{
+						Name: "some-entry",
+						Metadata: map[string]interface{}{
+							"version":  "some-version",
+							"some-key": "some-value",
+						},
+					},
+				},
+			},
+			Info: packit.Info{
+				ID:          "some-id",
+				Name:        "some-name",
+				Version:     "some-version",
+				Homepage:    "some-homepage",
+				Description: "some-description",
+				Keywords:    []string{"some-keyword"},
+				Licenses: []packit.BuildpackInfoLicense{
+					{
+						Type: "some-license-type",
+						URI:  "some-license-uri",
+					},
+				},
+			},
+		}))
+	})
+
+	context("failure cases", func() {
+		context("when the buildpack plan.toml is malformed", func() {
+			it.Before(func() {
+				err := os.WriteFile(planPath, []byte("%%%"), 0600)
+				Expect(err).NotTo(HaveOccurred())
+				exitHandler.ErrorCall.Stub = nil
+			})
+
+			it("calls the exit handler", func() {
+				packit.Generate(func(ctx packit.GenerateContext) (packit.GenerateResult, error) {
+					return packit.GenerateResult{}, nil
+				}, packit.WithArgs([]string{binaryPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("expected '.' or '=', but got '%' instead")))
+			})
+		})
+
+		context("when the generate func returns an error", func() {
+			it("calls the exit handler", func() {
+				exitHandler.ErrorCall.Stub = nil
+				packit.Generate(func(ctx packit.GenerateContext) (packit.GenerateResult, error) {
+					return packit.GenerateResult{}, errors.New("generate failed")
+				}, packit.WithArgs([]string{binaryPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError("generate failed"))
+			})
+		})
+
+		context("when the exension.toml is malformed", func() {
+			it.Before(func() {
+				err := os.WriteFile(filepath.Join(cnbDir, "extension.toml"), []byte("%%%"), 0600)
+				Expect(err).NotTo(HaveOccurred())
+				exitHandler.ErrorCall.Stub = nil
+			})
+
+			it("calls the exit handler", func() {
+				packit.Generate(func(ctx packit.GenerateContext) (packit.GenerateResult, error) {
+					return packit.GenerateResult{}, nil
+				}, packit.WithArgs([]string{binaryPath}), packit.WithExitHandler(exitHandler))
+
+				Expect(exitHandler.ErrorCall.Receives.Error).To(MatchError(ContainSubstring("expected '.' or '=', but got '%' instead")))
+			})
+		})
+	})
+}

--- a/init_test.go
+++ b/init_test.go
@@ -11,6 +11,7 @@ func TestUnitPackit(t *testing.T) {
 	suite := spec.New("packit", spec.Report(report.Terminal{}))
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
+	suite("Generate", testGenerate)
 	suite("Environment", testEnvironment)
 	suite("Layer", testLayer)
 	suite("Layers", testLayers)

--- a/run.go
+++ b/run.go
@@ -26,11 +26,36 @@ func Run(detect DetectFunc, build BuildFunc, options ...Option) {
 	switch phase {
 	case "detect":
 		Detect(detect, options...)
-
 	case "build":
 		Build(build, options...)
-
 	default:
 		config.exitHandler.Error(fmt.Errorf("failed to run buildpack: unknown lifecycle phase %q", phase))
 	}
+
+}
+
+// RunExtension combines the invocation of both generate and detect into a single entry
+// point. Calling Run from an executable with a name matching "generate" or
+// "detect" will result in the matching DetectFunc or GenerateFunc being called.
+func RunExtension(detect DetectFunc, generate GenerateFunc, options ...Option) {
+	config := OptionConfig{
+		exitHandler: internal.NewExitHandler(),
+		args:        os.Args,
+	}
+
+	for _, option := range options {
+		config = option(config)
+	}
+
+	phase := filepath.Base(config.args[0])
+
+	switch phase {
+	case "detect":
+		Detect(detect, options...)
+	case "generate":
+		Generate(generate, options...)
+	default:
+		config.exitHandler.Error(fmt.Errorf("failed to run buildpack: unknown lifecycle phase %q", phase))
+	}
+
 }


### PR DESCRIPTION
fixes #432 

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This adds stack extension support according to the spec (https://github.com/buildpacks/spec/blob/main/image_extension.md)

## Use Cases
<!-- An explanation of the use cases your change enables -->
We used generic to have as much code reuse between `Detect` of a buildpack and `Detect` of an extension. If we would not use generics, this would mean to copy the logic which is basically the same. The main differences are:

* `CNB_BUILDPACK_DIR` vs. `CNB_EXTENSION_DIR`
* `buildpack.toml` vs. `extension.toml`


Note: The current state reuses the `BuildpackInfo` struct (renaming it), although `extension.toml` does not contain `SBOMFormats`.

We tried to not break any user with this change.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
