### PR TITLE
Adding Extension config

### DIFF
--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -2,88 +2,55 @@ package cargo
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
-	"time"
 
 	"github.com/BurntSushi/toml"
 )
 
-type Config struct {
-	API       string          `toml:"api"       json:"api,omitempty"`
-	Buildpack ConfigBuildpack `toml:"buildpack" json:"buildpack,omitempty"`
-	Metadata  ConfigMetadata  `toml:"metadata"  json:"metadata,omitempty"`
-	Stacks    []ConfigStack   `toml:"stacks"    json:"stacks,omitempty"`
-	Order     []ConfigOrder   `toml:"order"     json:"order,omitempty"`
+type ExtensionConfig struct {
+	API       string                  `toml:"api"       json:"api,omitempty"`
+	Extension ConfigExtension         `toml:"extension" json:"extension,omitempty"`
+	Metadata  ConfigExtensionMetadata `toml:"metadata"  json:"metadata,omitempty"`
 }
 
-type ConfigStack struct {
-	ID     string   `toml:"id"     json:"id,omitempty"`
-	Mixins []string `toml:"mixins" json:"mixins,omitempty"`
+type ConfigExtensionMetadata struct {
+	IncludeFiles    []string                            `toml:"include-files"              json:"include-files,omitempty"`
+	PrePackage      string                              `toml:"pre-package"                json:"pre-package,omitempty"`
+	DefaultVersions map[string]string                   `toml:"default-versions"           json:"default-versions,omitempty"`
+	Dependencies    []ConfigExtensionMetadataDependency `toml:"dependencies"               json:"dependencies,omitempty"`
 }
 
-type ConfigBuildpack struct {
+type ConfigExtensionMetadataDependency struct {
+	Checksum       string        `toml:"checksum"         json:"checksum,omitempty"`
+	ID             string        `toml:"id"               json:"id,omitempty"`
+	Licenses       []interface{} `toml:"licenses"         json:"licenses,omitempty"`
+	Name           string        `toml:"name"             json:"name,omitempty"`
+	SHA256         string        `toml:"sha256"           json:"sha256,omitempty"`
+	Source         string        `toml:"source"           json:"source,omitempty"`
+	SourceChecksum string        `toml:"source-checksum"  json:"source-checksum,omitempty"`
+	SourceSHA256   string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
+	Stacks         []string      `toml:"stacks"           json:"stacks,omitempty"`
+	URI            string        `toml:"uri"              json:"uri,omitempty"`
+	Version        string        `toml:"version"          json:"version,omitempty"`
+}
+type ConfigExtension struct {
 	ID          string                   `toml:"id"                    json:"id,omitempty"`
 	Name        string                   `toml:"name"                  json:"name,omitempty"`
 	Version     string                   `toml:"version"               json:"version,omitempty"`
 	Homepage    string                   `toml:"homepage,omitempty"    json:"homepage,omitempty"`
-	ClearEnv    bool                     `toml:"clear-env,omitempty"   json:"clear-env,omitempty"`
 	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
 	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
-	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
+	Licenses    []ConfigExtensionLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
 	SBOMFormats []string                 `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
 }
 
-type ConfigBuildpackLicense struct {
+type ConfigExtensionLicense struct {
 	Type string `toml:"type" json:"type"`
 	URI  string `toml:"uri"  json:"uri"`
 }
 
-type ConfigMetadata struct {
-	IncludeFiles          []string                             `toml:"include-files"              json:"include-files,omitempty"`
-	PrePackage            string                               `toml:"pre-package"                json:"pre-package,omitempty"`
-	DefaultVersions       map[string]string                    `toml:"default-versions"           json:"default-versions,omitempty"`
-	Dependencies          []ConfigMetadataDependency           `toml:"dependencies"               json:"dependencies,omitempty"`
-	DependencyConstraints []ConfigMetadataDependencyConstraint `toml:"dependency-constraints"     json:"dependency-constraints,omitempty"`
-	Unstructured          map[string]interface{}               `toml:"-"                          json:"-"`
-}
-
-type ConfigMetadataDependency struct {
-	Checksum        string        `toml:"checksum"         json:"checksum,omitempty"`
-	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
-	PURL            string        `toml:"purl"             json:"purl,omitempty"`
-	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
-	ID              string        `toml:"id"               json:"id,omitempty"`
-	Licenses        []interface{} `toml:"licenses"         json:"licenses,omitempty"`
-	Name            string        `toml:"name"             json:"name,omitempty"`
-	SHA256          string        `toml:"sha256"           json:"sha256,omitempty"`
-	Source          string        `toml:"source"           json:"source,omitempty"`
-	SourceChecksum  string        `toml:"source-checksum"  json:"source-checksum,omitempty"`
-	SourceSHA256    string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
-	Stacks          []string      `toml:"stacks"           json:"stacks,omitempty"`
-	StripComponents int           `toml:"strip-components" json:"strip-components,omitempty"`
-	URI             string        `toml:"uri"              json:"uri,omitempty"`
-	Version         string        `toml:"version"          json:"version,omitempty"`
-}
-
-type ConfigMetadataDependencyConstraint struct {
-	Constraint string `toml:"constraint"       json:"constraint,omitempty"`
-	ID         string `toml:"id"               json:"id,omitempty"`
-	Patches    int    `toml:"patches"          json:"patches,omitempty"`
-}
-
-type ConfigOrder struct {
-	Group []ConfigOrderGroup `toml:"group" json:"group,omitempty"`
-}
-
-type ConfigOrderGroup struct {
-	ID       string `toml:"id"       json:"id,omitempty"`
-	Version  string `toml:"version"  json:"version,omitempty"`
-	Optional bool   `toml:"optional,omitempty" json:"optional,omitempty"`
-}
-
-func EncodeConfig(writer io.Writer, config Config) error {
-	content, err := json.Marshal(config)
+func EncodeExtensionConfig(writer io.Writer, extensionConfig ExtensionConfig) error {
+	content, err := json.Marshal(extensionConfig)
 	if err != nil {
 		return err
 	}
@@ -94,20 +61,10 @@ func EncodeConfig(writer io.Writer, config Config) error {
 		return err
 	}
 
-	c, err = convertPatches(config.Metadata.DependencyConstraints, c)
-	if err != nil {
-		return err
-	}
-
-	c, err = convertStripComponents(config.Metadata.Dependencies, c)
-	if err != nil {
-		return err
-	}
-
 	return toml.NewEncoder(writer).Encode(c)
 }
 
-func DecodeConfig(reader io.Reader, config *Config) error {
+func DecodeExtensionConfig(reader io.Reader, extensionConfig *ExtensionConfig) error {
 	var c map[string]interface{}
 	_, err := toml.NewDecoder(reader).Decode(&c)
 	if err != nil {
@@ -119,161 +76,5 @@ func DecodeConfig(reader io.Reader, config *Config) error {
 		return err
 	}
 
-	return json.Unmarshal(content, config)
-}
-
-func (m ConfigMetadata) MarshalJSON() ([]byte, error) {
-	metadata := map[string]interface{}{}
-
-	for key, value := range m.Unstructured {
-		metadata[key] = value
-	}
-
-	if len(m.IncludeFiles) > 0 {
-		metadata["include-files"] = m.IncludeFiles
-	}
-
-	if len(m.PrePackage) > 0 {
-		metadata["pre-package"] = m.PrePackage
-	}
-
-	if len(m.Dependencies) > 0 {
-		metadata["dependencies"] = m.Dependencies
-	}
-
-	if len(m.DependencyConstraints) > 0 {
-		metadata["dependency-constraints"] = m.DependencyConstraints
-	}
-
-	if len(m.DefaultVersions) > 0 {
-		metadata["default-versions"] = m.DefaultVersions
-	}
-
-	return json.Marshal(metadata)
-}
-
-func (m *ConfigMetadata) UnmarshalJSON(data []byte) error {
-	var metadata map[string]json.RawMessage
-	err := json.Unmarshal(data, &metadata)
-	if err != nil {
-		return err
-	}
-
-	if includeFiles, ok := metadata["include-files"]; ok {
-		err = json.Unmarshal(includeFiles, &m.IncludeFiles)
-		if err != nil {
-			return err
-		}
-		delete(metadata, "include-files")
-	}
-
-	if prePackage, ok := metadata["pre-package"]; ok {
-		err = json.Unmarshal(prePackage, &m.PrePackage)
-		if err != nil {
-			return err
-		}
-		delete(metadata, "pre-package")
-	}
-
-	if dependencies, ok := metadata["dependencies"]; ok {
-		err = json.Unmarshal(dependencies, &m.Dependencies)
-		if err != nil {
-			return err
-		}
-		delete(metadata, "dependencies")
-	}
-
-	if dependencyConstraints, ok := metadata["dependency-constraints"]; ok {
-		err = json.Unmarshal(dependencyConstraints, &m.DependencyConstraints)
-		if err != nil {
-			return err
-		}
-		delete(metadata, "dependency-constraints")
-	}
-
-	if defaultVersions, ok := metadata["default-versions"]; ok {
-		err = json.Unmarshal(defaultVersions, &m.DefaultVersions)
-		if err != nil {
-			return err
-		}
-		delete(metadata, "default-versions")
-	}
-
-	if len(metadata) > 0 {
-		m.Unstructured = map[string]interface{}{}
-		for key, value := range metadata {
-			m.Unstructured[key] = value
-		}
-	}
-
-	return nil
-}
-
-func (cd ConfigMetadataDependency) HasStack(stack string) bool {
-	for _, s := range cd.Stacks {
-		if s == stack {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Unmarshal stores json numbers in float64 types, adding an unnecessary decimal point to the patch in the final toml.
-// convertPatches converts this float64 into an int and returns a new map that contains an integer value for patches
-func convertPatches(cons []ConfigMetadataDependencyConstraint, c map[string]interface{}) (map[string]interface{}, error) {
-	if len(cons) > 0 {
-		metadata, ok := c["metadata"].(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failure to assert type: unexpected data in metadata")
-		}
-
-		constraints, ok := metadata["dependency-constraints"].([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failure to assert type: unexpected data in constraints")
-		}
-
-		for _, dependencyConstraint := range constraints {
-			patches, ok := dependencyConstraint.(map[string]interface{})["patches"]
-			if !ok {
-				return nil, fmt.Errorf("failure to assert type: unexpected data in constraint patches")
-			}
-
-			floatPatches, ok := patches.(float64)
-			if !ok {
-				return nil, fmt.Errorf("failure to assert type: unexpected data")
-			}
-			dependencyConstraint.(map[string]interface{})["patches"] = int(floatPatches)
-		}
-	}
-	return c, nil
-}
-
-// Accomplishes the same this as the convertPatches function but for strip components in the dependencies list.
-func convertStripComponents(deps []ConfigMetadataDependency, c map[string]interface{}) (map[string]interface{}, error) {
-	if len(deps) > 0 {
-		metadata, ok := c["metadata"].(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failure to assert type: unexpected data in metadata")
-		}
-
-		dependencies, ok := metadata["dependencies"].([]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failure to assert type: unexpected data in constraints")
-		}
-
-		for _, dependency := range dependencies {
-			stripComponents, ok := dependency.(map[string]interface{})["strip-components"]
-			if !ok {
-				continue
-			}
-
-			floatStripComponents, ok := stripComponents.(float64)
-			if !ok {
-				return nil, fmt.Errorf("failure to assert type: unexpected data")
-			}
-			dependency.(map[string]interface{})["strip-components"] = int(floatStripComponents)
-		}
-	}
-	return c, nil
+	return json.Unmarshal(content, extensionConfig)
 }

--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -14,10 +14,11 @@ type ExtensionConfig struct {
 }
 
 type ConfigExtensionMetadata struct {
-	IncludeFiles    []string                            `toml:"include-files"              json:"include-files,omitempty"`
-	PrePackage      string                              `toml:"pre-package"                json:"pre-package,omitempty"`
-	DefaultVersions map[string]string                   `toml:"default-versions"           json:"default-versions,omitempty"`
-	Dependencies    []ConfigExtensionMetadataDependency `toml:"dependencies"               json:"dependencies,omitempty"`
+	IncludeFiles    []string                               `toml:"include-files"              json:"include-files,omitempty"`
+	PrePackage      string                                 `toml:"pre-package"                json:"pre-package,omitempty"`
+	DefaultVersions map[string]string                      `toml:"default-versions"           json:"default-versions,omitempty"`
+	Dependencies    []ConfigExtensionMetadataDependency    `toml:"dependencies"               json:"dependencies,omitempty"`
+	Configurations  []ConfigExtensionMetadataConfiguration `toml:"configurations"             json:"configurations,omitempty"`
 }
 
 type ConfigExtensionMetadataDependency struct {
@@ -32,6 +33,13 @@ type ConfigExtensionMetadataDependency struct {
 	Stacks         []string      `toml:"stacks"           json:"stacks,omitempty"`
 	URI            string        `toml:"uri"              json:"uri,omitempty"`
 	Version        string        `toml:"version"          json:"version,omitempty"`
+}
+type ConfigExtensionMetadataConfiguration struct {
+	Default     string `toml:"default"          json:"default,omitempty"`
+	Description string `toml:"description"	    json:"description,omitempty"`
+	Launch      bool   `toml:"launch"	        json:"launch,omitempty"`
+	Name        string `toml:"name"             json:"name,omitempty"`
+	Build       bool   `toml:"build"	        json:"build,omitempty"`
 }
 type ConfigExtension struct {
 	ID          string                   `toml:"id"                    json:"id,omitempty"`

--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -1,0 +1,279 @@
+package cargo
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/BurntSushi/toml"
+)
+
+type Config struct {
+	API       string          `toml:"api"       json:"api,omitempty"`
+	Buildpack ConfigBuildpack `toml:"buildpack" json:"buildpack,omitempty"`
+	Metadata  ConfigMetadata  `toml:"metadata"  json:"metadata,omitempty"`
+	Stacks    []ConfigStack   `toml:"stacks"    json:"stacks,omitempty"`
+	Order     []ConfigOrder   `toml:"order"     json:"order,omitempty"`
+}
+
+type ConfigStack struct {
+	ID     string   `toml:"id"     json:"id,omitempty"`
+	Mixins []string `toml:"mixins" json:"mixins,omitempty"`
+}
+
+type ConfigBuildpack struct {
+	ID          string                   `toml:"id"                    json:"id,omitempty"`
+	Name        string                   `toml:"name"                  json:"name,omitempty"`
+	Version     string                   `toml:"version"               json:"version,omitempty"`
+	Homepage    string                   `toml:"homepage,omitempty"    json:"homepage,omitempty"`
+	ClearEnv    bool                     `toml:"clear-env,omitempty"   json:"clear-env,omitempty"`
+	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
+	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
+	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
+	SBOMFormats []string                 `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
+}
+
+type ConfigBuildpackLicense struct {
+	Type string `toml:"type" json:"type"`
+	URI  string `toml:"uri"  json:"uri"`
+}
+
+type ConfigMetadata struct {
+	IncludeFiles          []string                             `toml:"include-files"              json:"include-files,omitempty"`
+	PrePackage            string                               `toml:"pre-package"                json:"pre-package,omitempty"`
+	DefaultVersions       map[string]string                    `toml:"default-versions"           json:"default-versions,omitempty"`
+	Dependencies          []ConfigMetadataDependency           `toml:"dependencies"               json:"dependencies,omitempty"`
+	DependencyConstraints []ConfigMetadataDependencyConstraint `toml:"dependency-constraints"     json:"dependency-constraints,omitempty"`
+	Unstructured          map[string]interface{}               `toml:"-"                          json:"-"`
+}
+
+type ConfigMetadataDependency struct {
+	Checksum        string        `toml:"checksum"         json:"checksum,omitempty"`
+	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
+	PURL            string        `toml:"purl"             json:"purl,omitempty"`
+	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
+	ID              string        `toml:"id"               json:"id,omitempty"`
+	Licenses        []interface{} `toml:"licenses"         json:"licenses,omitempty"`
+	Name            string        `toml:"name"             json:"name,omitempty"`
+	SHA256          string        `toml:"sha256"           json:"sha256,omitempty"`
+	Source          string        `toml:"source"           json:"source,omitempty"`
+	SourceChecksum  string        `toml:"source-checksum"  json:"source-checksum,omitempty"`
+	SourceSHA256    string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
+	Stacks          []string      `toml:"stacks"           json:"stacks,omitempty"`
+	StripComponents int           `toml:"strip-components" json:"strip-components,omitempty"`
+	URI             string        `toml:"uri"              json:"uri,omitempty"`
+	Version         string        `toml:"version"          json:"version,omitempty"`
+}
+
+type ConfigMetadataDependencyConstraint struct {
+	Constraint string `toml:"constraint"       json:"constraint,omitempty"`
+	ID         string `toml:"id"               json:"id,omitempty"`
+	Patches    int    `toml:"patches"          json:"patches,omitempty"`
+}
+
+type ConfigOrder struct {
+	Group []ConfigOrderGroup `toml:"group" json:"group,omitempty"`
+}
+
+type ConfigOrderGroup struct {
+	ID       string `toml:"id"       json:"id,omitempty"`
+	Version  string `toml:"version"  json:"version,omitempty"`
+	Optional bool   `toml:"optional,omitempty" json:"optional,omitempty"`
+}
+
+func EncodeConfig(writer io.Writer, config Config) error {
+	content, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	c := map[string]interface{}{}
+	err = json.Unmarshal(content, &c)
+	if err != nil {
+		return err
+	}
+
+	c, err = convertPatches(config.Metadata.DependencyConstraints, c)
+	if err != nil {
+		return err
+	}
+
+	c, err = convertStripComponents(config.Metadata.Dependencies, c)
+	if err != nil {
+		return err
+	}
+
+	return toml.NewEncoder(writer).Encode(c)
+}
+
+func DecodeConfig(reader io.Reader, config *Config) error {
+	var c map[string]interface{}
+	_, err := toml.NewDecoder(reader).Decode(&c)
+	if err != nil {
+		return err
+	}
+
+	content, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	return json.Unmarshal(content, config)
+}
+
+func (m ConfigMetadata) MarshalJSON() ([]byte, error) {
+	metadata := map[string]interface{}{}
+
+	for key, value := range m.Unstructured {
+		metadata[key] = value
+	}
+
+	if len(m.IncludeFiles) > 0 {
+		metadata["include-files"] = m.IncludeFiles
+	}
+
+	if len(m.PrePackage) > 0 {
+		metadata["pre-package"] = m.PrePackage
+	}
+
+	if len(m.Dependencies) > 0 {
+		metadata["dependencies"] = m.Dependencies
+	}
+
+	if len(m.DependencyConstraints) > 0 {
+		metadata["dependency-constraints"] = m.DependencyConstraints
+	}
+
+	if len(m.DefaultVersions) > 0 {
+		metadata["default-versions"] = m.DefaultVersions
+	}
+
+	return json.Marshal(metadata)
+}
+
+func (m *ConfigMetadata) UnmarshalJSON(data []byte) error {
+	var metadata map[string]json.RawMessage
+	err := json.Unmarshal(data, &metadata)
+	if err != nil {
+		return err
+	}
+
+	if includeFiles, ok := metadata["include-files"]; ok {
+		err = json.Unmarshal(includeFiles, &m.IncludeFiles)
+		if err != nil {
+			return err
+		}
+		delete(metadata, "include-files")
+	}
+
+	if prePackage, ok := metadata["pre-package"]; ok {
+		err = json.Unmarshal(prePackage, &m.PrePackage)
+		if err != nil {
+			return err
+		}
+		delete(metadata, "pre-package")
+	}
+
+	if dependencies, ok := metadata["dependencies"]; ok {
+		err = json.Unmarshal(dependencies, &m.Dependencies)
+		if err != nil {
+			return err
+		}
+		delete(metadata, "dependencies")
+	}
+
+	if dependencyConstraints, ok := metadata["dependency-constraints"]; ok {
+		err = json.Unmarshal(dependencyConstraints, &m.DependencyConstraints)
+		if err != nil {
+			return err
+		}
+		delete(metadata, "dependency-constraints")
+	}
+
+	if defaultVersions, ok := metadata["default-versions"]; ok {
+		err = json.Unmarshal(defaultVersions, &m.DefaultVersions)
+		if err != nil {
+			return err
+		}
+		delete(metadata, "default-versions")
+	}
+
+	if len(metadata) > 0 {
+		m.Unstructured = map[string]interface{}{}
+		for key, value := range metadata {
+			m.Unstructured[key] = value
+		}
+	}
+
+	return nil
+}
+
+func (cd ConfigMetadataDependency) HasStack(stack string) bool {
+	for _, s := range cd.Stacks {
+		if s == stack {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Unmarshal stores json numbers in float64 types, adding an unnecessary decimal point to the patch in the final toml.
+// convertPatches converts this float64 into an int and returns a new map that contains an integer value for patches
+func convertPatches(cons []ConfigMetadataDependencyConstraint, c map[string]interface{}) (map[string]interface{}, error) {
+	if len(cons) > 0 {
+		metadata, ok := c["metadata"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failure to assert type: unexpected data in metadata")
+		}
+
+		constraints, ok := metadata["dependency-constraints"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failure to assert type: unexpected data in constraints")
+		}
+
+		for _, dependencyConstraint := range constraints {
+			patches, ok := dependencyConstraint.(map[string]interface{})["patches"]
+			if !ok {
+				return nil, fmt.Errorf("failure to assert type: unexpected data in constraint patches")
+			}
+
+			floatPatches, ok := patches.(float64)
+			if !ok {
+				return nil, fmt.Errorf("failure to assert type: unexpected data")
+			}
+			dependencyConstraint.(map[string]interface{})["patches"] = int(floatPatches)
+		}
+	}
+	return c, nil
+}
+
+// Accomplishes the same this as the convertPatches function but for strip components in the dependencies list.
+func convertStripComponents(deps []ConfigMetadataDependency, c map[string]interface{}) (map[string]interface{}, error) {
+	if len(deps) > 0 {
+		metadata, ok := c["metadata"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failure to assert type: unexpected data in metadata")
+		}
+
+		dependencies, ok := metadata["dependencies"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failure to assert type: unexpected data in constraints")
+		}
+
+		for _, dependency := range dependencies {
+			stripComponents, ok := dependency.(map[string]interface{})["strip-components"]
+			if !ok {
+				continue
+			}
+
+			floatStripComponents, ok := stripComponents.(float64)
+			if !ok {
+				return nil, fmt.Errorf("failure to assert type: unexpected data")
+			}
+			dependency.(map[string]interface{})["strip-components"] = int(floatStripComponents)
+		}
+	}
+	return c, nil
+}

--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -36,10 +36,10 @@ type ConfigExtensionMetadataDependency struct {
 }
 type ConfigExtensionMetadataConfiguration struct {
 	Default     string `toml:"default"          json:"default,omitempty"`
-	Description string `toml:"description"	    json:"description,omitempty"`
-	Launch      bool   `toml:"launch"	        json:"launch,omitempty"`
+	Launch      bool   `toml:"launch"           json:"launch,omitempty"`
+	Description string `toml:"description"      json:"description,omitempty"`
+	Build       bool   `toml:"build"            json:"build,omitempty"`
 	Name        string `toml:"name"             json:"name,omitempty"`
-	Build       bool   `toml:"build"	        json:"build,omitempty"`
 }
 type ConfigExtension struct {
 	ID          string                   `toml:"id"                    json:"id,omitempty"`

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -1,6 +1,8 @@
 package cargo_test
 
 import (
+	"bytes"
+
 	"strings"
 	"testing"
 
@@ -8,12 +10,117 @@ import (
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/v2/matchers"
 )
 
 func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
+		buffer *bytes.Buffer
 	)
+
+	it.Before(func() {
+		buffer = bytes.NewBuffer(nil)
+	})
+
+	context("EncodeConfig", func() {
+		it("encodes the config to TOML", func() {
+
+			err := cargo.EncodeExtensionConfig(buffer, cargo.ExtensionConfig{
+				API: "0.7",
+				Extension: cargo.ConfigExtension{
+					ID:          "some-extension-id",
+					Name:        "some-extension-name",
+					Version:     "some-extension-version",
+					Homepage:    "some-extension-homepage",
+					Description: "some-extension-description",
+					Keywords:    []string{"some-extension-keyword"},
+					Licenses: []cargo.ConfigExtensionLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
+				},
+				Metadata: cargo.ConfigExtensionMetadata{
+					IncludeFiles: []string{
+						"some-include-file",
+						"other-include-file",
+					},
+					PrePackage: "some-pre-package-script.sh",
+					Dependencies: []cargo.ConfigExtensionMetadataDependency{
+						{
+							Checksum:       "sha256:some-sum",
+							ID:             "some-dependency",
+							Licenses:       []interface{}{"fancy-license", "fancy-license-2"},
+							Name:           "Some Dependency",
+							SHA256:         "shasum",
+							Source:         "source",
+							SourceChecksum: "sha256:source-shasum",
+							SourceSHA256:   "source-shasum",
+							Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:            "http://some-url",
+							Version:        "1.2.3",
+						},
+					},
+					Configurations: []cargo.ConfigExtensionMetadataConfiguration{
+						{
+							Default:     "0",
+							Description: "some-metadata-configuration-description",
+							Launch:      true,
+							Name:        "SOME_METADATA_CONFIGURATION_NAME",
+							Build:       true,
+						},
+					},
+					DefaultVersions: map[string]string{
+						"some-dependency": "1.2.x",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buffer.String()).To(MatchTOML(`
+api = "0.7"
+
+[extension]
+  description = "some-extension-description"
+  homepage = "some-extension-homepage"
+  id = "some-extension-id"
+  keywords = ["some-extension-keyword"]
+  name = "some-extension-name"
+  version = "some-extension-version"
+
+  [[extension.licenses]]
+    type = "some-license-type"
+    uri = "some-license-uri"
+
+[metadata]
+  include-files = ["some-include-file", "other-include-file"]
+  pre-package = "some-pre-package-script.sh"
+
+  [[metadata.configurations]]
+    build = true
+    description = "some-metadata-configuration-description"
+    launch = true
+    default = "0"
+    name = "SOME_METADATA_CONFIGURATION_NAME"
+  [metadata.default-versions]
+    some-dependency = "1.2.x"
+
+  [[metadata.dependencies]]
+    checksum = "sha256:some-sum"
+    id = "some-dependency"
+    licenses = ["fancy-license", "fancy-license-2"]
+    name = "Some Dependency"
+    sha256 = "shasum"
+    source = "source"
+    source-checksum = "sha256:source-shasum"
+    source_sha256 = "source-shasum"
+    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+    uri = "http://some-url"
+    version = "1.2.3"
+`))
+		})
+	})
 
 	context("DecodeExtensionConfig", func() {
 		it("decodes TOML to Extensionconfig", func() {
@@ -38,9 +145,6 @@ keywords = [ "some-extension-keyword" ]
 
 [metadata.default-versions]
 	some-dependency = "1.2.x"
-
-[[metadata.some-map]]
-	key = "value"
 
 [[metadata.dependencies]]
 	checksum = "sha256:some-sum"

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -1,0 +1,800 @@
+package cargo_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/packit/v2/matchers"
+)
+
+func testConfig(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		buffer *bytes.Buffer
+	)
+
+	it.Before(func() {
+		buffer = bytes.NewBuffer(nil)
+	})
+
+	context("EncodeConfig", func() {
+		it("encodes the config to TOML", func() {
+			deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cargo.EncodeConfig(buffer, cargo.Config{
+				API: "0.6",
+				Buildpack: cargo.ConfigBuildpack{
+					ID:          "some-buildpack-id",
+					Name:        "some-buildpack-name",
+					Version:     "some-buildpack-version",
+					Homepage:    "some-buildpack-homepage",
+					ClearEnv:    true,
+					Description: "some-buildpack-description",
+					Keywords:    []string{"some-buildpack-keyword"},
+					Licenses: []cargo.ConfigBuildpackLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
+					SBOMFormats: []string{"some-sbom-format"},
+				},
+				Stacks: []cargo.ConfigStack{
+					{
+						ID:     "some-stack-id",
+						Mixins: []string{"some-mixin-id"},
+					},
+					{
+						ID: "other-stack-id",
+					},
+				},
+				Metadata: cargo.ConfigMetadata{
+					IncludeFiles: []string{
+						"some-include-file",
+						"other-include-file",
+					},
+					Unstructured: map[string]interface{}{"some-map": []map[string]interface{}{{"key": "value"}}},
+					PrePackage:   "some-pre-package-script.sh",
+					Dependencies: []cargo.ConfigMetadataDependency{
+						{
+							Checksum:        "sha256:some-sum",
+							CPE:             "some-cpe",
+							PURL:            "some-purl",
+							DeprecationDate: &deprecationDate,
+							ID:              "some-dependency",
+							Licenses:        []interface{}{"fancy-license", "fancy-license-2"},
+							Name:            "Some Dependency",
+							SHA256:          "shasum",
+							Source:          "source",
+							SourceChecksum:  "sha256:source-shasum",
+							SourceSHA256:    "source-shasum",
+							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							StripComponents: 1,
+							URI:             "http://some-url",
+							Version:         "1.2.3",
+						},
+					},
+					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+						{
+							ID:         "some-dependency",
+							Constraint: "1.*",
+							Patches:    1,
+						},
+					},
+					DefaultVersions: map[string]string{
+						"some-dependency": "1.2.x",
+					},
+				},
+				Order: []cargo.ConfigOrder{
+					{
+						Group: []cargo.ConfigOrderGroup{
+							{
+								ID:      "some-dependency",
+								Version: "some-version"},
+							{
+								ID:       "other-dependency",
+								Version:  "other-version",
+								Optional: true,
+							},
+						},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buffer.String()).To(MatchTOML(`
+api = "0.6"
+
+[buildpack]
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-buildpack-homepage"
+	clear-env = true
+	description = "some-buildpack-description"
+	keywords = [ "some-buildpack-keyword" ]
+	sbom-formats = [ "some-sbom-format" ]
+
+[[buildpack.licenses]]
+  type = "some-license-type"
+	uri = "some-license-uri"
+
+[metadata]
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[metadata.default-versions]
+	some-dependency = "1.2.x"
+
+[[metadata.dependencies]]
+	checksum = "sha256:some-sum"
+  cpe = "some-cpe"
+  purl = "some-purl"
+  deprecation_date = "2020-06-01T00:00:00Z"
+  id = "some-dependency"
+	licenses = ["fancy-license", "fancy-license-2"]
+  name = "Some Dependency"
+  sha256 = "shasum"
+	source = "source"
+	source-checksum = "sha256:source-shasum"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+  strip-components = 1
+  uri = "http://some-url"
+  version = "1.2.3"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1
+
+[[metadata.some-map]]
+  key = "value"
+
+[[stacks]]
+  id = "some-stack-id"
+  mixins = ["some-mixin-id"]
+
+[[stacks]]
+  id = "other-stack-id"
+
+[[order]]
+  [[order.group]]
+	  id = "some-dependency"
+		version = "some-version"
+
+  [[order.group]]
+		id = "other-dependency"
+		version = "other-version"
+		optional = true
+`))
+		})
+
+		context("when the config dependency licenses are structured like ConfigBuildpackLicenses", func() {
+			it("encodes the config to TOML", func() {
+				deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = cargo.EncodeConfig(buffer, cargo.Config{
+					API: "0.6",
+					Buildpack: cargo.ConfigBuildpack{
+						ID:       "some-buildpack-id",
+						Name:     "some-buildpack-name",
+						Version:  "some-buildpack-version",
+						Homepage: "some-homepage-link",
+						Licenses: []cargo.ConfigBuildpackLicense{
+							{
+								Type: "some-license-type",
+								URI:  "some-license-uri",
+							},
+						},
+					},
+					Stacks: []cargo.ConfigStack{
+						{
+							ID:     "some-stack-id",
+							Mixins: []string{"some-mixin-id"},
+						},
+						{
+							ID: "other-stack-id",
+						},
+					},
+					Metadata: cargo.ConfigMetadata{
+						IncludeFiles: []string{
+							"some-include-file",
+							"other-include-file",
+						},
+						Unstructured: map[string]interface{}{"some-map": []map[string]interface{}{{"key": "value"}}},
+						PrePackage:   "some-pre-package-script.sh",
+						Dependencies: []cargo.ConfigMetadataDependency{
+							{
+								Checksum:        "sha256:some-sum",
+								CPE:             "some-cpe",
+								PURL:            "some-purl",
+								DeprecationDate: &deprecationDate,
+								ID:              "some-dependency",
+								Licenses: []interface{}{
+									cargo.ConfigBuildpackLicense{
+										Type: "fancy-license",
+										URI:  "some-license-uri",
+									},
+									cargo.ConfigBuildpackLicense{
+										Type: "fancy-license-2",
+										URI:  "some-license-uri",
+									},
+								},
+								Name:           "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
+							},
+						},
+						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+							{
+								ID:         "some-dependency",
+								Constraint: "1.*",
+								Patches:    1,
+							},
+						},
+						DefaultVersions: map[string]string{
+							"some-dependency": "1.2.x",
+						},
+					},
+					Order: []cargo.ConfigOrder{
+						{
+							Group: []cargo.ConfigOrderGroup{
+								{
+									ID:      "some-dependency",
+									Version: "some-version"},
+								{
+									ID:       "other-dependency",
+									Version:  "other-version",
+									Optional: true,
+								},
+							},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(buffer.String()).To(MatchTOML(`
+api = "0.6"
+
+[buildpack]
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-homepage-link"
+
+[[buildpack.licenses]]
+  type = "some-license-type"
+	uri = "some-license-uri"
+
+[metadata]
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[metadata.default-versions]
+	some-dependency = "1.2.x"
+
+[[metadata.dependencies]]
+	checksum = "sha256:some-sum"
+  cpe = "some-cpe"
+  purl = "some-purl"
+  deprecation_date = "2020-06-01T00:00:00Z"
+  id = "some-dependency"
+  name = "Some Dependency"
+  sha256 = "shasum"
+	source = "source"
+	source-checksum = "sha256:source-shasum"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+  uri = "http://some-url"
+  version = "1.2.3"
+
+  [[metadata.dependencies.licenses]]
+    type = "fancy-license"
+	  uri = "some-license-uri"
+
+	[[metadata.dependencies.licenses]]
+    type = "fancy-license-2"
+	  uri = "some-license-uri"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1
+
+[[metadata.some-map]]
+  key = "value"
+
+[[stacks]]
+  id = "some-stack-id"
+  mixins = ["some-mixin-id"]
+
+[[stacks]]
+  id = "other-stack-id"
+
+[[order]]
+  [[order.group]]
+	  id = "some-dependency"
+		version = "some-version"
+
+  [[order.group]]
+		id = "other-dependency"
+		version = "other-version"
+		optional = true
+`))
+			})
+
+		})
+
+		context("when not all metadata.dependencies include strip-components", func() {
+			it("correctly encodes all elements", func() {
+				err := cargo.EncodeConfig(buffer, cargo.Config{
+					API: "0.6",
+					Buildpack: cargo.ConfigBuildpack{
+						ID: "some-buildpack-id",
+					},
+					Metadata: cargo.ConfigMetadata{
+						Dependencies: []cargo.ConfigMetadataDependency{
+							{
+								ID: "some-dependency",
+							},
+							{
+								ID:              "other-dependency",
+								StripComponents: 1,
+							},
+						},
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(buffer.String()).To(MatchTOML(`
+api = "0.6"
+
+[buildpack]
+	id = "some-buildpack-id"
+
+[[metadata.dependencies]]
+  id = "some-dependency"
+
+[[metadata.dependencies]]
+  id = "other-dependency"
+	strip-components = 1
+`))
+			})
+
+		})
+
+		context("failure cases", func() {
+			context("when the Config cannot be marshalled to json", func() {
+				it("returns an error", func() {
+					err := cargo.EncodeConfig(bytes.NewBuffer(nil), cargo.Config{
+						Metadata: cargo.ConfigMetadata{
+							Unstructured: map[string]interface{}{
+								"some-key": func() {},
+							},
+						},
+					})
+
+					Expect(err).To(MatchError(ContainSubstring("json: unsupported type")))
+				})
+			})
+
+			context("when the patches in dependency constraints cannot be converted to an int", func() {
+				it("returns an error", func() {
+					err := cargo.EncodeConfig(bytes.NewBuffer(nil), cargo.Config{
+						Metadata: cargo.ConfigMetadata{
+							DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+								{
+									Constraint: "some-valid-constraint",
+									ID:         "some-valid-ID",
+									Patches:    0,
+								},
+							},
+						},
+					})
+					Expect(err).To(MatchError(ContainSubstring("failure to assert type: unexpected data in constraint patches")))
+				})
+			})
+		})
+	})
+
+	context("DecodeConfig", func() {
+		it("decodes TOML to config", func() {
+			tomlBuffer := strings.NewReader(`
+api = "0.6"
+
+[buildpack]
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-buildpack-homepage"
+	clear-env = true
+	description = "some-buildpack-description"
+	keywords = [ "some-buildpack-keyword" ]
+	sbom-formats = [ "some-sbom-format" ]
+
+[[buildpack.licenses]]
+	type = "some-license-type"
+	uri = "some-license-uri"
+
+[metadata]
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[metadata.default-versions]
+	some-dependency = "1.2.x"
+
+[[metadata.some-map]]
+  key = "value"
+
+[[metadata.dependencies]]
+	checksum = "sha256:some-sum"
+  cpe = "some-cpe"
+  purl = "some-purl"
+  id = "some-dependency"
+	licenses = ["fancy-license", "fancy-license-2"]
+  name = "Some Dependency"
+  sha256 = "shasum"
+  source = "source"
+  source-checksum = "sha256:source-shasum"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+	strip-components = 1
+  uri = "http://some-url"
+  version = "1.2.3"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1
+
+[[stacks]]
+  id = "some-stack-id"
+  mixins = ["some-mixin-id"]
+
+[[stacks]]
+  id = "other-stack-id"
+
+[[order]]
+  [[order.group]]
+	  id = "some-dependency"
+		version = "some-version"
+
+  [[order.group]]
+		id = "other-dependency"
+		version = "other-version"
+		optional = true
+`)
+
+			var config cargo.Config
+			Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
+			Expect(config).To(Equal(cargo.Config{
+				API: "0.6",
+				Buildpack: cargo.ConfigBuildpack{
+					ID:          "some-buildpack-id",
+					Name:        "some-buildpack-name",
+					Version:     "some-buildpack-version",
+					Homepage:    "some-buildpack-homepage",
+					ClearEnv:    true,
+					Description: "some-buildpack-description",
+					Keywords:    []string{"some-buildpack-keyword"},
+					Licenses: []cargo.ConfigBuildpackLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
+					SBOMFormats: []string{"some-sbom-format"},
+				},
+				Stacks: []cargo.ConfigStack{
+					{
+						ID:     "some-stack-id",
+						Mixins: []string{"some-mixin-id"},
+					},
+					{
+						ID: "other-stack-id",
+					},
+				},
+				Metadata: cargo.ConfigMetadata{
+					Unstructured: map[string]interface{}{"some-map": json.RawMessage(`[{"key":"value"}]`)},
+					IncludeFiles: []string{
+						"some-include-file",
+						"other-include-file",
+					},
+					PrePackage: "some-pre-package-script.sh",
+					Dependencies: []cargo.ConfigMetadataDependency{
+						{
+							Checksum:        "sha256:some-sum",
+							CPE:             "some-cpe",
+							PURL:            "some-purl",
+							ID:              "some-dependency",
+							Licenses:        []interface{}{"fancy-license", "fancy-license-2"},
+							Name:            "Some Dependency",
+							SHA256:          "shasum",
+							Source:          "source",
+							SourceChecksum:  "sha256:source-shasum",
+							SourceSHA256:    "source-shasum",
+							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							StripComponents: 1,
+							URI:             "http://some-url",
+							Version:         "1.2.3",
+						},
+					},
+					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+						{
+							ID:         "some-dependency",
+							Constraint: "1.*",
+							Patches:    1,
+						},
+					},
+					DefaultVersions: map[string]string{
+						"some-dependency": "1.2.x",
+					},
+				},
+				Order: []cargo.ConfigOrder{
+					{
+						Group: []cargo.ConfigOrderGroup{
+							{
+								ID:       "some-dependency",
+								Version:  "some-version",
+								Optional: false,
+							},
+							{
+								ID:       "other-dependency",
+								Version:  "other-version",
+								Optional: true,
+							},
+						},
+					},
+				},
+			}))
+		})
+
+		context("dependency license are not a list of IDs", func() {
+			it("decodes TOML to config", func() {
+				tomlBuffer := strings.NewReader(`
+api = "0.2"
+
+[buildpack]
+	id = "some-buildpack-id"
+	name = "some-buildpack-name"
+	version = "some-buildpack-version"
+	homepage = "some-homepage-link"
+
+[[buildpack.licenses]]
+	type = "some-license-type"
+	uri = "some-license-uri"
+
+[metadata]
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[metadata.default-versions]
+	some-dependency = "1.2.x"
+
+[[metadata.some-map]]
+  key = "value"
+
+[[metadata.dependencies]]
+	checksum = "sha256:some-sum"
+  cpe = "some-cpe"
+  purl = "some-purl"
+  id = "some-dependency"
+  name = "Some Dependency"
+  sha256 = "shasum"
+  source = "source"
+  source-checksum = "sha256:source-shasum"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+  uri = "http://some-url"
+  version = "1.2.3"
+
+  [[metadata.dependencies.licenses]]
+    type = "fancy-license"
+	  uri = "some-license-uri"
+
+	[[metadata.dependencies.licenses]]
+    type = "fancy-license-2"
+	  uri = "some-license-uri"
+
+[[metadata.dependency-constraints]]
+  id = "some-dependency"
+  constraint = "1.*"
+	patches = 1
+
+[[stacks]]
+  id = "some-stack-id"
+  mixins = ["some-mixin-id"]
+
+[[stacks]]
+  id = "other-stack-id"
+
+[[order]]
+  [[order.group]]
+	  id = "some-dependency"
+		version = "some-version"
+
+  [[order.group]]
+		id = "other-dependency"
+		version = "other-version"
+		optional = true
+`)
+
+				var config cargo.Config
+				Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
+				Expect(config).To(Equal(cargo.Config{
+					API: "0.2",
+					Buildpack: cargo.ConfigBuildpack{
+						ID:       "some-buildpack-id",
+						Name:     "some-buildpack-name",
+						Version:  "some-buildpack-version",
+						Homepage: "some-homepage-link",
+						Licenses: []cargo.ConfigBuildpackLicense{
+							{
+								Type: "some-license-type",
+								URI:  "some-license-uri",
+							},
+						},
+					},
+					Stacks: []cargo.ConfigStack{
+						{
+							ID:     "some-stack-id",
+							Mixins: []string{"some-mixin-id"},
+						},
+						{
+							ID: "other-stack-id",
+						},
+					},
+					Metadata: cargo.ConfigMetadata{
+						Unstructured: map[string]interface{}{"some-map": json.RawMessage(`[{"key":"value"}]`)},
+						IncludeFiles: []string{
+							"some-include-file",
+							"other-include-file",
+						},
+						PrePackage: "some-pre-package-script.sh",
+						Dependencies: []cargo.ConfigMetadataDependency{
+							{
+								Checksum: "sha256:some-sum",
+								CPE:      "some-cpe",
+								PURL:     "some-purl",
+								ID:       "some-dependency",
+								Licenses: []interface{}{
+									map[string]interface{}{
+										"type": "fancy-license",
+										"uri":  "some-license-uri",
+									},
+									map[string]interface{}{
+										"type": "fancy-license-2",
+										"uri":  "some-license-uri",
+									},
+								},
+								Name:           "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
+							},
+						},
+						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
+							{
+								ID:         "some-dependency",
+								Constraint: "1.*",
+								Patches:    1,
+							},
+						},
+						DefaultVersions: map[string]string{
+							"some-dependency": "1.2.x",
+						},
+					},
+					Order: []cargo.ConfigOrder{
+						{
+							Group: []cargo.ConfigOrderGroup{
+								{
+									ID:       "some-dependency",
+									Version:  "some-version",
+									Optional: false,
+								},
+								{
+									ID:       "other-dependency",
+									Version:  "other-version",
+									Optional: true,
+								},
+							},
+						},
+					},
+				}))
+			})
+
+		})
+
+		context("failure cases", func() {
+			context("when a bad reader is passed in", func() {
+				it("returns an error", func() {
+					err := cargo.DecodeConfig(errorReader{}, &cargo.Config{})
+					Expect(err).To(MatchError(ContainSubstring("failed to read")))
+				})
+			})
+		})
+	})
+
+	context("ConfigMetadata", func() {
+		context("MarshalJSON", func() {
+			context("when the all fields are empty", func() {
+				it("does not marshal any fields", func() {
+					var metadata cargo.ConfigMetadata
+					output, err := metadata.MarshalJSON()
+					Expect(err).NotTo(HaveOccurred())
+					Expect(string(output)).To(MatchJSON(`{}`))
+				})
+			})
+		})
+
+		context("UnmarshalJSON", func() {
+			context("when the all fields are empty", func() {
+				it("does not unmarshal any fields", func() {
+					var metadata cargo.ConfigMetadata
+					err := metadata.UnmarshalJSON([]byte(`{}`))
+					Expect(err).NotTo(HaveOccurred())
+					Expect(metadata).To(Equal(cargo.ConfigMetadata{}))
+				})
+			})
+
+			context("failure cases", func() {
+				context("metadata field is not a object", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`"some-string"`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+
+				context("metadata field include-files is not a []string", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`{"include-files": "some-string"}`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+
+				context("metadata field pre-package is not a string", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`{"pre-package": true}`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+
+				context("metadata field dependencies is not an array of objects", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`{"dependencies": true}`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+
+				context("metadata field dependency-constraints is not an array of objects", func() {
+					it("it returns an error", func() {
+						var metadata cargo.ConfigMetadata
+						err := metadata.UnmarshalJSON([]byte(`{"dependency-constraints": true}`))
+						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
+					})
+				})
+			})
+		})
+	})
+}

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -1,431 +1,34 @@
 package cargo_test
 
 import (
-	"bytes"
-	"encoding/json"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
 
 	. "github.com/onsi/gomega"
-	. "github.com/paketo-buildpacks/packit/v2/matchers"
 )
 
-func testConfig(t *testing.T, context spec.G, it spec.S) {
+func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
-
-		buffer *bytes.Buffer
 	)
 
-	it.Before(func() {
-		buffer = bytes.NewBuffer(nil)
-	})
-
-	context("EncodeConfig", func() {
-		it("encodes the config to TOML", func() {
-			deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
-			Expect(err).NotTo(HaveOccurred())
-
-			err = cargo.EncodeConfig(buffer, cargo.Config{
-				API: "0.6",
-				Buildpack: cargo.ConfigBuildpack{
-					ID:          "some-buildpack-id",
-					Name:        "some-buildpack-name",
-					Version:     "some-buildpack-version",
-					Homepage:    "some-buildpack-homepage",
-					ClearEnv:    true,
-					Description: "some-buildpack-description",
-					Keywords:    []string{"some-buildpack-keyword"},
-					Licenses: []cargo.ConfigBuildpackLicense{
-						{
-							Type: "some-license-type",
-							URI:  "some-license-uri",
-						},
-					},
-					SBOMFormats: []string{"some-sbom-format"},
-				},
-				Stacks: []cargo.ConfigStack{
-					{
-						ID:     "some-stack-id",
-						Mixins: []string{"some-mixin-id"},
-					},
-					{
-						ID: "other-stack-id",
-					},
-				},
-				Metadata: cargo.ConfigMetadata{
-					IncludeFiles: []string{
-						"some-include-file",
-						"other-include-file",
-					},
-					Unstructured: map[string]interface{}{"some-map": []map[string]interface{}{{"key": "value"}}},
-					PrePackage:   "some-pre-package-script.sh",
-					Dependencies: []cargo.ConfigMetadataDependency{
-						{
-							Checksum:        "sha256:some-sum",
-							CPE:             "some-cpe",
-							PURL:            "some-purl",
-							DeprecationDate: &deprecationDate,
-							ID:              "some-dependency",
-							Licenses:        []interface{}{"fancy-license", "fancy-license-2"},
-							Name:            "Some Dependency",
-							SHA256:          "shasum",
-							Source:          "source",
-							SourceChecksum:  "sha256:source-shasum",
-							SourceSHA256:    "source-shasum",
-							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-							StripComponents: 1,
-							URI:             "http://some-url",
-							Version:         "1.2.3",
-						},
-					},
-					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
-						{
-							ID:         "some-dependency",
-							Constraint: "1.*",
-							Patches:    1,
-						},
-					},
-					DefaultVersions: map[string]string{
-						"some-dependency": "1.2.x",
-					},
-				},
-				Order: []cargo.ConfigOrder{
-					{
-						Group: []cargo.ConfigOrderGroup{
-							{
-								ID:      "some-dependency",
-								Version: "some-version"},
-							{
-								ID:       "other-dependency",
-								Version:  "other-version",
-								Optional: true,
-							},
-						},
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(buffer.String()).To(MatchTOML(`
-api = "0.6"
-
-[buildpack]
-	id = "some-buildpack-id"
-	name = "some-buildpack-name"
-	version = "some-buildpack-version"
-	homepage = "some-buildpack-homepage"
-	clear-env = true
-	description = "some-buildpack-description"
-	keywords = [ "some-buildpack-keyword" ]
-	sbom-formats = [ "some-sbom-format" ]
-
-[[buildpack.licenses]]
-  type = "some-license-type"
-	uri = "some-license-uri"
-
-[metadata]
-	include-files = ["some-include-file", "other-include-file"]
-	pre-package = "some-pre-package-script.sh"
-
-[metadata.default-versions]
-	some-dependency = "1.2.x"
-
-[[metadata.dependencies]]
-	checksum = "sha256:some-sum"
-  cpe = "some-cpe"
-  purl = "some-purl"
-  deprecation_date = "2020-06-01T00:00:00Z"
-  id = "some-dependency"
-	licenses = ["fancy-license", "fancy-license-2"]
-  name = "Some Dependency"
-  sha256 = "shasum"
-	source = "source"
-	source-checksum = "sha256:source-shasum"
-  source_sha256 = "source-shasum"
-  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-  strip-components = 1
-  uri = "http://some-url"
-  version = "1.2.3"
-
-[[metadata.dependency-constraints]]
-  id = "some-dependency"
-  constraint = "1.*"
-	patches = 1
-
-[[metadata.some-map]]
-  key = "value"
-
-[[stacks]]
-  id = "some-stack-id"
-  mixins = ["some-mixin-id"]
-
-[[stacks]]
-  id = "other-stack-id"
-
-[[order]]
-  [[order.group]]
-	  id = "some-dependency"
-		version = "some-version"
-
-  [[order.group]]
-		id = "other-dependency"
-		version = "other-version"
-		optional = true
-`))
-		})
-
-		context("when the config dependency licenses are structured like ConfigBuildpackLicenses", func() {
-			it("encodes the config to TOML", func() {
-				deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
-				Expect(err).NotTo(HaveOccurred())
-
-				err = cargo.EncodeConfig(buffer, cargo.Config{
-					API: "0.6",
-					Buildpack: cargo.ConfigBuildpack{
-						ID:       "some-buildpack-id",
-						Name:     "some-buildpack-name",
-						Version:  "some-buildpack-version",
-						Homepage: "some-homepage-link",
-						Licenses: []cargo.ConfigBuildpackLicense{
-							{
-								Type: "some-license-type",
-								URI:  "some-license-uri",
-							},
-						},
-					},
-					Stacks: []cargo.ConfigStack{
-						{
-							ID:     "some-stack-id",
-							Mixins: []string{"some-mixin-id"},
-						},
-						{
-							ID: "other-stack-id",
-						},
-					},
-					Metadata: cargo.ConfigMetadata{
-						IncludeFiles: []string{
-							"some-include-file",
-							"other-include-file",
-						},
-						Unstructured: map[string]interface{}{"some-map": []map[string]interface{}{{"key": "value"}}},
-						PrePackage:   "some-pre-package-script.sh",
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								Checksum:        "sha256:some-sum",
-								CPE:             "some-cpe",
-								PURL:            "some-purl",
-								DeprecationDate: &deprecationDate,
-								ID:              "some-dependency",
-								Licenses: []interface{}{
-									cargo.ConfigBuildpackLicense{
-										Type: "fancy-license",
-										URI:  "some-license-uri",
-									},
-									cargo.ConfigBuildpackLicense{
-										Type: "fancy-license-2",
-										URI:  "some-license-uri",
-									},
-								},
-								Name:           "Some Dependency",
-								SHA256:         "shasum",
-								Source:         "source",
-								SourceChecksum: "sha256:source-shasum",
-								SourceSHA256:   "source-shasum",
-								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-								URI:            "http://some-url",
-								Version:        "1.2.3",
-							},
-						},
-						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
-							{
-								ID:         "some-dependency",
-								Constraint: "1.*",
-								Patches:    1,
-							},
-						},
-						DefaultVersions: map[string]string{
-							"some-dependency": "1.2.x",
-						},
-					},
-					Order: []cargo.ConfigOrder{
-						{
-							Group: []cargo.ConfigOrderGroup{
-								{
-									ID:      "some-dependency",
-									Version: "some-version"},
-								{
-									ID:       "other-dependency",
-									Version:  "other-version",
-									Optional: true,
-								},
-							},
-						},
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(buffer.String()).To(MatchTOML(`
-api = "0.6"
-
-[buildpack]
-	id = "some-buildpack-id"
-	name = "some-buildpack-name"
-	version = "some-buildpack-version"
-	homepage = "some-homepage-link"
-
-[[buildpack.licenses]]
-  type = "some-license-type"
-	uri = "some-license-uri"
-
-[metadata]
-	include-files = ["some-include-file", "other-include-file"]
-	pre-package = "some-pre-package-script.sh"
-
-[metadata.default-versions]
-	some-dependency = "1.2.x"
-
-[[metadata.dependencies]]
-	checksum = "sha256:some-sum"
-  cpe = "some-cpe"
-  purl = "some-purl"
-  deprecation_date = "2020-06-01T00:00:00Z"
-  id = "some-dependency"
-  name = "Some Dependency"
-  sha256 = "shasum"
-	source = "source"
-	source-checksum = "sha256:source-shasum"
-  source_sha256 = "source-shasum"
-  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-  uri = "http://some-url"
-  version = "1.2.3"
-
-  [[metadata.dependencies.licenses]]
-    type = "fancy-license"
-	  uri = "some-license-uri"
-
-	[[metadata.dependencies.licenses]]
-    type = "fancy-license-2"
-	  uri = "some-license-uri"
-
-[[metadata.dependency-constraints]]
-  id = "some-dependency"
-  constraint = "1.*"
-	patches = 1
-
-[[metadata.some-map]]
-  key = "value"
-
-[[stacks]]
-  id = "some-stack-id"
-  mixins = ["some-mixin-id"]
-
-[[stacks]]
-  id = "other-stack-id"
-
-[[order]]
-  [[order.group]]
-	  id = "some-dependency"
-		version = "some-version"
-
-  [[order.group]]
-		id = "other-dependency"
-		version = "other-version"
-		optional = true
-`))
-			})
-
-		})
-
-		context("when not all metadata.dependencies include strip-components", func() {
-			it("correctly encodes all elements", func() {
-				err := cargo.EncodeConfig(buffer, cargo.Config{
-					API: "0.6",
-					Buildpack: cargo.ConfigBuildpack{
-						ID: "some-buildpack-id",
-					},
-					Metadata: cargo.ConfigMetadata{
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								ID: "some-dependency",
-							},
-							{
-								ID:              "other-dependency",
-								StripComponents: 1,
-							},
-						},
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(buffer.String()).To(MatchTOML(`
-api = "0.6"
-
-[buildpack]
-	id = "some-buildpack-id"
-
-[[metadata.dependencies]]
-  id = "some-dependency"
-
-[[metadata.dependencies]]
-  id = "other-dependency"
-	strip-components = 1
-`))
-			})
-
-		})
-
-		context("failure cases", func() {
-			context("when the Config cannot be marshalled to json", func() {
-				it("returns an error", func() {
-					err := cargo.EncodeConfig(bytes.NewBuffer(nil), cargo.Config{
-						Metadata: cargo.ConfigMetadata{
-							Unstructured: map[string]interface{}{
-								"some-key": func() {},
-							},
-						},
-					})
-
-					Expect(err).To(MatchError(ContainSubstring("json: unsupported type")))
-				})
-			})
-
-			context("when the patches in dependency constraints cannot be converted to an int", func() {
-				it("returns an error", func() {
-					err := cargo.EncodeConfig(bytes.NewBuffer(nil), cargo.Config{
-						Metadata: cargo.ConfigMetadata{
-							DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
-								{
-									Constraint: "some-valid-constraint",
-									ID:         "some-valid-ID",
-									Patches:    0,
-								},
-							},
-						},
-					})
-					Expect(err).To(MatchError(ContainSubstring("failure to assert type: unexpected data in constraint patches")))
-				})
-			})
-		})
-	})
-
-	context("DecodeConfig", func() {
-		it("decodes TOML to config", func() {
+	context("DecodeExtensionConfig", func() {
+		it("decodes TOML to Extensionconfig", func() {
 			tomlBuffer := strings.NewReader(`
-api = "0.6"
+api = "0.7"
 
-[buildpack]
-	id = "some-buildpack-id"
-	name = "some-buildpack-name"
-	version = "some-buildpack-version"
-	homepage = "some-buildpack-homepage"
-	clear-env = true
-	description = "some-buildpack-description"
-	keywords = [ "some-buildpack-keyword" ]
-	sbom-formats = [ "some-sbom-format" ]
+[extension]
+id = "some-extension-id"
+name = "some-extension-name"
+version = "some-extension-version"
+homepage = "some-extension-homepage"
+description = "some-extension-description"
+keywords = [ "some-extension-keyword" ]
 
-[[buildpack.licenses]]
+[[extension.licenses]]
 	type = "some-license-type"
 	uri = "some-license-uri"
 
@@ -441,8 +44,6 @@ api = "0.6"
 
 [[metadata.dependencies]]
 	checksum = "sha256:some-sum"
-  cpe = "some-cpe"
-  purl = "some-purl"
   id = "some-dependency"
 	licenses = ["fancy-license", "fancy-license-2"]
   name = "Some Dependency"
@@ -451,350 +52,55 @@ api = "0.6"
   source-checksum = "sha256:source-shasum"
   source_sha256 = "source-shasum"
   stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-	strip-components = 1
   uri = "http://some-url"
   version = "1.2.3"
-
-[[metadata.dependency-constraints]]
-  id = "some-dependency"
-  constraint = "1.*"
-	patches = 1
-
-[[stacks]]
-  id = "some-stack-id"
-  mixins = ["some-mixin-id"]
-
-[[stacks]]
-  id = "other-stack-id"
-
-[[order]]
-  [[order.group]]
-	  id = "some-dependency"
-		version = "some-version"
-
-  [[order.group]]
-		id = "other-dependency"
-		version = "other-version"
-		optional = true
 `)
 
-			var config cargo.Config
-			Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
-			Expect(config).To(Equal(cargo.Config{
-				API: "0.6",
-				Buildpack: cargo.ConfigBuildpack{
-					ID:          "some-buildpack-id",
-					Name:        "some-buildpack-name",
-					Version:     "some-buildpack-version",
-					Homepage:    "some-buildpack-homepage",
-					ClearEnv:    true,
-					Description: "some-buildpack-description",
-					Keywords:    []string{"some-buildpack-keyword"},
-					Licenses: []cargo.ConfigBuildpackLicense{
+			var config cargo.ExtensionConfig
+			Expect(cargo.DecodeExtensionConfig(tomlBuffer, &config)).To(Succeed())
+			Expect(config).To(Equal(cargo.ExtensionConfig{
+				API: "0.7",
+				Extension: cargo.ConfigExtension{
+					ID:          "some-extension-id",
+					Name:        "some-extension-name",
+					Version:     "some-extension-version",
+					Homepage:    "some-extension-homepage",
+					Description: "some-extension-description",
+					Keywords:    []string{"some-extension-keyword"},
+					Licenses: []cargo.ConfigExtensionLicense{
 						{
 							Type: "some-license-type",
 							URI:  "some-license-uri",
 						},
 					},
-					SBOMFormats: []string{"some-sbom-format"},
 				},
-				Stacks: []cargo.ConfigStack{
-					{
-						ID:     "some-stack-id",
-						Mixins: []string{"some-mixin-id"},
-					},
-					{
-						ID: "other-stack-id",
-					},
-				},
-				Metadata: cargo.ConfigMetadata{
-					Unstructured: map[string]interface{}{"some-map": json.RawMessage(`[{"key":"value"}]`)},
+				Metadata: cargo.ConfigExtensionMetadata{
 					IncludeFiles: []string{
 						"some-include-file",
 						"other-include-file",
 					},
 					PrePackage: "some-pre-package-script.sh",
-					Dependencies: []cargo.ConfigMetadataDependency{
+					Dependencies: []cargo.ConfigExtensionMetadataDependency{
 						{
-							Checksum:        "sha256:some-sum",
-							CPE:             "some-cpe",
-							PURL:            "some-purl",
-							ID:              "some-dependency",
-							Licenses:        []interface{}{"fancy-license", "fancy-license-2"},
-							Name:            "Some Dependency",
-							SHA256:          "shasum",
-							Source:          "source",
-							SourceChecksum:  "sha256:source-shasum",
-							SourceSHA256:    "source-shasum",
-							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-							StripComponents: 1,
-							URI:             "http://some-url",
-							Version:         "1.2.3",
-						},
-					},
-					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
-						{
-							ID:         "some-dependency",
-							Constraint: "1.*",
-							Patches:    1,
+							Checksum:       "sha256:some-sum",
+							ID:             "some-dependency",
+							Licenses:       []interface{}{"fancy-license", "fancy-license-2"},
+							Name:           "Some Dependency",
+							SHA256:         "shasum",
+							Source:         "source",
+							SourceChecksum: "sha256:source-shasum",
+							SourceSHA256:   "source-shasum",
+							Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:            "http://some-url",
+							Version:        "1.2.3",
 						},
 					},
 					DefaultVersions: map[string]string{
 						"some-dependency": "1.2.x",
 					},
 				},
-				Order: []cargo.ConfigOrder{
-					{
-						Group: []cargo.ConfigOrderGroup{
-							{
-								ID:       "some-dependency",
-								Version:  "some-version",
-								Optional: false,
-							},
-							{
-								ID:       "other-dependency",
-								Version:  "other-version",
-								Optional: true,
-							},
-						},
-					},
-				},
 			}))
 		})
-
-		context("dependency license are not a list of IDs", func() {
-			it("decodes TOML to config", func() {
-				tomlBuffer := strings.NewReader(`
-api = "0.2"
-
-[buildpack]
-	id = "some-buildpack-id"
-	name = "some-buildpack-name"
-	version = "some-buildpack-version"
-	homepage = "some-homepage-link"
-
-[[buildpack.licenses]]
-	type = "some-license-type"
-	uri = "some-license-uri"
-
-[metadata]
-	include-files = ["some-include-file", "other-include-file"]
-	pre-package = "some-pre-package-script.sh"
-
-[metadata.default-versions]
-	some-dependency = "1.2.x"
-
-[[metadata.some-map]]
-  key = "value"
-
-[[metadata.dependencies]]
-	checksum = "sha256:some-sum"
-  cpe = "some-cpe"
-  purl = "some-purl"
-  id = "some-dependency"
-  name = "Some Dependency"
-  sha256 = "shasum"
-  source = "source"
-  source-checksum = "sha256:source-shasum"
-  source_sha256 = "source-shasum"
-  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-  uri = "http://some-url"
-  version = "1.2.3"
-
-  [[metadata.dependencies.licenses]]
-    type = "fancy-license"
-	  uri = "some-license-uri"
-
-	[[metadata.dependencies.licenses]]
-    type = "fancy-license-2"
-	  uri = "some-license-uri"
-
-[[metadata.dependency-constraints]]
-  id = "some-dependency"
-  constraint = "1.*"
-	patches = 1
-
-[[stacks]]
-  id = "some-stack-id"
-  mixins = ["some-mixin-id"]
-
-[[stacks]]
-  id = "other-stack-id"
-
-[[order]]
-  [[order.group]]
-	  id = "some-dependency"
-		version = "some-version"
-
-  [[order.group]]
-		id = "other-dependency"
-		version = "other-version"
-		optional = true
-`)
-
-				var config cargo.Config
-				Expect(cargo.DecodeConfig(tomlBuffer, &config)).To(Succeed())
-				Expect(config).To(Equal(cargo.Config{
-					API: "0.2",
-					Buildpack: cargo.ConfigBuildpack{
-						ID:       "some-buildpack-id",
-						Name:     "some-buildpack-name",
-						Version:  "some-buildpack-version",
-						Homepage: "some-homepage-link",
-						Licenses: []cargo.ConfigBuildpackLicense{
-							{
-								Type: "some-license-type",
-								URI:  "some-license-uri",
-							},
-						},
-					},
-					Stacks: []cargo.ConfigStack{
-						{
-							ID:     "some-stack-id",
-							Mixins: []string{"some-mixin-id"},
-						},
-						{
-							ID: "other-stack-id",
-						},
-					},
-					Metadata: cargo.ConfigMetadata{
-						Unstructured: map[string]interface{}{"some-map": json.RawMessage(`[{"key":"value"}]`)},
-						IncludeFiles: []string{
-							"some-include-file",
-							"other-include-file",
-						},
-						PrePackage: "some-pre-package-script.sh",
-						Dependencies: []cargo.ConfigMetadataDependency{
-							{
-								Checksum: "sha256:some-sum",
-								CPE:      "some-cpe",
-								PURL:     "some-purl",
-								ID:       "some-dependency",
-								Licenses: []interface{}{
-									map[string]interface{}{
-										"type": "fancy-license",
-										"uri":  "some-license-uri",
-									},
-									map[string]interface{}{
-										"type": "fancy-license-2",
-										"uri":  "some-license-uri",
-									},
-								},
-								Name:           "Some Dependency",
-								SHA256:         "shasum",
-								Source:         "source",
-								SourceChecksum: "sha256:source-shasum",
-								SourceSHA256:   "source-shasum",
-								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-								URI:            "http://some-url",
-								Version:        "1.2.3",
-							},
-						},
-						DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
-							{
-								ID:         "some-dependency",
-								Constraint: "1.*",
-								Patches:    1,
-							},
-						},
-						DefaultVersions: map[string]string{
-							"some-dependency": "1.2.x",
-						},
-					},
-					Order: []cargo.ConfigOrder{
-						{
-							Group: []cargo.ConfigOrderGroup{
-								{
-									ID:       "some-dependency",
-									Version:  "some-version",
-									Optional: false,
-								},
-								{
-									ID:       "other-dependency",
-									Version:  "other-version",
-									Optional: true,
-								},
-							},
-						},
-					},
-				}))
-			})
-
-		})
-
-		context("failure cases", func() {
-			context("when a bad reader is passed in", func() {
-				it("returns an error", func() {
-					err := cargo.DecodeConfig(errorReader{}, &cargo.Config{})
-					Expect(err).To(MatchError(ContainSubstring("failed to read")))
-				})
-			})
-		})
 	})
 
-	context("ConfigMetadata", func() {
-		context("MarshalJSON", func() {
-			context("when the all fields are empty", func() {
-				it("does not marshal any fields", func() {
-					var metadata cargo.ConfigMetadata
-					output, err := metadata.MarshalJSON()
-					Expect(err).NotTo(HaveOccurred())
-					Expect(string(output)).To(MatchJSON(`{}`))
-				})
-			})
-		})
-
-		context("UnmarshalJSON", func() {
-			context("when the all fields are empty", func() {
-				it("does not unmarshal any fields", func() {
-					var metadata cargo.ConfigMetadata
-					err := metadata.UnmarshalJSON([]byte(`{}`))
-					Expect(err).NotTo(HaveOccurred())
-					Expect(metadata).To(Equal(cargo.ConfigMetadata{}))
-				})
-			})
-
-			context("failure cases", func() {
-				context("metadata field is not a object", func() {
-					it("it returns an error", func() {
-						var metadata cargo.ConfigMetadata
-						err := metadata.UnmarshalJSON([]byte(`"some-string"`))
-						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
-					})
-				})
-
-				context("metadata field include-files is not a []string", func() {
-					it("it returns an error", func() {
-						var metadata cargo.ConfigMetadata
-						err := metadata.UnmarshalJSON([]byte(`{"include-files": "some-string"}`))
-						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
-					})
-				})
-
-				context("metadata field pre-package is not a string", func() {
-					it("it returns an error", func() {
-						var metadata cargo.ConfigMetadata
-						err := metadata.UnmarshalJSON([]byte(`{"pre-package": true}`))
-						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
-					})
-				})
-
-				context("metadata field dependencies is not an array of objects", func() {
-					it("it returns an error", func() {
-						var metadata cargo.ConfigMetadata
-						err := metadata.UnmarshalJSON([]byte(`{"dependencies": true}`))
-						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
-					})
-				})
-
-				context("metadata field dependency-constraints is not an array of objects", func() {
-					it("it returns an error", func() {
-						var metadata cargo.ConfigMetadata
-						err := metadata.UnmarshalJSON([]byte(`{"dependency-constraints": true}`))
-						Expect(err).To(MatchError(ContainSubstring("json: cannot unmarshal")))
-					})
-				})
-			})
-		})
-	})
 }

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -121,69 +121,70 @@ api = "0.7"
 `))
 		})
 
-		it("encodes the config to TOML when the config dependency licenses are structured like ConfigExtensionLicenses ", func() {
+		context("when the config dependency licenses are structured like ConfigExtensionLicenses", func() {
+			it("encodes the config to TOML", func() {
 
-			err := cargo.EncodeExtensionConfig(buffer, cargo.ExtensionConfig{
-				API: "0.7",
-				Extension: cargo.ConfigExtension{
-					ID:          "some-extension-id",
-					Name:        "some-extension-name",
-					Version:     "some-extension-version",
-					Homepage:    "some-extension-homepage",
-					Description: "some-extension-description",
-					Keywords:    []string{"some-extension-keyword"},
-					Licenses: []cargo.ConfigExtensionLicense{
-						{
-							Type: "some-license-type",
-							URI:  "some-license-uri",
+				err := cargo.EncodeExtensionConfig(buffer, cargo.ExtensionConfig{
+					API: "0.7",
+					Extension: cargo.ConfigExtension{
+						ID:          "some-extension-id",
+						Name:        "some-extension-name",
+						Version:     "some-extension-version",
+						Homepage:    "some-extension-homepage",
+						Description: "some-extension-description",
+						Keywords:    []string{"some-extension-keyword"},
+						Licenses: []cargo.ConfigExtensionLicense{
+							{
+								Type: "some-license-type",
+								URI:  "some-license-uri",
+							},
 						},
 					},
-				},
-				Metadata: cargo.ConfigExtensionMetadata{
-					IncludeFiles: []string{
-						"some-include-file",
-						"other-include-file",
-					},
-					PrePackage: "some-pre-package-script.sh",
-					Dependencies: []cargo.ConfigExtensionMetadataDependency{
-						{
-							Checksum: "sha256:some-sum",
-							ID:       "some-dependency",
-							Licenses: []interface{}{
-								cargo.ConfigBuildpackLicense{
-									Type: "fancy-license",
-									URI:  "some-license-uri",
-								},
-								cargo.ConfigBuildpackLicense{
-									Type: "fancy-license-2",
-									URI:  "some-license-uri",
-								},
-							}, Name: "Some Dependency",
-							SHA256:         "shasum",
-							Source:         "source",
-							SourceChecksum: "sha256:source-shasum",
-							SourceSHA256:   "source-shasum",
-							Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-							URI:            "http://some-url",
-							Version:        "1.2.3",
+					Metadata: cargo.ConfigExtensionMetadata{
+						IncludeFiles: []string{
+							"some-include-file",
+							"other-include-file",
+						},
+						PrePackage: "some-pre-package-script.sh",
+						Dependencies: []cargo.ConfigExtensionMetadataDependency{
+							{
+								Checksum: "sha256:some-sum",
+								ID:       "some-dependency",
+								Licenses: []interface{}{
+									cargo.ConfigBuildpackLicense{
+										Type: "fancy-license",
+										URI:  "some-license-uri",
+									},
+									cargo.ConfigBuildpackLicense{
+										Type: "fancy-license-2",
+										URI:  "some-license-uri",
+									},
+								}, Name: "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
+							},
+						},
+						Configurations: []cargo.ConfigExtensionMetadataConfiguration{
+							{
+								Default:     "0",
+								Description: "some-metadata-configuration-description",
+								Launch:      true,
+								Name:        "SOME_METADATA_CONFIGURATION_NAME",
+								Build:       true,
+							},
+						},
+						DefaultVersions: map[string]string{
+							"some-dependency": "1.2.x",
 						},
 					},
-					Configurations: []cargo.ConfigExtensionMetadataConfiguration{
-						{
-							Default:     "0",
-							Description: "some-metadata-configuration-description",
-							Launch:      true,
-							Name:        "SOME_METADATA_CONFIGURATION_NAME",
-							Build:       true,
-						},
-					},
-					DefaultVersions: map[string]string{
-						"some-dependency": "1.2.x",
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(buffer.String()).To(MatchTOML(`
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(buffer.String()).To(MatchTOML(`
 api = "0.7"
 
 [extension]
@@ -231,6 +232,7 @@ api = "0.7"
     type = "fancy-license-2"
 	uri = "some-license-uri"
 `))
+			})
 		})
 	})
 
@@ -333,6 +335,115 @@ keywords = [ "some-extension-keyword" ]
 				},
 			}))
 		})
-	})
 
+		context("dependency license are not a list of IDs", func() {
+			it("decodes TOML to extensionConfig", func() {
+				tomlBuffer := strings.NewReader(`
+api = "0.2"
+
+[extension]
+  id = "some-extension-id"
+  name = "some-extension-name"
+  version = "some-extension-version"
+  homepage = "some-extension-homepage"
+
+  [[extension.licenses]]
+    type = "some-license-type"
+    uri = "some-license-uri"
+
+[metadata]
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[metadata.default-versions]
+	some-dependency = "1.2.x"
+
+[[metadata.some-map]]
+  key = "value"
+
+[[metadata.dependencies]]
+  checksum = "sha256:some-sum"
+  id = "some-dependency"
+  name = "Some Dependency"
+  sha256 = "shasum"
+  source = "source"
+  source-checksum = "sha256:source-shasum"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+  uri = "http://some-url"
+  version = "1.2.3"
+
+  [[metadata.dependencies.licenses]]
+    type = "fancy-license"
+	  uri = "some-license-uri"
+
+	[[metadata.dependencies.licenses]]
+    type = "fancy-license-2"
+	  uri = "some-license-uri"
+`)
+
+				var config cargo.ExtensionConfig
+				Expect(cargo.DecodeExtensionConfig(tomlBuffer, &config)).To(Succeed())
+				Expect(config).To(Equal(cargo.ExtensionConfig{
+					API: "0.2",
+					Extension: cargo.ConfigExtension{
+						ID:       "some-extension-id",
+						Name:     "some-extension-name",
+						Version:  "some-extension-version",
+						Homepage: "some-extension-homepage",
+						Licenses: []cargo.ConfigExtensionLicense{
+							{
+								Type: "some-license-type",
+								URI:  "some-license-uri",
+							},
+						},
+					},
+					Metadata: cargo.ConfigExtensionMetadata{
+						IncludeFiles: []string{
+							"some-include-file",
+							"other-include-file",
+						},
+						PrePackage: "some-pre-package-script.sh",
+						Dependencies: []cargo.ConfigExtensionMetadataDependency{
+							{
+								Checksum: "sha256:some-sum",
+								ID:       "some-dependency",
+								Licenses: []interface{}{
+									map[string]interface{}{
+										"type": "fancy-license",
+										"uri":  "some-license-uri",
+									},
+									map[string]interface{}{
+										"type": "fancy-license-2",
+										"uri":  "some-license-uri",
+									},
+								},
+								Name:           "Some Dependency",
+								SHA256:         "shasum",
+								Source:         "source",
+								SourceChecksum: "sha256:source-shasum",
+								SourceSHA256:   "source-shasum",
+								Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+								URI:            "http://some-url",
+								Version:        "1.2.3",
+							},
+						},
+						DefaultVersions: map[string]string{
+							"some-dependency": "1.2.x",
+						},
+					},
+				}))
+			})
+
+		})
+
+		context("failure cases", func() {
+			context("when a bad reader is passed in", func() {
+				it("returns an error", func() {
+					err := cargo.DecodeExtensionConfig(errorReader{}, &cargo.ExtensionConfig{})
+					Expect(err).To(MatchError(ContainSubstring("failed to read")))
+				})
+			})
+		})
+	})
 }

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -40,20 +40,27 @@ keywords = [ "some-extension-keyword" ]
 	some-dependency = "1.2.x"
 
 [[metadata.some-map]]
-  key = "value"
+	key = "value"
 
 [[metadata.dependencies]]
 	checksum = "sha256:some-sum"
-  id = "some-dependency"
+	id = "some-dependency"
 	licenses = ["fancy-license", "fancy-license-2"]
-  name = "Some Dependency"
-  sha256 = "shasum"
-  source = "source"
-  source-checksum = "sha256:source-shasum"
-  source_sha256 = "source-shasum"
-  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-  uri = "http://some-url"
-  version = "1.2.3"
+	name = "Some Dependency"
+	sha256 = "shasum"
+	source = "source"
+	source-checksum = "sha256:source-shasum"
+	source_sha256 = "source-shasum"
+	stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+	uri = "http://some-url"
+	version = "1.2.3"
+
+[[metadata.configurations]]
+	default = "0"
+	description = "some-metadata-configuration-description"
+	launch = true
+	name = "SOME_METADATA_CONFIGURATION_NAME"
+	build = true
 `)
 
 			var config cargo.ExtensionConfig
@@ -93,6 +100,15 @@ keywords = [ "some-extension-keyword" ]
 							Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
 							URI:            "http://some-url",
 							Version:        "1.2.3",
+						},
+					},
+					Configurations: []cargo.ConfigExtensionMetadataConfiguration{
+						{
+							Default:     "0",
+							Description: "some-metadata-configuration-description",
+							Launch:      true,
+							Name:        "SOME_METADATA_CONFIGURATION_NAME",
+							Build:       true,
 						},
 					},
 					DefaultVersions: map[string]string{

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -23,8 +23,8 @@ func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 		buffer = bytes.NewBuffer(nil)
 	})
 
-	context("EncodeConfig", func() {
-		it("encodes the config to TOML", func() {
+	context("EncodeExtensionConfig", func() {
+		it("encodes the extension config to TOML", func() {
 
 			err := cargo.EncodeExtensionConfig(buffer, cargo.ExtensionConfig{
 				API: "0.7",
@@ -99,9 +99,9 @@ api = "0.7"
 
   [[metadata.configurations]]
     build = true
+    default = "0"
     description = "some-metadata-configuration-description"
     launch = true
-    default = "0"
     name = "SOME_METADATA_CONFIGURATION_NAME"
   [metadata.default-versions]
     some-dependency = "1.2.x"
@@ -118,6 +118,118 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
     uri = "http://some-url"
     version = "1.2.3"
+`))
+		})
+
+		it("encodes the config to TOML when the config dependency licenses are structured like ConfigExtensionLicenses ", func() {
+
+			err := cargo.EncodeExtensionConfig(buffer, cargo.ExtensionConfig{
+				API: "0.7",
+				Extension: cargo.ConfigExtension{
+					ID:          "some-extension-id",
+					Name:        "some-extension-name",
+					Version:     "some-extension-version",
+					Homepage:    "some-extension-homepage",
+					Description: "some-extension-description",
+					Keywords:    []string{"some-extension-keyword"},
+					Licenses: []cargo.ConfigExtensionLicense{
+						{
+							Type: "some-license-type",
+							URI:  "some-license-uri",
+						},
+					},
+				},
+				Metadata: cargo.ConfigExtensionMetadata{
+					IncludeFiles: []string{
+						"some-include-file",
+						"other-include-file",
+					},
+					PrePackage: "some-pre-package-script.sh",
+					Dependencies: []cargo.ConfigExtensionMetadataDependency{
+						{
+							Checksum: "sha256:some-sum",
+							ID:       "some-dependency",
+							Licenses: []interface{}{
+								cargo.ConfigBuildpackLicense{
+									Type: "fancy-license",
+									URI:  "some-license-uri",
+								},
+								cargo.ConfigBuildpackLicense{
+									Type: "fancy-license-2",
+									URI:  "some-license-uri",
+								},
+							}, Name: "Some Dependency",
+							SHA256:         "shasum",
+							Source:         "source",
+							SourceChecksum: "sha256:source-shasum",
+							SourceSHA256:   "source-shasum",
+							Stacks:         []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:            "http://some-url",
+							Version:        "1.2.3",
+						},
+					},
+					Configurations: []cargo.ConfigExtensionMetadataConfiguration{
+						{
+							Default:     "0",
+							Description: "some-metadata-configuration-description",
+							Launch:      true,
+							Name:        "SOME_METADATA_CONFIGURATION_NAME",
+							Build:       true,
+						},
+					},
+					DefaultVersions: map[string]string{
+						"some-dependency": "1.2.x",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buffer.String()).To(MatchTOML(`
+api = "0.7"
+
+[extension]
+  description = "some-extension-description"
+  homepage = "some-extension-homepage"
+  id = "some-extension-id"
+  keywords = ["some-extension-keyword"]
+  name = "some-extension-name"
+  version = "some-extension-version"
+
+  [[extension.licenses]]
+    type = "some-license-type"
+    uri = "some-license-uri"
+
+[metadata]
+  include-files = ["some-include-file", "other-include-file"]
+  pre-package = "some-pre-package-script.sh"
+
+  [[metadata.configurations]]
+    build = true
+    default = "0"
+    description = "some-metadata-configuration-description"
+    launch = true
+    name = "SOME_METADATA_CONFIGURATION_NAME"
+  [metadata.default-versions]
+    some-dependency = "1.2.x"
+
+  [[metadata.dependencies]]
+    checksum = "sha256:some-sum"
+    id = "some-dependency"
+    name = "Some Dependency"
+    sha256 = "shasum"
+    source = "source"
+    source-checksum = "sha256:source-shasum"
+    source_sha256 = "source-shasum"
+    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+    uri = "http://some-url"
+    version = "1.2.3"
+
+  [[metadata.dependencies.licenses]]
+    type = "fancy-license"
+	uri = "some-license-uri"
+
+   [[metadata.dependencies.licenses]]
+    type = "fancy-license-2"
+	uri = "some-license-uri"
 `))
 		})
 	})

--- a/cargo/extension_parser.go
+++ b/cargo/extension_parser.go
@@ -1,0 +1,24 @@
+package cargo
+
+import "os"
+
+type ExtensionParser struct{}
+
+func NewExtensionParser() ExtensionParser {
+	return ExtensionParser{}
+}
+
+func (p ExtensionParser) Parse(path string) (Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	var config Config
+	err = DecodeConfig(file, &config)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return config, nil
+}

--- a/cargo/extension_parser.go
+++ b/cargo/extension_parser.go
@@ -8,16 +8,16 @@ func NewExtensionParser() ExtensionParser {
 	return ExtensionParser{}
 }
 
-func (p ExtensionParser) Parse(path string) (Config, error) {
+func (p ExtensionParser) Parse(path string) (ExtensionConfig, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		return Config{}, err
+		return ExtensionConfig{}, err
 	}
 
-	var config Config
-	err = DecodeConfig(file, &config)
+	var config ExtensionConfig
+	err = DecodeExtensionConfig(file, &config)
 	if err != nil {
-		return Config{}, err
+		return ExtensionConfig{}, err
 	}
 
 	return config, nil

--- a/cargo/extension_parser_test.go
+++ b/cargo/extension_parser_test.go
@@ -1,0 +1,118 @@
+package cargo_test
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/paketo-buildpacks/packit/v2/cargo"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testBuildpackParser(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		path   string
+		parser cargo.BuildpackParser
+	)
+
+	it.Before(func() {
+		file, err := os.CreateTemp("", "buildpack.toml")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = file.WriteString(`api = "0.2"
+[buildpack]
+id = "some-buildpack-id"
+name = "some-buildpack-name"
+version = "some-buildpack-version"
+
+[metadata]
+include-files = ["some-include-file", "other-include-file"]
+pre-package = "some-pre-package-script.sh"
+
+[[metadata.dependencies]]
+	deprecation_date = 2020-06-01T00:00:00Z
+  id = "some-dependency"
+  name = "Some Dependency"
+  sha256 = "shasum"
+	source = "source"
+  source_sha256 = "source-shasum"
+  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+  uri = "http://some-url"
+  version = "1.2.3"
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(file.Close()).To(Succeed())
+
+		path = file.Name()
+
+		parser = cargo.NewBuildpackParser()
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(path)).To(Succeed())
+	})
+
+	context("Parse", func() {
+		it("parses a given buildpack.toml", func() {
+			deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
+			Expect(err).NotTo(HaveOccurred())
+			config, err := parser.Parse(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(config).To(Equal(cargo.Config{
+				API: "0.2",
+				Buildpack: cargo.ConfigBuildpack{
+					ID:      "some-buildpack-id",
+					Name:    "some-buildpack-name",
+					Version: "some-buildpack-version",
+				},
+				Metadata: cargo.ConfigMetadata{
+					IncludeFiles: []string{
+						"some-include-file",
+						"other-include-file",
+					},
+					PrePackage: "some-pre-package-script.sh",
+					Dependencies: []cargo.ConfigMetadataDependency{
+						{
+							DeprecationDate: &deprecationDate,
+							ID:              "some-dependency",
+							Name:            "Some Dependency",
+							SHA256:          "shasum",
+							Source:          "source",
+							SourceSHA256:    "source-shasum",
+							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:             "http://some-url",
+							Version:         "1.2.3",
+						},
+					},
+				},
+			}))
+		})
+
+		context("when the buildpack.toml does not exist", func() {
+			it.Before(func() {
+				Expect(os.Remove(path)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := parser.Parse(path)
+				Expect(err).To(MatchError(ContainSubstring("no such file or directory")))
+			})
+		})
+
+		context("when the buildpack.toml is malformed", func() {
+			it.Before(func() {
+				Expect(os.WriteFile(path, []byte("%%%"), 0644)).To(Succeed())
+			})
+
+			it("returns an error", func() {
+				_, err := parser.Parse(path)
+				Expect(err).To(MatchError(ContainSubstring("expected '.' or '=', but got '%' instead")))
+			})
+		})
+	})
+}

--- a/cargo/extension_parser_test.go
+++ b/cargo/extension_parser_test.go
@@ -3,7 +3,6 @@ package cargo_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"github.com/paketo-buildpacks/packit/v2/cargo"
 	"github.com/sclevine/spec"
@@ -11,38 +10,40 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func testBuildpackParser(t *testing.T, context spec.G, it spec.S) {
+func testExtensionParser(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
 
 		path   string
-		parser cargo.BuildpackParser
+		parser cargo.ExtensionParser
 	)
 
 	it.Before(func() {
-		file, err := os.CreateTemp("", "buildpack.toml")
+		file, err := os.CreateTemp("", "extension.toml")
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = file.WriteString(`api = "0.2"
-[buildpack]
-id = "some-buildpack-id"
-name = "some-buildpack-name"
-version = "some-buildpack-version"
+		_, err = file.WriteString(`api = "0.7"
+[extension]
+id = "some-extension-id"
+name = "some-extension-name"
+version = "some-extension-version"
 
 [metadata]
-include-files = ["some-include-file", "other-include-file"]
-pre-package = "some-pre-package-script.sh"
+	include-files = ["some-include-file", "other-include-file"]
+	pre-package = "some-pre-package-script.sh"
+
+[[metadata.some-map]]
+	key = "value"
 
 [[metadata.dependencies]]
-	deprecation_date = 2020-06-01T00:00:00Z
-  id = "some-dependency"
-  name = "Some Dependency"
-  sha256 = "shasum"
+	id = "some-dependency"
+	name = "Some Dependency"
+	sha256 = "shasum"
 	source = "source"
-  source_sha256 = "source-shasum"
-  stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
-  uri = "http://some-url"
-  version = "1.2.3"
+	source_sha256 = "source-shasum"
+	stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
+	uri = "http://some-url"
+	version = "1.2.3"
 `)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -50,7 +51,7 @@ pre-package = "some-pre-package-script.sh"
 
 		path = file.Name()
 
-		parser = cargo.NewBuildpackParser()
+		parser = cargo.NewExtensionParser()
 	})
 
 	it.After(func() {
@@ -58,42 +59,39 @@ pre-package = "some-pre-package-script.sh"
 	})
 
 	context("Parse", func() {
-		it("parses a given buildpack.toml", func() {
-			deprecationDate, err := time.Parse(time.RFC3339, "2020-06-01T00:00:00Z")
-			Expect(err).NotTo(HaveOccurred())
+		it("parses a given extension.toml", func() {
 			config, err := parser.Parse(path)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(config).To(Equal(cargo.Config{
-				API: "0.2",
-				Buildpack: cargo.ConfigBuildpack{
-					ID:      "some-buildpack-id",
-					Name:    "some-buildpack-name",
-					Version: "some-buildpack-version",
+			Expect(config).To(Equal(cargo.ExtensionConfig{
+				API: "0.7",
+				Extension: cargo.ConfigExtension{
+					ID:      "some-extension-id",
+					Name:    "some-extension-name",
+					Version: "some-extension-version",
 				},
-				Metadata: cargo.ConfigMetadata{
+				Metadata: cargo.ConfigExtensionMetadata{
 					IncludeFiles: []string{
 						"some-include-file",
 						"other-include-file",
 					},
 					PrePackage: "some-pre-package-script.sh",
-					Dependencies: []cargo.ConfigMetadataDependency{
+					Dependencies: []cargo.ConfigExtensionMetadataDependency{
 						{
-							DeprecationDate: &deprecationDate,
-							ID:              "some-dependency",
-							Name:            "Some Dependency",
-							SHA256:          "shasum",
-							Source:          "source",
-							SourceSHA256:    "source-shasum",
-							Stacks:          []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
-							URI:             "http://some-url",
-							Version:         "1.2.3",
+							ID:           "some-dependency",
+							Name:         "Some Dependency",
+							SHA256:       "shasum",
+							Source:       "source",
+							SourceSHA256: "source-shasum",
+							Stacks:       []string{"io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"},
+							URI:          "http://some-url",
+							Version:      "1.2.3",
 						},
 					},
 				},
 			}))
 		})
 
-		context("when the buildpack.toml does not exist", func() {
+		context("when the extension.toml does not exist", func() {
 			it.Before(func() {
 				Expect(os.Remove(path)).To(Succeed())
 			})
@@ -104,7 +102,7 @@ pre-package = "some-pre-package-script.sh"
 			})
 		})
 
-		context("when the buildpack.toml is malformed", func() {
+		context("when the extension.toml is malformed", func() {
 			it.Before(func() {
 				Expect(os.WriteFile(path, []byte("%%%"), 0644)).To(Succeed())
 			})

--- a/cargo/init_test.go
+++ b/cargo/init_test.go
@@ -12,6 +12,7 @@ func TestUnitCargo(t *testing.T) {
 	suite := spec.New("cargo", spec.Report(report.Terminal{}))
 	suite("BuildpackParser", testBuildpackParser)
 	suite("Config", testConfig)
+	suite("ExtensionConfig", testExtensionConfig)
 	suite("DirectoryDuplicator", testDirectoryDuplicator)
 	suite("Transport", testTransport)
 	suite("ValidatedReader", testValidatedReader)

--- a/cargo/init_test.go
+++ b/cargo/init_test.go
@@ -11,6 +11,7 @@ import (
 func TestUnitCargo(t *testing.T) {
 	suite := spec.New("cargo", spec.Report(report.Terminal{}))
 	suite("BuildpackParser", testBuildpackParser)
+	suite("ExtensionParser", testExtensionParser)
 	suite("Config", testConfig)
 	suite("ExtensionConfig", testExtensionConfig)
 	suite("DirectoryDuplicator", testDirectoryDuplicator)


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR adds the Extension Config structure similar to what is for Buildpack Config structure https://github.com/paketo-buildpacks/packit/blob/v2/cargo/config.go , but for extensions.

## Use Cases
<!-- An explanation of the use cases your change enables -->
With these changes someone can use the extension config to parse and manipulate extension.toml files. For example the developer can use the NewExtensionParser from the cargo repo to create an ExtensionParser, parse an extension.toml file and manipulate it.

```go
	extensionConfigParser := cargo.NewExtensionParser()
	config, err := extensionConfigParser.Parse(extensionTOMLPath)
	if err != nil {
		return fmt.Errorf("failed to parse extension.toml file : %s", err)
	}

	config.Extension.Version = flags.version
```
## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
