### PR TITLE
Allows users to set a dependency mirror

### DIFF
--- a/postal/fakes/mirror_resolver.go
+++ b/postal/fakes/mirror_resolver.go
@@ -1,0 +1,31 @@
+package fakes
+
+import "sync"
+
+type MirrorResolver struct {
+	FindDependencyMirrorCall struct {
+		mutex     sync.Mutex
+		CallCount int
+		Receives  struct {
+			Uri         string
+			PlatformDir string
+		}
+		Returns struct {
+			String string
+			Error  error
+		}
+		Stub func(string, string) (string, error)
+	}
+}
+
+func (f *MirrorResolver) FindDependencyMirror(param1 string, param2 string) (string, error) {
+	f.FindDependencyMirrorCall.mutex.Lock()
+	defer f.FindDependencyMirrorCall.mutex.Unlock()
+	f.FindDependencyMirrorCall.CallCount++
+	f.FindDependencyMirrorCall.Receives.Uri = param1
+	f.FindDependencyMirrorCall.Receives.PlatformDir = param2
+	if f.FindDependencyMirrorCall.Stub != nil {
+		return f.FindDependencyMirrorCall.Stub(param1, param2)
+	}
+	return f.FindDependencyMirrorCall.Returns.String, f.FindDependencyMirrorCall.Returns.Error
+}

--- a/postal/internal/dependency_mirror.go
+++ b/postal/internal/dependency_mirror.go
@@ -1,0 +1,138 @@
+package internal
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+)
+
+type DependencyMirrorResolver struct {
+	bindingResolver BindingResolver
+}
+
+func NewDependencyMirrorResolver(bindingResolver BindingResolver) DependencyMirrorResolver {
+	return DependencyMirrorResolver{
+		bindingResolver: bindingResolver,
+	}
+}
+
+func formatAndVerifyMirror(mirror, uri string) (string, error) {
+	mirrorURL, err := url.Parse(mirror)
+	if err != nil {
+		return "", err
+	}
+
+	uriURL, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+
+	if mirrorURL.Scheme != "https" && mirrorURL.Scheme != "file" {
+		return "", fmt.Errorf("invalid mirror scheme")
+	}
+
+	mirrorURL.Path = strings.Replace(mirrorURL.Path, "{originalHost}", uriURL.Host+uriURL.Path, 1)
+	return mirrorURL.String(), nil
+}
+
+func (d DependencyMirrorResolver) FindDependencyMirror(uri, platformDir string) (string, error) {
+	mirror, err := d.findMirrorFromEnv(uri)
+	if err != nil {
+		return "", err
+	}
+
+	if mirror != "" {
+		return formatAndVerifyMirror(mirror, uri)
+	}
+
+	mirror, err = d.findMirrorFromBinding(uri, platformDir)
+	if err != nil {
+		return "", err
+	}
+
+	if mirror != "" {
+		return formatAndVerifyMirror(mirror, uri)
+	}
+
+	return "", nil
+}
+
+func (d DependencyMirrorResolver) findMirrorFromEnv(uri string) (string, error) {
+	const DefaultMirror = "BP_DEPENDENCY_MIRROR"
+	const NonDefaultMirrorPrefix = "BP_DEPENDENCY_MIRROR_"
+	mirrors := make(map[string]string)
+	environmentVariables := os.Environ()
+	for _, ev := range environmentVariables {
+		pair := strings.SplitN(ev, "=", 2)
+		key := pair[0]
+		value := pair[1]
+
+		if !strings.Contains(key, DefaultMirror) {
+			continue
+		}
+
+		if key == DefaultMirror {
+			mirrors["default"] = value
+			continue
+		}
+
+		// convert key
+		hostname := strings.SplitN(key, NonDefaultMirrorPrefix, 2)[1]
+		hostname = strings.ReplaceAll(strings.ReplaceAll(hostname, "__", "-"), "_", ".")
+		hostname = strings.ToLower(hostname)
+		mirrors[hostname] = value
+
+		if !strings.Contains(uri, hostname) {
+			continue
+		}
+
+		return value, nil
+	}
+
+	if mirrorUri, ok := mirrors["default"]; ok {
+		return mirrorUri, nil
+	}
+
+	return "", nil
+}
+
+func (d DependencyMirrorResolver) findMirrorFromBinding(uri, platformDir string) (string, error) {
+	bindings, err := d.bindingResolver.Resolve("dependency-mirror", "", platformDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve 'dependency-mirror' binding: %w", err)
+	}
+
+	if len(bindings) > 1 {
+		return "", fmt.Errorf("cannot have multiple bindings of type 'dependency-mirror'")
+	}
+
+	if len(bindings) == 0 {
+		return "", nil
+	}
+
+	mirror := ""
+	entries := bindings[0].Entries
+	for hostname, entry := range entries {
+		if hostname == "default" {
+			mirror, err = entry.ReadString()
+			if err != nil {
+				return "", err
+			}
+			continue
+		}
+
+		if !strings.Contains(uri, hostname) {
+			continue
+		}
+
+		mirror, err = entry.ReadString()
+		if err != nil {
+			return "", err
+		}
+
+		return mirror, nil
+	}
+
+	return mirror, nil
+}

--- a/postal/internal/dependency_mirror_test.go
+++ b/postal/internal/dependency_mirror_test.go
@@ -1,0 +1,285 @@
+package internal_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/packit/v2/postal/internal"
+	"github.com/paketo-buildpacks/packit/v2/postal/internal/fakes"
+	"github.com/paketo-buildpacks/packit/v2/servicebindings"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testDependencyMirror(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect          = NewWithT(t).Expect
+		tmpDir          string
+		resolver        internal.DependencyMirrorResolver
+		bindingResolver *fakes.BindingResolver
+		err             error
+	)
+
+	context("FindDependencyMirror", func() {
+		context("via binding", func() {
+			it.Before(func() {
+				tmpDir, err = os.MkdirTemp("", "dependency-mirror")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(filepath.Join(tmpDir, "default"), []byte("https://mirror.example.org/{originalHost}"), os.ModePerm))
+				Expect(os.WriteFile(filepath.Join(tmpDir, "type"), []byte("dependency-mirror"), os.ModePerm))
+
+				bindingResolver = &fakes.BindingResolver{}
+				resolver = internal.NewDependencyMirrorResolver(bindingResolver)
+
+				bindingResolver.ResolveCall.Returns.BindingSlice = []servicebindings.Binding{
+					{
+						Name: "some-binding",
+						Path: "some-path",
+						Type: "dependency-mirror",
+						Entries: map[string]*servicebindings.Entry{
+							"default": servicebindings.NewEntry(filepath.Join(tmpDir, "default")),
+						},
+					},
+				}
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(tmpDir)).To(Succeed())
+			})
+
+			context("given a default mirror binding", func() {
+				it("finds a matching dependency mirror in the platform bindings if there is one", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("dependency-mirror"))
+					Expect(bindingResolver.ResolveCall.Receives.Provider).To(BeEmpty())
+					Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal("some-platform-dir"))
+					Expect(boundDependency).To(Equal("https://mirror.example.org/some-uri"))
+				})
+			})
+
+			context("given default mirror and specific hostname bindings", func() {
+				it.Before(func() {
+					Expect(os.WriteFile(filepath.Join(tmpDir, "github.com"), []byte("https://mirror.example.org/public-github"), os.ModePerm))
+					Expect(os.WriteFile(filepath.Join(tmpDir, "nodejs.org"), []byte("https://mirror.example.org/node-dist"), os.ModePerm))
+
+					bindingResolver.ResolveCall.Returns.BindingSlice[0].Entries = map[string]*servicebindings.Entry{
+						"default":    servicebindings.NewEntry(filepath.Join(tmpDir, "default")),
+						"github.com": servicebindings.NewEntry(filepath.Join(tmpDir, "github.com")),
+						"nodejs.org": servicebindings.NewEntry(filepath.Join(tmpDir, "nodejs.org")),
+					}
+				})
+
+				it("finds the default mirror when given uri does not match a specific hostname", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("dependency-mirror"))
+					Expect(bindingResolver.ResolveCall.Receives.Provider).To(BeEmpty())
+					Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal("some-platform-dir"))
+					Expect(boundDependency).To(Equal("https://mirror.example.org/some-uri"))
+				})
+
+				it("finds the mirror matching the specific hostname in the given uri", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-github.com-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("dependency-mirror"))
+					Expect(bindingResolver.ResolveCall.Receives.Provider).To(BeEmpty())
+					Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal("some-platform-dir"))
+					Expect(boundDependency).To(Equal("https://mirror.example.org/public-github"))
+				})
+			})
+
+			context("given a specific hostname binding and no default mirror binding", func() {
+				it.Before(func() {
+					Expect(os.Remove(filepath.Join(tmpDir, "default")))
+					Expect(os.WriteFile(filepath.Join(tmpDir, "github.com"), []byte("https://mirror.example.org/public-github"), os.ModePerm))
+					Expect(os.WriteFile(filepath.Join(tmpDir, "nodejs.org"), []byte("https://mirror.example.org/node-dist"), os.ModePerm))
+
+					bindingResolver.ResolveCall.Returns.BindingSlice[0].Entries = map[string]*servicebindings.Entry{
+						"github.com": servicebindings.NewEntry(filepath.Join(tmpDir, "github.com")),
+						"nodejs.org": servicebindings.NewEntry(filepath.Join(tmpDir, "nodejs.org")),
+					}
+				})
+
+				it("return empty string for non specific hostnames", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("dependency-mirror"))
+					Expect(bindingResolver.ResolveCall.Receives.Provider).To(BeEmpty())
+					Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal("some-platform-dir"))
+					Expect(boundDependency).To(Equal(""))
+				})
+
+				it("finds the mirror matching the specific hostname in the given uri", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-nodejs.org-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(bindingResolver.ResolveCall.Receives.Typ).To(Equal("dependency-mirror"))
+					Expect(bindingResolver.ResolveCall.Receives.Provider).To(BeEmpty())
+					Expect(bindingResolver.ResolveCall.Receives.PlatformDir).To(Equal("some-platform-dir"))
+					Expect(boundDependency).To(Equal("https://mirror.example.org/node-dist"))
+				})
+			})
+		})
+
+		context("via environment variables", func() {
+			it.Before(func() {
+				Expect(os.Setenv("BP_DEPENDENCY_MIRROR", "https://mirror.example.org/{originalHost}"))
+
+				bindingResolver = &fakes.BindingResolver{}
+				resolver = internal.NewDependencyMirrorResolver(bindingResolver)
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR"))
+			})
+
+			context("given the default mirror environment variable is set", func() {
+				it("finds the matching dependency mirror", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal("https://mirror.example.org/some-uri"))
+				})
+			})
+
+			context("given environment variables for a default mirror and specific hostname mirrors", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_DEPENDENCY_MIRROR_GITHUB_COM", "https://mirror.example.org/public-github"))
+					Expect(os.Setenv("BP_DEPENDENCY_MIRROR_TESTING_123__ABC", "https://mirror.example.org/testing"))
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR_GITHUB_COM"))
+					Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR_TESTING_123__ABC"))
+				})
+
+				it("finds the default mirror when given uri does not match a specific hostname", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal("https://mirror.example.org/some-uri"))
+				})
+
+				it("finds the mirror matching the specific hostname in the given uri", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-github.com-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal("https://mirror.example.org/public-github"))
+				})
+
+				it("properly decodes the hostname", func() {
+					boundDependency, err := resolver.FindDependencyMirror("testing.123-abc-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal("https://mirror.example.org/testing"))
+				})
+			})
+
+			context("given environment variables for a specific hostname and none for a default mirror", func() {
+				it.Before(func() {
+					Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR"))
+					Expect(os.Setenv("BP_DEPENDENCY_MIRROR_GITHUB_COM", "https://mirror.example.org/public-github"))
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR_GITHUB_COM"))
+				})
+
+				it("return empty string for non specific hostnames", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal(""))
+				})
+
+				it("finds the mirror matching the specific hostname in the given uri", func() {
+					boundDependency, err := resolver.FindDependencyMirror("some-github.com-uri", "some-platform-dir")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(boundDependency).To(Equal("https://mirror.example.org/public-github"))
+				})
+			})
+		})
+
+		context("when mirror is provided by both bindings and environment variables", func() {
+			it.Before(func() {
+				tmpDir, err = os.MkdirTemp("", "dependency-mirror")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.WriteFile(filepath.Join(tmpDir, "default"), []byte("https://mirror.example.org/{originalHost}"), os.ModePerm))
+				Expect(os.WriteFile(filepath.Join(tmpDir, "type"), []byte("dependency-mirror"), os.ModePerm))
+
+				Expect(os.Setenv("BP_DEPENDENCY_MIRROR", "https://mirror.other-example.org/{originalHost}"))
+			})
+
+			it.After(func() {
+				Expect(os.RemoveAll(tmpDir)).To(Succeed())
+				Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR"))
+			})
+
+			it("defaults to environment variable and ignores binding", func() {
+				boundDependency, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(boundDependency).NotTo(Equal("https://mirror.example.org/some-uri"))
+				Expect(boundDependency).To(Equal("https://mirror.other-example.org/some-uri"))
+
+			})
+		})
+
+		context("failure cases", func() {
+			context("when more than one dependency mirror binding exists", func() {
+				it.Before(func() {
+					tmpDir, err = os.MkdirTemp("", "dependency-mirror")
+					Expect(err).NotTo(HaveOccurred())
+					Expect(os.WriteFile(filepath.Join(tmpDir, "default"), []byte("https://mirror.example.org/{originalHost}"), os.ModePerm))
+					Expect(os.WriteFile(filepath.Join(tmpDir, "github.com"), []byte("https://mirror.example.org/public-github"), os.ModePerm))
+					Expect(os.WriteFile(filepath.Join(tmpDir, "type"), []byte("dependency-mirror"), os.ModePerm))
+
+					bindingResolver = &fakes.BindingResolver{}
+					resolver = internal.NewDependencyMirrorResolver(bindingResolver)
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(tmpDir)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					bindingResolver.ResolveCall.Returns.BindingSlice = []servicebindings.Binding{
+						{
+							Name: "some-binding",
+							Path: "some-path",
+							Type: "dependency-mirror",
+							Entries: map[string]*servicebindings.Entry{
+								"default": servicebindings.NewEntry(filepath.Join(tmpDir, "default")),
+							},
+						},
+						{
+							Name: "some-other-binding",
+							Path: "some-other-path",
+							Type: "dependency-mirror",
+							Entries: map[string]*servicebindings.Entry{
+								"github.com": servicebindings.NewEntry(filepath.Join(tmpDir, "github.com")),
+							},
+						},
+					}
+
+					_, err = resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).To(MatchError(ContainSubstring("cannot have multiple bindings of type 'dependency-mirror'")))
+				})
+			})
+
+			context("when mirror contains invalid scheme", func() {
+				it.Before(func() {
+					Expect(os.Setenv("BP_DEPENDENCY_MIRROR", "http://mirror.example.org/{originalHost}"))
+
+					bindingResolver = &fakes.BindingResolver{}
+					resolver = internal.NewDependencyMirrorResolver(bindingResolver)
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("BP_DEPENDENCY_MIRROR"))
+				})
+
+				it("returns an error", func() {
+					_, err := resolver.FindDependencyMirror("some-uri", "some-platform-dir")
+					Expect(err).To(MatchError(ContainSubstring("invalid mirror scheme")))
+				})
+			})
+		})
+	})
+}

--- a/postal/internal/init_test.go
+++ b/postal/internal/init_test.go
@@ -10,6 +10,7 @@ import (
 func TestUnitPostalInternal(t *testing.T) {
 	suite := spec.New("packit/postal/internal", spec.Report(report.Terminal{}))
 	suite("DependencyMappings", testDependencyMappings)
+	suite("DependencyMirror", testDependencyMirror)
 
 	suite.Run(t)
 }


### PR DESCRIPTION
Implements [dependency-mirrors RFC](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0060-dependency-mirrors.md)

A new release of each buildpack will need to be cut with the updated version of packit containing this change.

Reason for this change:
While there is already support for dependency mappings, this adds support for dependency mirrors. The difference is the user would not need to specify a mapping for each individual dependency. Dependency mirrors are more efficient because the user can set one mirror for all or multiple dependencies.

The mirror can be set via an environment variable or a binding of type `dependency-mirror`. In addition, multiple mirror URLs can be set, a default mirror with extra specific hostname mirrors. For example, if a user wants to download all dependencies from the same place except for dependencies that originated in github (see below). The default mirror can contain a placeholder, `{originalHost}`, to support mirrors that host many different repositories, which in some cases include the original hostname in the path.  If only specific hostname mirrors are set, the appropriate dependencies will be download via those mirrors while everything else will be downloaded through the original URLs in the buildpack's metadata.

Example mirrors via environment variables:
```
BP_DEPENDENCY_MIRROR              https://mirror.example.org/{originalHost}
BP_DEPENDENCY_MIRROR_GITHUB_COM   https://mirror.example.org/public-github
BP_DEPENDENCY_MIRROR_NODEJS_ORG   https://mirror.example.org/node-dist
```
Example of mirrors via binding
```
/platform
    └── bindings
        └── dependency-mirror
            ├── default                https://mirror.example.org/{originalHost}
            ├── github.com             https://mirror.example.org/public-github
            ├── nodejs.org             https://mirror.example.org/node-dist
            └── type                   dependency-mirror
```

If a dependency mapping and a dependency mirror is set, an error will be generated. Dependency mappings and mirrors cannot be used simultaneously.

If a binding is used to set dependency mirrors, there can only be one binding of type `dependency-mirror`, containing multiple `Entries` for each mirror URL.

If both methods, environment variable(s) and binding, are used to set a dependency mirror, the mirror(s) from the environment variable(s) will be chosen, as specified in the above RFC.



