### PR TITLE
Adds stdin to pexec

### DIFF
--- a/fakes/some-executable/main.go
+++ b/fakes/some-executable/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 
@@ -11,6 +12,14 @@ func main() {
 	fmt.Fprintf(os.Stdout, "Output on stdout\n")
 	fmt.Fprintf(os.Stderr, "Output on stderr\n")
 	fmt.Printf("Arguments: %v\n", os.Args)
+
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Input on stdin\n%s\n", stdin)
 
 	pwd, _ := os.Getwd()
 	fmt.Printf("PWD=%s\n", pwd)

--- a/pexec/executable.go
+++ b/pexec/executable.go
@@ -57,6 +57,7 @@ func (e Executable) Execute(execution Execution) error {
 
 	cmd.Stdout = execution.Stdout
 	cmd.Stderr = execution.Stderr
+	cmd.Stdin = execution.Stdin
 
 	return cmd.Run()
 }
@@ -81,4 +82,7 @@ type Execution struct {
 
 	// Stderr is where the output of stderr will be written during the execution.
 	Stderr io.Writer
+
+	// Stdin is where the input of stdin will be read during the execution.
+	Stdin io.Reader
 }

--- a/pexec/executable_test.go
+++ b/pexec/executable_test.go
@@ -112,7 +112,7 @@ func testPexec(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("when given a reader for stdin", func() {
-			it("pipes that reader to stdin", func() {
+			it("pipes that reader to stdout", func() {
 				err := executable.Execute(pexec.Execution{
 					Stdin:  strings.NewReader("something on stdin"),
 					Stdout: stdout,


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Allows users of `pexec` to pipe `io.Reader` types into `stdin`.

## Use Cases
<!-- An explanation of the use cases your change enables -->
I am looking to add support to `occam.DockerContainerExec` to stream a tar file into a container. I can't do this unless `pexec` supports taking that stream as input to `stdin`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
