### PR TITLE
Update service binding implementation to match libcnb and packit v2

### DIFF
--- a/servicebindings/entry.go
+++ b/servicebindings/entry.go
@@ -1,13 +1,16 @@
 package servicebindings
 
 import (
+	"bytes"
+	"io"
 	"os"
 )
 
 // Entry represents the read-only content of a binding entry.
 type Entry struct {
-	path string
-	file *os.File
+	path  string
+	file  *os.File
+	value *bytes.Reader
 }
 
 // NewEntry returns a new Entry whose content is given by the file at the provided path.
@@ -17,18 +20,39 @@ func NewEntry(path string) *Entry {
 	}
 }
 
+// NewWithValue returns a new Entry with predefined value.
+func NewWithValue(value []byte) *Entry {
+	return &Entry{
+		value: bytes.NewReader(value),
+	}
+}
+
 // ReadBytes reads the entire raw content of the entry. There is no need to call Close after calling ReadBytes.
 func (e *Entry) ReadBytes() ([]byte, error) {
+	if e.value != nil {
+		return io.ReadAll(e.value)
+	}
 	return os.ReadFile(e.path)
 }
 
 // ReadString reads the entire content of the entry as a string. There is no need to call Close after calling
 // ReadString.
 func (e *Entry) ReadString() (string, error) {
-	bytes, err := e.ReadBytes()
-	if err != nil {
-		return "", err
+	var bytes []byte
+	var err error
+
+	if e.value != nil {
+		bytes, err = io.ReadAll(e.value)
+		if err != nil {
+			return "", err
+		}
+	} else {
+		bytes, err = e.ReadBytes()
+		if err != nil {
+			return "", err
+		}
 	}
+
 	return string(bytes), nil
 }
 
@@ -36,6 +60,10 @@ func (e *Entry) ReadString() (string, error) {
 // of entry data, Read returns 0, io.EOF.
 // Close must be called when all read operations are complete.
 func (e *Entry) Read(b []byte) (int, error) {
+	if e.value != nil {
+		return e.value.Read(b)
+	}
+
 	if e.file == nil {
 		file, err := os.Open(e.path)
 		if err != nil {
@@ -49,11 +77,16 @@ func (e *Entry) Read(b []byte) (int, error) {
 // Close closes the entry and resets it for reading. After calling Close, any subsequent calls to Read will read entry
 // data from the beginning. Close may be called on a closed entry without error.
 func (e *Entry) Close() error {
-	if e.file == nil {
-		return nil
-	}
 	defer func() {
 		e.file = nil
 	}()
-	return e.file.Close()
+
+	if e.value != nil {
+		_, err := e.value.Seek(0, io.SeekStart)
+		return err
+	} else if e.file == nil {
+		return nil
+	} else {
+		return e.file.Close()
+	}
 }

--- a/servicebindings/resolver.go
+++ b/servicebindings/resolver.go
@@ -1,6 +1,7 @@
 package servicebindings
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -32,10 +33,9 @@ type Binding struct {
 //
 // It also supports backwards compatibility with the legacy service binding spec:
 // https://github.com/buildpacks/spec/blob/main/extensions/bindings.md
-type Resolver struct {
-	bindingRoot string
-	bindings    []Binding
-}
+//
+// It also supports reading bindings from VCAP_SERVICES
+type Resolver struct{}
 
 // NewResolver returns a new service binding resolver.
 func NewResolver() *Resolver {
@@ -47,21 +47,19 @@ func NewResolver() *Resolver {
 //
 // The location of bindings is given by one of the following, in order of precedence:
 //
-//   1. SERVICE_BINDING_ROOT environment variable
-//   2. CNB_BINDINGS environment variable, if above is not set
-//   3. `<platformDir>/bindings`, if both above are not set
+//  1. SERVICE_BINDING_ROOT environment variable
+//  2. CNB_BINDINGS environment variable, if above is not set
+//  3. VCAP_SERVICES environment variable, if above is not set
+//  4. `<platformDir>/bindings`, if all above are not set
 func (r *Resolver) Resolve(typ, provider, platformDir string) ([]Binding, error) {
-	if newRoot := bindingRoot(platformDir); r.bindingRoot != newRoot {
-		r.bindingRoot = newRoot
-		bindings, err := loadBindings(r.bindingRoot)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load bindings from '%s': %w", r.bindingRoot, err)
-		}
-		r.bindings = bindings
+	bindings, err := loadBindings(platformDir)
+	if err != nil {
+		// return nil, fmt.Errorf("failed to load bindings: %w", err)
+		return nil, err
 	}
 
 	var resolved []Binding
-	for _, binding := range r.bindings {
+	for _, binding := range bindings {
 		if (strings.EqualFold(binding.Type, typ)) &&
 			(provider == "" || strings.EqualFold(binding.Provider, provider)) {
 			resolved = append(resolved, binding)
@@ -76,9 +74,10 @@ func (r *Resolver) Resolve(typ, provider, platformDir string) ([]Binding, error)
 //
 // The location of bindings is given by one of the following, in order of precedence:
 //
-//   1. SERVICE_BINDING_ROOT environment variable
-//   2. CNB_BINDINGS environment variable, if above is not set
-//   3. `<platformDir>/bindings`, if both above are not set
+//  1. SERVICE_BINDING_ROOT environment variable
+//  2. CNB_BINDINGS environment variable, if above is not set
+//  3. VCAP_SERVICES environment variable, if above is not set
+//  4. `<platformDir>/bindings`, if all above are not set
 
 func (r *Resolver) ResolveOne(typ, provider, platformDir string) (Binding, error) {
 	bindings, err := r.Resolve(typ, provider, platformDir)
@@ -91,12 +90,28 @@ func (r *Resolver) ResolveOne(typ, provider, platformDir string) (Binding, error
 	return bindings[0], nil
 }
 
-func loadBindings(bindingRoot string) ([]Binding, error) {
+func loadBindings(platformDir string) ([]Binding, error) {
+	if path, ok := os.LookupEnv("SERVICE_BINDING_ROOT"); ok {
+		return loadBindingsFromPath(path)
+	}
+
+	if path, ok := os.LookupEnv("CNB_BINDINGS"); ok {
+		return loadBindingsFromPath(path)
+	}
+
+	if content, ok := os.LookupEnv("VCAP_SERVICES"); ok {
+		return loadBindingsFromVcapServices(content)
+	}
+
+	return loadBindingsFromPath(filepath.Join(platformDir, "bindings"))
+}
+
+func loadBindingsFromPath(bindingRoot string) ([]Binding, error) {
 	files, err := os.ReadDir(bindingRoot)
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load bindings from '%s': %w", bindingRoot, err)
 	}
 
 	var bindings []Binding
@@ -110,26 +125,14 @@ func loadBindings(bindingRoot string) ([]Binding, error) {
 		if isLegacy {
 			binding, err = loadLegacyBinding(bindingRoot, file.Name())
 		} else {
-			binding, err = loadBinding(bindingRoot, file.Name())
+			binding, err = loadK8sBinding(bindingRoot, file.Name())
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to read binding '%s': %w", file.Name(), err)
+			return nil, fmt.Errorf("failed to load bindings from '%s': failed to read binding '%s': %w", bindingRoot, file.Name(), err)
 		}
 		bindings = append(bindings, binding)
 	}
 	return bindings, nil
-}
-
-func bindingRoot(platformDir string) string {
-	root := os.Getenv("SERVICE_BINDING_ROOT")
-	if root == "" {
-		root = os.Getenv("CNB_BINDINGS")
-	}
-
-	if root == "" {
-		root = filepath.Join(platformDir, "bindings")
-	}
-	return root
 }
 
 // According to the legacy spec (https://github.com/buildpacks/spec/blob/main/extensions/bindings.md), a legacy binding
@@ -145,7 +148,7 @@ func isLegacyBinding(bindingRoot, name string) (bool, error) {
 }
 
 // See: https://github.com/k8s-service-bindings/spec#workload-projection
-func loadBinding(bindingRoot, name string) (Binding, error) {
+func loadK8sBinding(bindingRoot, name string) (Binding, error) {
 	binding := Binding{
 		Name:    name,
 		Path:    filepath.Join(bindingRoot, name),
@@ -165,6 +168,7 @@ func loadBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Type = strings.TrimSpace(binding.Type)
 	delete(entries, "type")
 
 	provider, ok := entries["provider"]
@@ -173,6 +177,7 @@ func loadBinding(bindingRoot, name string) (Binding, error) {
 		if err != nil {
 			return Binding{}, err
 		}
+		binding.Provider = strings.TrimSpace(binding.Provider)
 		delete(entries, "provider")
 	}
 
@@ -202,6 +207,7 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Type = strings.TrimSpace(binding.Type)
 	delete(metadata, "kind")
 
 	provider, ok := metadata["provider"]
@@ -212,6 +218,7 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	if err != nil {
 		return Binding{}, err
 	}
+	binding.Provider = strings.TrimSpace(binding.Provider)
 	delete(metadata, "provider")
 
 	binding.Entries = metadata
@@ -227,6 +234,65 @@ func loadLegacyBinding(bindingRoot, name string) (Binding, error) {
 	}
 
 	return binding, nil
+}
+
+func loadBindingsFromVcapServices(content string) ([]Binding, error) {
+	var contentTyped map[string][]vcapServicesBinding
+
+	err := json.Unmarshal([]byte(content), &contentTyped)
+	if err != nil {
+		return []Binding{}, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': %w", err)
+	}
+
+	bindings := []Binding{}
+	for p, bArray := range contentTyped {
+		for _, b := range bArray {
+			entries := map[string]*Entry{}
+			for k, v := range b.Credentials {
+				entries[k], err = toJSONString(v)
+				if err != nil {
+					return nil, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': %w", err)
+				}
+			}
+
+			bindingType := b.Label
+			if value, ok := entries["type"]; ok {
+				str, err := value.ReadString()
+				if err != nil {
+					return nil, fmt.Errorf("failed to load bindings from 'VCAP_SERVICES': could not read binding type: %w", err)
+				}
+				bindingType = str
+			}
+
+			bindings = append(bindings, Binding{
+				Name:     b.Name,
+				Type:     bindingType,
+				Provider: p,
+				Entries:  entries,
+			})
+		}
+	}
+
+	return bindings, nil
+}
+
+type vcapServicesBinding struct {
+	Name        string                 `json:"name"`
+	Label       string                 `json:"label"`
+	Credentials map[string]interface{} `json:"credentials"`
+}
+
+func toJSONString(input interface{}) (*Entry, error) {
+	switch in := input.(type) {
+	case string:
+		return NewWithValue([]byte(in)), nil
+	default:
+		jsonProperty, err := json.Marshal(in)
+		if err != nil {
+			return nil, err
+		}
+		return NewWithValue(jsonProperty), nil
+	}
 }
 
 func loadEntries(path string) (map[string]*Entry, error) {

--- a/servicebindings/resolver_test.go
+++ b/servicebindings/resolver_test.go
@@ -147,6 +147,65 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 				})
 			})
 		})
+
+		context("VCAP_SERVICES env var is set", func() {
+			it.Before(func() {
+				content, err := os.ReadFile("testdata/vcap_services.json")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(os.Setenv("VCAP_SERVICES", string(content))).To(Succeed())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("VCAP_SERVICES")).To(Succeed())
+			})
+
+			context("SERVICE_BINDING_ROOT env var is not set", func() {
+				it.Before(func() {
+					Expect(os.Unsetenv("SERVICE_BINDING_ROOT")).To(Succeed())
+				})
+
+				it("resolves bindings from VCAP_SERVICES", func() {
+					resolver := servicebindings.NewResolver()
+					bindings, err := resolver.Resolve("postgres", "", platformDir)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(bindings).To(ConsistOf(
+						servicebindings.Binding{
+							Name:     "postgres",
+							Path:     "",
+							Type:     "postgres",
+							Provider: "postgres",
+							Entries: map[string]*servicebindings.Entry{
+								"username": servicebindings.NewWithValue([]byte("foo")),
+								"password": servicebindings.NewWithValue([]byte("bar")),
+								"urls":     servicebindings.NewWithValue([]byte("{\"example\":\"http://example.com\"}")),
+							},
+						},
+					))
+				})
+			})
+
+			context("SERVICE_BINDING_ROOT env var is set", func() {
+				it.Before(func() {
+					Expect(os.Setenv("SERVICE_BINDING_ROOT", bindingRootK8s)).To(Succeed())
+				})
+
+				it("resolves bindings from SERVICE_BINDING_ROOT", func() {
+					resolver := servicebindings.NewResolver()
+
+					bindings, err := resolver.Resolve("some-type", "", platformDir)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(bindings).To(ConsistOf(
+						servicebindings.Binding{
+							Name:    "some-binding",
+							Path:    filepath.Join(bindingRootK8s, "some-binding"),
+							Type:    "some-type",
+							Entries: map[string]*servicebindings.Entry{},
+						},
+					))
+				})
+
+			})
+		})
 	})
 
 	context("resolving bindings", func() {
@@ -205,6 +264,19 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 
 			err = os.WriteFile(filepath.Join(bindingRoot, "binding-2", "password"), nil, os.ModePerm)
 			Expect(err).NotTo(HaveOccurred())
+
+			err = os.MkdirAll(filepath.Join(bindingRoot, "binding-3"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "type"), []byte("\n type-3\n"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "provider"), []byte("\tprovider-3\n"), os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(bindingRoot, "binding-3", "value"), nil, os.ModePerm)
+			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		it.After(func() {
@@ -254,6 +326,23 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 						Entries: map[string]*servicebindings.Entry{
 							"username": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-1B", "username")),
 							"password": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-1B", "password")),
+						},
+					},
+				))
+			})
+
+			it("resolves by type/provider files that contains whitespace", func() {
+				bindings, err := resolver.Resolve("type-3", "provider-3", "")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(bindings).To(ConsistOf(
+					servicebindings.Binding{
+						Name:     "binding-3",
+						Path:     filepath.Join(bindingRoot, "binding-3"),
+						Type:     "type-3",
+						Provider: "provider-3",
+						Entries: map[string]*servicebindings.Entry{
+							"value": servicebindings.NewEntry(filepath.Join(bindingRoot, "binding-3", "value")),
 						},
 					},
 				))
@@ -322,6 +411,23 @@ func testResolver(t *testing.T, context spec.G, it spec.S) {
 
 				_, err = resolver.Resolve("bad-type", "", "")
 				Expect(err).To(MatchError(HavePrefix("failed to load bindings from '%s': failed to read binding 'bad-binding': open %s: permission denied", bindingRoot, filepath.Join(bindingRoot, "bad-binding", "type"))))
+			})
+
+			context("VCAP_SERVICES", func() {
+				it.Before(func() {
+					Expect(os.Setenv("VCAP_SERVICES", "{bad json")).To(Succeed())
+					Expect(os.Unsetenv("SERVICE_BINDING_ROOT")).To(Succeed())
+				})
+
+				it.After(func() {
+					Expect(os.Unsetenv("VCAP_SERVICES")).To(Succeed())
+				})
+
+				it("returns errors if it cannot parse VCAP_SERVICES", func() {
+					_, err := resolver.Resolve("bad-type", "", "")
+					Expect(err).To(MatchError(HavePrefix("failed to load bindings from 'VCAP_SERVICES'")))
+				})
+
 			})
 
 			it("returns empty list if binding root doesn't exist", func() {

--- a/servicebindings/testdata/vcap_services.json
+++ b/servicebindings/testdata/vcap_services.json
@@ -1,0 +1,69 @@
+{
+    "elephantsql-provider": [
+      {
+        "name": "elephantsql-binding-c6c60",
+        "binding_guid": "44ceb72f-100b-4f50-87a2-7809c8b42b8d",
+        "binding_name": "elephantsql-binding-c6c60",
+        "instance_guid": "391308e8-8586-4c42-b464-c7831aa2ad22",
+        "instance_name": "elephantsql-c6c60",
+        "label": "elephantsql-type",
+        "tags": [
+          "postgres",
+          "postgresql",
+          "relational"
+        ],
+        "plan": "turtle",
+        "credentials": {
+          "uri": "postgres://exampleuser:examplepass@postgres.example.com:5432/exampleuser",
+          "int": 1,
+          "bool": true
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "sendgrid-provider": [
+      {
+        "name": "mysendgrid",
+        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+        "binding_name": null,
+        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+        "instance_name": "mysendgrid",
+        "label": "sendgrid-type",
+        "tags": [
+          "smtp"
+        ],
+        "plan": "free",
+        "credentials": {
+          "hostname": "smtp.example.com",
+          "username": "QvsXMbJ3rK",
+          "password": "HCHMOYluTv"
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ],
+    "postgres": [
+      {
+        "name": "postgres",
+        "label": "postgres",
+        "plan": "default",
+        "tags": [
+          "postgres"
+        ],
+        "binding_guid": "6533b1b6-7916-488d-b286-ca33d3fa0081",
+        "binding_name": null,
+        "instance_guid": "8c907d0f-ec0f-44e4-87cf-e23c9ba3925d",
+        "credentials": {
+          "username": "foo",
+          "password": "bar",
+          "urls": {
+            "example": "http://example.com"
+          }
+        },
+        "syslog_drain_url": null,
+        "volume_mounts": []
+      }
+    ]
+  }
+  


### PR DESCRIPTION
## Summary
This adds the capability to read VCAP_SERVICES similar to v2 packit and libcnb

## Use Cases
This allows v1 packit to parse VCAP_SERVICES as many buildpacks still use v1

## Checklist
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
