### PR TITLE
raise error when dependecy download returns http error status code

### DIFF
--- a/cargo/transport.go
+++ b/cargo/transport.go
@@ -35,5 +35,10 @@ func (t Transport) Drop(root, uri string) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("failed to make request: %s", err)
 	}
 
+	if response.StatusCode >= 400 {
+		response.Body.Close()
+		return nil, fmt.Errorf("unexpected status code %d while fetching %q", response.StatusCode, uri)
+	}
+
 	return response.Body, nil
 }

--- a/cargo/transport_test.go
+++ b/cargo/transport_test.go
@@ -74,6 +74,13 @@ func testTransport(t *testing.T, context spec.G, it spec.S) {
 						Expect(err).To(MatchError(ContainSubstring("connection refused")))
 					})
 				})
+
+				context("when the http status indicates an error", func() {
+					it("returns an error", func() {
+						_, err := transport.Drop("", fmt.Sprintf("%s/some-bundle-that-does-not-exist", server.URL))
+						Expect(err).To(MatchError(ContainSubstring("unexpected status code 404 while fetching")))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
## Summary

When a HTTP server returns an unsuccessful HTTP status (e.g. 503 or 404) `cargo` would currently ignore this.
Most likely the sha verification would fail afterwards, but I guess it's better to catch the actual error.

## Use Cases

More accurate errors

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
