### PR TITLE
feat: add support for targets to cargo

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -15,11 +15,17 @@ type Config struct {
 	Metadata  ConfigMetadata  `toml:"metadata"  json:"metadata,omitempty"`
 	Stacks    []ConfigStack   `toml:"stacks"    json:"stacks,omitempty"`
 	Order     []ConfigOrder   `toml:"order"     json:"order,omitempty"`
+	Targets   []ConfigTarget  `toml:"targets"   json:"targets,omitempty"`
 }
 
 type ConfigStack struct {
 	ID     string   `toml:"id"     json:"id,omitempty"`
 	Mixins []string `toml:"mixins" json:"mixins,omitempty"`
+}
+
+type ConfigTarget struct {
+	OS     string   `toml:"os"     json:"os,omitempty"`
+	Arch   string   `toml:"arch"   json:"arch,omitempty"`
 }
 
 type ConfigBuildpack struct {

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -57,6 +57,12 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 						ID: "other-stack-id",
 					},
 				},
+				Targets: []cargo.ConfigTarget{
+					{
+						OS:     "linux",
+						Arch:   "arm64",
+					},
+				},
 				Metadata: cargo.ConfigMetadata{
 					IncludeFiles: []string{
 						"some-include-file",
@@ -165,6 +171,10 @@ api = "0.6"
 
 [[stacks]]
   id = "other-stack-id"
+
+[[targets]]
+  os = "linux"
+  arch = "arm64"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Add support for targets in buildpack.toml which
are used for multi-arch support.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds support for targets in the buildpack.toml parsing. 

## Use Cases
<!-- An explanation of the use cases your change enables -->
This is needed
for multi-arch support. Otherwise Jam ends up stripping them out
when adding the version number to the buildpack.toml file before
creating the tgz and cnb for a buildpack


## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
