### PR TITLE
Fix confusion in boolean parameter order in tests

### DIFF
--- a/sbom/internal/formats/common/testutils/utils.go
+++ b/sbom/internal/formats/common/testutils/utils.go
@@ -37,7 +37,14 @@ func FromSnapshot() ImageOption {
 	}
 }
 
-func AssertEncoderAgainstGoldenImageSnapshot(t *testing.T, format sbom.Format, sbom sbom.SBOM, testImage string, updateSnapshot bool, json bool, redactors ...redactor) {
+type Type int
+
+const (
+	TypePlain Type = iota
+	TypeJson
+)
+
+func AssertEncoderAgainstGoldenImageSnapshot(t *testing.T, format sbom.Format, sbom sbom.SBOM, testImage string, updateSnapshot bool, contentType Type, redactors ...redactor) {
 	var buffer bytes.Buffer
 
 	// grab the latest image contents and persist
@@ -63,7 +70,7 @@ func AssertEncoderAgainstGoldenImageSnapshot(t *testing.T, format sbom.Format, s
 		expected = r(expected)
 	}
 
-	if json {
+	if contentType == TypeJson {
 		require.JSONEq(t, string(expected), string(actual))
 	} else if !bytes.Equal(expected, actual) {
 		// assert that the golden file snapshot matches the actual contents
@@ -73,7 +80,7 @@ func AssertEncoderAgainstGoldenImageSnapshot(t *testing.T, format sbom.Format, s
 	}
 }
 
-func AssertEncoderAgainstGoldenSnapshot(t *testing.T, format sbom.Format, sbom sbom.SBOM, updateSnapshot bool, json bool, redactors ...redactor) {
+func AssertEncoderAgainstGoldenSnapshot(t *testing.T, format sbom.Format, sbom sbom.SBOM, updateSnapshot bool, contentType Type, redactors ...redactor) {
 	var buffer bytes.Buffer
 
 	err := format.Encode(&buffer, sbom)
@@ -94,7 +101,7 @@ func AssertEncoderAgainstGoldenSnapshot(t *testing.T, format sbom.Format, sbom s
 		expected = r(expected)
 	}
 
-	if json {
+	if contentType == TypeJson {
 		require.JSONEq(t, string(expected), string(actual))
 	} else if !bytes.Equal(expected, actual) {
 		dmp := diffmatchpatch.New()

--- a/sbom/internal/formats/cyclonedx13/encoder_test.go
+++ b/sbom/internal/formats/cyclonedx13/encoder_test.go
@@ -15,7 +15,7 @@ func TestCycloneDxDirectoryEncoder(t *testing.T) {
 		Format(),
 		testutils.DirectoryInput(t),
 		*updateCycloneDx,
-		true,
+		testutils.TypeJson,
 		cycloneDxRedactor,
 	)
 }
@@ -27,7 +27,7 @@ func TestCycloneDxImageEncoder(t *testing.T) {
 		testutils.ImageInput(t, testImage),
 		testImage,
 		*updateCycloneDx,
-		true,
+		testutils.TypeJson,
 		cycloneDxRedactor,
 	)
 }

--- a/sbom/internal/formats/spdx22/encoder_test.go
+++ b/sbom/internal/formats/spdx22/encoder_test.go
@@ -15,7 +15,7 @@ func TestSPDXJSONDirectoryEncoder(t *testing.T) {
 		Format(),
 		testutils.DirectoryInput(t),
 		*updateSpdxJson,
-		true,
+		testutils.TypeJson,
 		spdxJsonRedactor,
 	)
 }
@@ -27,7 +27,7 @@ func TestSPDXJSONImageEncoder(t *testing.T) {
 		testutils.ImageInput(t, testImage, testutils.FromSnapshot()),
 		testImage,
 		*updateSpdxJson,
-		true,
+		testutils.TypeJson,
 		spdxJsonRedactor,
 	)
 }
@@ -41,7 +41,7 @@ func TestSPDXRelationshipOrder(t *testing.T) {
 		s,
 		testImage,
 		*updateSpdxJson,
-		true,
+		testutils.TypeJson,
 		spdxJsonRedactor,
 	)
 }

--- a/sbom/internal/formats/syft2/encoder_test.go
+++ b/sbom/internal/formats/syft2/encoder_test.go
@@ -23,8 +23,8 @@ func TestDirectoryEncoder(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		testutils.DirectoryInput(t),
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }
 
@@ -34,8 +34,8 @@ func TestImageEncoder(t *testing.T) {
 		Format(),
 		testutils.ImageInput(t, testImage, testutils.FromSnapshot()),
 		testImage,
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }
 
@@ -203,7 +203,7 @@ func TestEncodeFullJSONDocument(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		s,
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }

--- a/sbom/internal/formats/syft301/encoder_test.go
+++ b/sbom/internal/formats/syft301/encoder_test.go
@@ -21,8 +21,8 @@ func TestDirectoryEncoder(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		testutils.DirectoryInput(t),
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }
 
@@ -32,8 +32,8 @@ func TestImageEncoder(t *testing.T) {
 		Format(),
 		testutils.ImageInput(t, testImage, testutils.FromSnapshot()),
 		testImage,
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }
 
@@ -201,7 +201,7 @@ func TestEncodeFullJSONDocument(t *testing.T) {
 	testutils.AssertEncoderAgainstGoldenSnapshot(t,
 		Format(),
 		s,
-		true,
 		*updateJson,
+		testutils.TypeJson,
 	)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary

The test helpers `AssertEncoderAgainstGoldenImageSnapshot` and `AssertEncoderAgainstGoldenSnapshot` took two boolean parameters:  `updateSnapshot bool` and `json bool`. Some tests seem to have confused their order making the test act "weird".

To prevent it from happening again we introduced an enum `Type` with the values `TypePlain` and `TypeJson`.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Improve tests

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
