### PR TITLE
feat: Add support for targets in cargo for extension

### DIFF
--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -11,6 +11,12 @@ type ExtensionConfig struct {
 	API       string                  `toml:"api"       json:"api,omitempty"`
 	Extension ConfigExtension         `toml:"extension" json:"extension,omitempty"`
 	Metadata  ConfigExtensionMetadata `toml:"metadata"  json:"metadata,omitempty"`
+	Targets   []ExtensionConfigTarget `toml:"targets"   json:"targets,omitempty"`
+}
+
+type ExtensionConfigTarget struct {
+	OS   string `toml:"os"     json:"os,omitempty"`
+	Arch string `toml:"arch"   json:"arch,omitempty"`
 }
 
 type ConfigExtensionMetadata struct {

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -72,8 +72,19 @@ func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 							Build:       true,
 						},
 					},
+
 					DefaultVersions: map[string]string{
 						"some-dependency": "1.2.x",
+					},
+				},
+				Targets: []cargo.ExtensionConfigTarget{
+					{
+						OS:   "linux",
+						Arch: "arm64",
+					},
+					{
+						OS:   "linux",
+						Arch: "amd64",
 					},
 				},
 			})
@@ -118,6 +129,14 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.tiny"]
     uri = "http://some-url"
     version = "1.2.3"
+
+[[targets]]
+  os = "linux"
+  arch = "arm64"
+
+[[targets]]
+  os = "linux"
+  arch = "amd64"
 `))
 		})
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
While jam packages an extension, it recreates the extension.toml. The generated extension.toml is based on what has been parsed from packit. In case some of the variables available on the extension.toml are not available for parsing from the config, will not be included on the generated extension.toml. 

This PR adds the targets attribute on the config, similar to this PR for buildpacks https://github.com/paketo-buildpacks/packit/pull/604, to packit be able to output them on the generated extension.toml.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
