### PR TITLE
Fix override of existing values in prepend & append

### DIFF
--- a/scribe/formatted_map.go
+++ b/scribe/formatted_map.go
@@ -58,9 +58,17 @@ func NewFormattedMapFromEnvironment(environment map[string]string) FormattedMap 
 		case parts[1] == "override" || parts[1] == "default":
 			envMap[parts[0]] = value
 		case parts[1] == "prepend":
-			envMap[parts[0]] = strings.Join([]string{value, "$" + parts[0]}, environment[parts[0]+".delim"])
+			if existingValue, ok := envMap[parts[0]]; ok {
+				envMap[parts[0]] = strings.Join([]string{value, existingValue.(string)}, environment[parts[0]+".delim"])
+			} else {
+				envMap[parts[0]] = strings.Join([]string{value, "$" + parts[0]}, environment[parts[0]+".delim"])
+			}
 		case parts[1] == "append":
-			envMap[parts[0]] = strings.Join([]string{"$" + parts[0], value}, environment[parts[0]+".delim"])
+			if existingValue, ok := envMap[parts[0]]; ok {
+				envMap[parts[0]] = strings.Join([]string{existingValue.(string), value}, environment[parts[0]+".delim"])
+			} else {
+				envMap[parts[0]] = strings.Join([]string{"$" + parts[0], value}, environment[parts[0]+".delim"])
+			}
 		}
 	}
 

--- a/scribe/formatted_map.go
+++ b/scribe/formatted_map.go
@@ -58,17 +58,17 @@ func NewFormattedMapFromEnvironment(environment map[string]string) FormattedMap 
 		case parts[1] == "override" || parts[1] == "default":
 			envMap[parts[0]] = value
 		case parts[1] == "prepend":
-			if existingValue, ok := envMap[parts[0]]; ok {
-				envMap[parts[0]] = strings.Join([]string{value, existingValue.(string)}, environment[parts[0]+".delim"])
-			} else {
-				envMap[parts[0]] = strings.Join([]string{value, "$" + parts[0]}, environment[parts[0]+".delim"])
+			existingValue, ok := envMap[parts[0]]
+			if !ok {
+				existingValue = "$" + parts[0]
 			}
+			envMap[parts[0]] = strings.Join([]string{value, fmt.Sprintf("%v", existingValue)}, environment[parts[0]+".delim"])
 		case parts[1] == "append":
-			if existingValue, ok := envMap[parts[0]]; ok {
-				envMap[parts[0]] = strings.Join([]string{existingValue.(string), value}, environment[parts[0]+".delim"])
-			} else {
-				envMap[parts[0]] = strings.Join([]string{"$" + parts[0], value}, environment[parts[0]+".delim"])
+			existingValue, ok := envMap[parts[0]]
+			if !ok {
+				existingValue = "$" + parts[0]
 			}
+			envMap[parts[0]] = strings.Join([]string{fmt.Sprintf("%v", existingValue), value}, environment[parts[0]+".delim"])
 		}
 	}
 

--- a/scribe/formatted_map_test.go
+++ b/scribe/formatted_map_test.go
@@ -33,11 +33,15 @@ func testFormattedMap(t *testing.T, context spec.G, it spec.S) {
 					"PREPEND.delim":     ":",
 					"APPEND.append":     "some-value",
 					"APPEND.delim":      ":",
+					"BOTH.append":       "appended-value",
+					"BOTH.delim":        ":",
+					"BOTH.prepend":      "prepended-value",
 				})).To(Equal(scribe.FormattedMap{
 					"OVERRIDE": "some-value",
 					"DEFAULT":  "some-value",
 					"PREPEND":  "some-value:$PREPEND",
 					"APPEND":   "$APPEND:some-value",
+					"BOTH":     "prepended-value:$BOTH:appended-value",
 				}))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Currently, when using `NewFormattedMapFromEnvironment(environment)`, entries like "$KEY:value" are overwritten by the last loop execution when using both append and prepend on the same $KEY. This fix appends and prepends values to entries which are already existing.

## Use Cases
We stumbled upon this in the following PR: https://github.com/paketo-buildpacks/npm-install/pull/688#discussion_r1651028653. Integration tests in this project are not working because they check for specific log entries written with `NewFormattedMapFromEnvironment(environment)`, which yield the wrong result, because they overwrite "$KEY:value" when append and prepend are used on the same $KEY.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
