### PR TITLE
Add support for buildpack API v0.9

### DIFF
--- a/launch_metadata.go
+++ b/launch_metadata.go
@@ -8,6 +8,10 @@ type LaunchMetadata struct {
 	// be executed during the launch phase.
 	Processes []Process
 
+	// DirectProcesses is a list of processes that will be returned to the lifecycle to
+	// be executed directly during the launch phase.
+	DirectProcesses []DirectProcess
+
 	// Slices is a list of slices that will be returned to the lifecycle to be
 	// exported as separate layers during the export phase.
 	Slices []Slice
@@ -31,5 +35,5 @@ func (l LaunchMetadata) isEmpty() bool {
 		sbom = l.SBOM.Formats()
 	}
 
-	return len(sbom)+len(l.Processes)+len(l.Slices)+len(l.Labels)+len(l.BOM) == 0
+	return len(sbom)+len(l.Processes)+len(l.DirectProcesses)+len(l.Slices)+len(l.Labels)+len(l.BOM) == 0
 }

--- a/process.go
+++ b/process.go
@@ -1,14 +1,5 @@
 package packit
 
-import "strings"
-
-type LaunchProcesses interface {
-	GetType() string
-	GetCommand() []string
-	GetArgs() []string
-	GetDefault() bool
-}
-
 // Process represents a process to be run during the launch phase as described
 // in the specification lower than v0.9:
 // https://github.com/buildpacks/spec/blob/main/buildpack.md#launch. The
@@ -38,19 +29,6 @@ type Process struct {
 	WorkingDirectory string `toml:"working-directory,omitempty"`
 }
 
-func (p Process) GetType() string {
-	return p.Type
-}
-func (p Process) GetCommand() []string {
-	return strings.Split(p.Command, " ")
-}
-func (p Process) GetArgs() []string {
-	return p.Args
-}
-func (p Process) GetDefault() bool {
-	return p.Default
-}
-
 // DirectProcess represents a process to be run during the launch phase as described
 // in the specification higher or equal than v0.9:
 // https://github.com/buildpacks/spec/blob/main/buildpack.md#launch. The
@@ -75,17 +53,4 @@ type DirectProcess struct {
 	// directory other than the application directory. This can either be an
 	// absolute path or one relative to the default application directory.
 	WorkingDirectory string `toml:"working-directory,omitempty"`
-}
-
-func (p DirectProcess) GetType() string {
-	return p.Type
-}
-func (p DirectProcess) GetCommand() []string {
-	return p.Command
-}
-func (p DirectProcess) GetArgs() []string {
-	return p.Args
-}
-func (p DirectProcess) GetDefault() bool {
-	return p.Default
 }

--- a/process.go
+++ b/process.go
@@ -1,7 +1,16 @@
 package packit
 
+import "strings"
+
+type LaunchProcesses interface {
+	GetType() string
+	GetCommand() []string
+	GetArgs() []string
+	GetDefault() bool
+}
+
 // Process represents a process to be run during the launch phase as described
-// in the specification:
+// in the specification lower than v0.9:
 // https://github.com/buildpacks/spec/blob/main/buildpack.md#launch. The
 // fields of the process are describe in the specification of the launch.toml
 // file:
@@ -27,4 +36,56 @@ type Process struct {
 	// directory other than the application directory. This can either be an
 	// absolute path or one relative to the default application directory.
 	WorkingDirectory string `toml:"working-directory,omitempty"`
+}
+
+func (p Process) GetType() string {
+	return p.Type
+}
+func (p Process) GetCommand() []string {
+	return strings.Split(p.Command, " ")
+}
+func (p Process) GetArgs() []string {
+	return p.Args
+}
+func (p Process) GetDefault() bool {
+	return p.Default
+}
+
+// DirectProcess represents a process to be run during the launch phase as described
+// in the specification higher or equal than v0.9:
+// https://github.com/buildpacks/spec/blob/main/buildpack.md#launch. The
+// fields of the process are describe in the specification of the launch.toml
+// file:
+// https://github.com/buildpacks/spec/blob/main/buildpack.md#launchtoml-toml.
+type DirectProcess struct {
+	// Type is an identifier to describe the type of process to be executed, eg.
+	// "web".
+	Type string `toml:"type"`
+
+	// Command is the start command to be executed at launch.
+	Command []string `toml:"command"`
+
+	// Args is a list of arguments to be passed to the command at launch.
+	Args []string `toml:"args"`
+
+	// Default indicates if this process should be the default when launched.
+	Default bool `toml:"default,omitempty"`
+
+	// WorkingDirectory indicates if this process should be run in a working
+	// directory other than the application directory. This can either be an
+	// absolute path or one relative to the default application directory.
+	WorkingDirectory string `toml:"working-directory,omitempty"`
+}
+
+func (p DirectProcess) GetType() string {
+	return p.Type
+}
+func (p DirectProcess) GetCommand() []string {
+	return p.Command
+}
+func (p DirectProcess) GetArgs() []string {
+	return p.Args
+}
+func (p DirectProcess) GetDefault() bool {
+	return p.Default
 }

--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -111,6 +111,26 @@ Entries:
 // name, whether or not it is a default process, the command, arguments, and
 // any process specific environment variables.
 func (e Emitter) LaunchProcesses(processes []packit.Process, processEnvs ...map[string]packit.Environment) {
+	launchProcesses := []packit.LaunchProcesses{}
+	for _, process := range processes {
+		launchProcesses = append(launchProcesses, process)
+	}
+	e.launch(launchProcesses, processEnvs...)
+}
+
+// LaunchDirectProcesses take a list of processes and a map of process specific
+// enivronment varables and prints out a formatted table including the type
+// name, whether or not it is a default process, the command, arguments, and
+// any process specific environment variables.
+func (e Emitter) LaunchDirectProcesses(processes []packit.DirectProcess, processEnvs ...map[string]packit.Environment) {
+	launchProcesses := []packit.LaunchProcesses{}
+	for _, process := range processes {
+		launchProcesses = append(launchProcesses, process)
+	}
+	e.launch(launchProcesses, processEnvs...)
+}
+
+func (e Emitter) launch(processes []packit.LaunchProcesses, processEnvs ...map[string]packit.Environment) {
 	e.Process("Assigning launch processes:")
 
 	var (
@@ -118,8 +138,8 @@ func (e Emitter) LaunchProcesses(processes []packit.Process, processEnvs ...map[
 	)
 
 	for _, process := range processes {
-		pType := process.Type
-		if process.Default {
+		pType := process.GetType()
+		if process.GetDefault() {
 			pType += " " + "(default)"
 		}
 
@@ -129,16 +149,17 @@ func (e Emitter) LaunchProcesses(processes []packit.Process, processEnvs ...map[
 	}
 
 	for _, process := range processes {
-		pType := process.Type
-		if process.Default {
+		pType := process.GetType()
+		if process.GetDefault() {
 			pType += " " + "(default)"
 		}
 
-		pad := typePadding + len(process.Command) - len(pType)
-		p := fmt.Sprintf("%s: %*s", pType, pad, process.Command)
+		command := strings.Join(process.GetCommand(), " ")
+		pad := typePadding + len(command) - len(pType)
+		p := fmt.Sprintf("%s: %*s", pType, pad, command)
 
-		if process.Args != nil {
-			p += " " + strings.Join(process.Args, " ")
+		if process.GetArgs() != nil {
+			p += " " + strings.Join(process.GetArgs(), " ")
 		}
 
 		e.Subprocess(p)
@@ -147,7 +168,7 @@ func (e Emitter) LaunchProcesses(processes []packit.Process, processEnvs ...map[
 		// matter the order of the process envs map list
 		processEnv := packit.Environment{}
 		for _, pEnvs := range processEnvs {
-			if env, ok := pEnvs[process.Type]; ok {
+			if env, ok := pEnvs[process.GetType()]; ok {
 				for key, value := range env {
 					processEnv[key] = value
 				}


### PR DESCRIPTION
## Summary

This PR adds compatible support for buildpack API v0.9 fixing https://github.com/paketo-buildpacks/packit/issues/431. 

## Use Cases

It currently supports three "modes" to stay compatible also with older API versions:

- API < v0.9: No changes required, direct and indirect processes are possible
- API >= v0.9: If only the BP API version is bumped, the provided [`Process`](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/process.go#L18-L39) struct is translated into a [`DirectProcess`](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/process.go#L76-L94) using [`ToDirectProcess`](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/process.go#L54-L68). If it was used as an indirect process, it will be [translated](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/process.go#L56-L58) by prepending `bash` to the original command. I would put this up for discussion if it is the right thing to do. Maybe failing or supporting either the old or the new struct is a better way.
- API >= v0.9: Using [node-start](https://github.com/paketo-buildpacks/node-start/blob/main/build.go) as an example, the new facilities could be used like this:

```go
func Build(applicationFinder ApplicationFinder, logger scribe.Emitter, reloader Reloader) packit.BuildFunc {
	return func(context packit.BuildContext) (packit.BuildResult, error) {
...
		originalProcess := packit.DirectProcess{
			Type:    "web",
			Command: []string{"node"},
			Args:    []string{file},
			Default: true,
		}
...
		logger.LaunchDirectProcesses(processes)
		return packit.BuildResult{
			Launch: packit.LaunchMetadata{
				DirectProcesses: processes,
			},
		}, nil
	}
}
```

The separate [`LaunchProcess`](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/process.go#L5-L10) interface is a bit ugly but it was the easiest way to enable compatibility with the [`emitter`](https://github.com/sap-contributions/packit/blob/c97e53b8120b11bcc311a7208ca75d6ad2a475b7/scribe/emitter.go#L133), but I'm open for alternatives as well. One neat way could be to use generics, but the project is currently using go 1.16. 

## Checklist

* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
