### PR TITLE
do not run draft release workflow on branches named v2-<something>

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - main
     - v*
+    - '!v*-*'
   repository_dispatch:
     types: [ version-bump ]
   workflow_dispatch:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

It's common for us to create branches called `v2-feature-x`, causing pushes to that branch to get picked up by our release automation accidentally. This should resolve that.

With this change, notice that the Create Draft release workflow never ran for this branch `v2-update-workflow` with these changes - https://github.com/paketo-buildpacks/packit/actions/workflows/create-draft-release.yml?query=branch%3Av2-update-workflow


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
