### PR TITLE
Update service binding implementation to match libcnb

### DIFF
--- a/servicebindings/resolver.go
+++ b/servicebindings/resolver.go
@@ -33,10 +33,9 @@ type Binding struct {
 //
 // It also supports backwards compatibility with the legacy service binding spec:
 // https://github.com/buildpacks/spec/blob/main/extensions/bindings.md
-type Resolver struct {
-	bindingRoot string
-	bindings    []Binding
-}
+//
+// It also supports reading bindings from VCAP_SERVICES
+type Resolver struct{}
 
 // NewResolver returns a new service binding resolver.
 func NewResolver() *Resolver {
@@ -50,19 +49,16 @@ func NewResolver() *Resolver {
 //
 //  1. SERVICE_BINDING_ROOT environment variable
 //  2. CNB_BINDINGS environment variable, if above is not set
-//  3. `<platformDir>/bindings`, if both above are not set
+//  3. VCAP_SERVICES environment variable, if above is not set
+//  4. `<platformDir>/bindings`, if all above are not set
 func (r *Resolver) Resolve(typ, provider, platformDir string) ([]Binding, error) {
-	if newRoot := bindingRoot(platformDir); r.bindingRoot != newRoot {
-		r.bindingRoot = newRoot
-		bindings, err := loadBindings(r.bindingRoot)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load bindings from '%s': %w", r.bindingRoot, err)
-		}
-		r.bindings = bindings
+	bindings, err := loadBindings(platformDir)
+	if err != nil {
+		return nil, err
 	}
 
 	var resolved []Binding
-	for _, binding := range r.bindings {
+	for _, binding := range bindings {
 		if (strings.EqualFold(binding.Type, typ)) &&
 			(provider == "" || strings.EqualFold(binding.Provider, provider)) {
 			resolved = append(resolved, binding)
@@ -77,9 +73,10 @@ func (r *Resolver) Resolve(typ, provider, platformDir string) ([]Binding, error)
 //
 // The location of bindings is given by one of the following, in order of precedence:
 //
-//   1. SERVICE_BINDING_ROOT environment variable
-//   2. CNB_BINDINGS environment variable, if above is not set
-//   3. `<platformDir>/bindings`, if both above are not set
+//  1. SERVICE_BINDING_ROOT environment variable
+//  2. CNB_BINDINGS environment variable, if above is not set
+//  3. VCAP_SERVICES environment variable, if above is not set
+//  4. `<platformDir>/bindings`, if all above are not set
 
 func (r *Resolver) ResolveOne(typ, provider, platformDir string) (Binding, error) {
 	bindings, err := r.Resolve(typ, provider, platformDir)
@@ -92,16 +89,28 @@ func (r *Resolver) ResolveOne(typ, provider, platformDir string) (Binding, error
 	return bindings[0], nil
 }
 
-func loadBindings(bindingRoot string) ([]Binding, error) {
-	if vcapEnv, ok := os.LookupEnv("VCAP_SERVICES"); ok {
-		return loadvcapservicesbinding(vcapEnv)
+func loadBindings(platformDir string) ([]Binding, error) {
+	if path, ok := os.LookupEnv("SERVICE_BINDING_ROOT"); ok {
+		return loadBindingsFromPath(path)
 	}
 
+	if path, ok := os.LookupEnv("CNB_BINDINGS"); ok {
+		return loadBindingsFromPath(path)
+	}
+
+	if content, ok := os.LookupEnv("VCAP_SERVICES"); ok {
+		return loadBindingsFromVcapServices(content)
+	}
+
+	return loadBindingsFromPath(filepath.Join(platformDir, "bindings"))
+}
+
+func loadBindingsFromPath(bindingRoot string) ([]Binding, error) {
 	files, err := os.ReadDir(bindingRoot)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load bindings from '%s': %w", bindingRoot, err)
 	}
 
 	var bindings []Binding
@@ -115,26 +124,14 @@ func loadBindings(bindingRoot string) ([]Binding, error) {
 		if isLegacy {
 			binding, err = loadLegacyBinding(bindingRoot, file.Name())
 		} else {
-			binding, err = loadBinding(bindingRoot, file.Name())
+			binding, err = loadK8sBinding(bindingRoot, file.Name())
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to read binding '%s': %w", file.Name(), err)
+			return nil, fmt.Errorf("failed to load bindings from '%s': failed to read binding '%s': %w", bindingRoot, file.Name(), err)
 		}
 		bindings = append(bindings, binding)
 	}
 	return bindings, nil
-}
-
-func bindingRoot(platformDir string) string {
-	root := os.Getenv("SERVICE_BINDING_ROOT")
-	if root == "" {
-		root = os.Getenv("CNB_BINDINGS")
-	}
-
-	if root == "" {
-		root = filepath.Join(platformDir, "bindings")
-	}
-	return root
 }
 
 // According to the legacy spec (https://github.com/buildpacks/spec/blob/main/extensions/bindings.md), a legacy binding
@@ -150,7 +147,7 @@ func isLegacyBinding(bindingRoot, name string) (bool, error) {
 }
 
 // See: https://github.com/k8s-service-bindings/spec#workload-projection
-func loadBinding(bindingRoot, name string) (Binding, error) {
+func loadK8sBinding(bindingRoot, name string) (Binding, error) {
 	binding := Binding{
 		Name:    name,
 		Path:    filepath.Join(bindingRoot, name),
@@ -238,12 +235,12 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	return binding, nil
 }
 
-func loadvcapservicesbinding(content string) ([]Binding, error) {
+func loadBindingsFromVcapServices(content string) ([]Binding, error) {
 	var contentTyped map[string][]vcapServicesBinding
 
 	err := json.Unmarshal([]byte(content), &contentTyped)
 	if err != nil {
-		return []Binding{}, err
+		return []Binding{}, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': %w", err)
 	}
 
 	bindings := []Binding{}
@@ -253,12 +250,22 @@ func loadvcapservicesbinding(content string) ([]Binding, error) {
 			for k, v := range b.Credentials {
 				entries[k], err = toJSONString(v)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': %w", err)
 				}
 			}
+
+			bindingType := b.Label
+			if value, ok := entries["type"]; ok {
+				str, err := value.ReadString()
+				if err != nil {
+					return nil, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': could not read binding type: %w", err)
+				}
+				bindingType = str
+			}
+
 			bindings = append(bindings, Binding{
 				Name:     b.Name,
-				Type:     b.Label,
+				Type:     bindingType,
 				Provider: p,
 				Entries:  entries,
 			})

--- a/servicebindings/resolver_test.go
+++ b/servicebindings/resolver_test.go
@@ -159,9 +159,9 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 				Expect(os.Unsetenv("VCAP_SERVICES")).To(Succeed())
 			})
 
-			context("SERVICE_BINDING_ROOT env var is set", func() {
+			context("SERVICE_BINDING_ROOT env var is not set", func() {
 				it.Before(func() {
-					Expect(os.Setenv("SERVICE_BINDING_ROOT", bindingRootK8s)).To(Succeed())
+					Expect(os.Unsetenv("SERVICE_BINDING_ROOT")).To(Succeed())
 				})
 
 				it("resolves bindings from VCAP_SERVICES", func() {
@@ -182,6 +182,28 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 						},
 					))
 				})
+			})
+
+			context("SERVICE_BINDING_ROOT env var is set", func() {
+				it.Before(func() {
+					Expect(os.Setenv("SERVICE_BINDING_ROOT", bindingRootK8s)).To(Succeed())
+				})
+
+				it("resolves bindings from SERVICE_BINDING_ROOT", func() {
+					resolver := servicebindings.NewResolver()
+
+					bindings, err := resolver.Resolve("some-type", "", platformDir)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(bindings).To(ConsistOf(
+						servicebindings.Binding{
+							Name:    "some-binding",
+							Path:    filepath.Join(bindingRootK8s, "some-binding"),
+							Type:    "some-type",
+							Entries: map[string]*servicebindings.Entry{},
+						},
+					))
+				})
+
 			})
 		})
 	})
@@ -389,6 +411,49 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 
 				_, err = resolver.Resolve("bad-type", "", "")
 				Expect(err).To(MatchError(HavePrefix("failed to load bindings from '%s': failed to read binding 'bad-binding': open %s: permission denied", bindingRoot, filepath.Join(bindingRoot, "bad-binding", "type"))))
+			})
+
+			context("VCAP_SERVICES", func() {
+				context("success", func() {
+					it.Before(func() {
+						content, err := os.ReadFile("testdata/vcap_services.json")
+						Expect(err).NotTo(HaveOccurred())
+						Expect(os.Setenv("VCAP_SERVICES", string(content))).To(Succeed())
+						Expect(os.Unsetenv("SERVICE_BINDING_ROOT")).To(Succeed())
+					})
+
+					it.After(func() {
+						Expect(os.Unsetenv("VCAP_SERVICES")).To(Succeed())
+					})
+
+					it("successfully parses VCAP_SERVICES", func() {
+						bindings, err := resolver.Resolve("postgres", "", "")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(bindings).To(HaveLen(1))
+					})
+
+					it("handles custom types", func() {
+						bindings, err := resolver.Resolve("custom-type", "", "")
+						Expect(err).ToNot(HaveOccurred())
+						Expect(bindings).To(HaveLen(1))
+					})
+				})
+				context("errors", func() {
+					it.Before(func() {
+						Expect(os.Setenv("VCAP_SERVICES", "{bad json")).To(Succeed())
+						Expect(os.Unsetenv("SERVICE_BINDING_ROOT")).To(Succeed())
+					})
+
+					it.After(func() {
+						Expect(os.Unsetenv("VCAP_SERVICES")).To(Succeed())
+					})
+
+					it("returns errors if it cannot parse VCAP_SERVICES", func() {
+						_, err := resolver.Resolve("bad-type", "", "")
+						Expect(err).To(MatchError(HavePrefix("failed to load bindings from 'VCAP_SERVICES'")))
+					})
+
+				})
 			})
 
 			it("returns empty list if binding root doesn't exist", func() {

--- a/servicebindings/testdata/vcap_services.json
+++ b/servicebindings/testdata/vcap_services.json
@@ -64,6 +64,23 @@
         "syslog_drain_url": null,
         "volume_mounts": []
       }
-    ]
+    ],
+    "user-provided": [
+    {
+      "name": "my-custom-binding",
+      "label": "user-provided",
+      "plan": "default",
+      "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0082",
+      "binding_name": null,
+      "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925f",
+      "credentials": {
+        "username": "foo",
+        "password": "bar",
+        "type": "custom-type"
+      },
+      "syslog_drain_url": null,
+      "volume_mounts": []
+    }
+  ]
   }
   


### PR DESCRIPTION
## Summary
The ordering of when VCAP_SERVICES was parsed was inconsistent between buildpack libraries resulting in unexpected behavior so I updated it to match libcnb
Also added logic to read type from a field called type in the binding when parsing VCAP_SERVICES.

I also removed the caching of service bindings because the caching is only beneficial if resolve is called multiple times from the same buildpack. Due to the fact that few buildpacks even support multiple binding types and that the binding resolution does not have massive overhead (there are typically not many bindings present) I didn't see a need to keep the complexity. 

## Use Cases
This change will result in consistent behavior between the two buildpack libraries. By parsing the type file we will also create consistency with k8s service bindings and allows a service broker to set an explicit type. it also allows for user provided services to define the type they want because using the label will always result in type 'user-provided'.

fixes #658 
fixes #659 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
