### PR TITLE
Adding hasStack method for ConfigExtensionMetadaDependency

### DIFF
--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -86,3 +86,13 @@ func DecodeExtensionConfig(reader io.Reader, extensionConfig *ExtensionConfig) e
 
 	return json.Unmarshal(content, extensionConfig)
 }
+
+func (cd ConfigExtensionMetadataDependency) HasStack(stack string) bool {
+	for _, s := range cd.Stacks {
+		if s == stack {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Adding the hasStack method for `ConfigExtensionMetadaDependency` struct
## Use Cases
<!-- An explanation of the use cases your change enables -->
This function is necessary for supporting `--stack` flag on jam. 
```
if flags.stack != "" {
var filteredDependencies []cargo.ConfigExtensionMetadataDependency
for _, dep := range config.Metadata.Dependencies {
	if dep.HasStack(flags.stack) {
		filteredDependencies = append(filteredDependencies, dep)
	}
}

config.Metadata.Dependencies = filteredDependencies
}
```

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
