### PR TITLE
Support reading service bindings from `VCAP_SERVICES` env var

### DIFF
--- a/servicebindings/entry.go
+++ b/servicebindings/entry.go
@@ -1,13 +1,16 @@
 package servicebindings
 
 import (
+	"bytes"
+	"io"
 	"os"
 )
 
 // Entry represents the read-only content of a binding entry.
 type Entry struct {
-	path string
-	file *os.File
+	path  string
+	file  *os.File
+	value *bytes.Reader
 }
 
 // NewEntry returns a new Entry whose content is given by the file at the provided path.
@@ -17,18 +20,39 @@ func NewEntry(path string) *Entry {
 	}
 }
 
+// NewWithValue returns a new Entry with predefined value.
+func NewWithValue(value []byte) *Entry {
+	return &Entry{
+		value: bytes.NewReader(value),
+	}
+}
+
 // ReadBytes reads the entire raw content of the entry. There is no need to call Close after calling ReadBytes.
 func (e *Entry) ReadBytes() ([]byte, error) {
+	if e.value != nil {
+		return io.ReadAll(e.value)
+	}
 	return os.ReadFile(e.path)
 }
 
 // ReadString reads the entire content of the entry as a string. There is no need to call Close after calling
 // ReadString.
 func (e *Entry) ReadString() (string, error) {
-	bytes, err := e.ReadBytes()
-	if err != nil {
-		return "", err
+	var bytes []byte
+	var err error
+
+	if e.value != nil {
+		bytes, err = io.ReadAll(e.value)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		bytes, err = e.ReadBytes()
+		if err != nil {
+			return "", err
+		}
 	}
+
 	return string(bytes), nil
 }
 
@@ -36,6 +60,10 @@ func (e *Entry) ReadString() (string, error) {
 // of entry data, Read returns 0, io.EOF.
 // Close must be called when all read operations are complete.
 func (e *Entry) Read(b []byte) (int, error) {
+	if e.value != nil {
+		return e.value.Read(b)
+	}
+
 	if e.file == nil {
 		file, err := os.Open(e.path)
 		if err != nil {
@@ -49,11 +77,16 @@ func (e *Entry) Read(b []byte) (int, error) {
 // Close closes the entry and resets it for reading. After calling Close, any subsequent calls to Read will read entry
 // data from the beginning. Close may be called on a closed entry without error.
 func (e *Entry) Close() error {
-	if e.file == nil {
-		return nil
-	}
 	defer func() {
 		e.file = nil
 	}()
-	return e.file.Close()
+
+	if e.value != nil {
+		_, err := e.value.Seek(0, io.SeekStart)
+		return err
+	} else if e.file == nil {
+		return nil
+	} else {
+		return e.file.Close()
+	}
 }

--- a/servicebindings/testdata/vcap_services.json
+++ b/servicebindings/testdata/vcap_services.json
@@ -1,0 +1,69 @@
+{
+    "elephantsql-provider": [
+      {
+        "name": "elephantsql-binding-c6c60",
+        "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
+        "binding_name": "elephantsql-binding-c6c60",
+        "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
+        "instance_name": "elephantsql-c6c60",
+        "label": "elephantsql-type",
+        "tags": [
+          "postgres",
+          "postgresql",
+          "relational"
+        ],
+        "plan": "turtle",
+        "credentials": {
+          "uri": "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser",
+          "int": 1,
+          "bool": true
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "sendgrid-provider": [
+      {
+        "name": "mysendgrid",
+        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+        "binding_name": null,
+        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+        "instance_name": "mysendgrid",
+        "label": "sendgrid-type",
+        "tags": [
+          "smtp"
+        ],
+        "plan": "free",
+        "credentials": {
+          "hostname": "smtp.example.com",
+          "username": "QvsXMbJ3rK",
+          "password": "HCHMOYluTv"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "postgres": [
+      {
+        "name": "postgres",
+        "label": "postgres",
+        "plan": "default",
+        "tags": [
+          "postgres"
+        ],
+        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+        "binding_name": null,
+        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+        "credentials": {
+          "username": "foo",
+          "password": "bar",
+          "urls": {
+            "example": "http://example.com"
+          }
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ]
+  }
+  


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR adds `VCAP_SERVICES` environment variable as a source of service bindings

## Use Cases
<!-- An explanation of the use cases your change enables -->

At the moment, both `libcnb` and `libpak` (through `libcnb`) support reading service bindings from `VCAP_SERVICES` environment variable. This PR will bring feature-parity between `libpak` and `packit`, as well as improve user experience for the upcoming CNB@CloudFoundry RFC: https://github.com/cloudfoundry/community/pull/796

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
