### PR TITLE
Add OS and Distros to dependency metadata

### DIFF
--- a/cargo/config.go
+++ b/cargo/config.go
@@ -24,8 +24,13 @@ type ConfigStack struct {
 }
 
 type ConfigTarget struct {
-	OS     string   `toml:"os"     json:"os,omitempty"`
-	Arch   string   `toml:"arch"   json:"arch,omitempty"`
+	OS   string `toml:"os"       json:"os,omitempty"`
+	Arch string `toml:"arch"     json:"arch,omitempty"`
+}
+
+type ConfigDistro struct {
+	Name    string `toml:"name" json:"name"`
+	Version string `toml:"version"  json:"version"`
 }
 
 type ConfigBuildpack struct {
@@ -55,21 +60,24 @@ type ConfigMetadata struct {
 }
 
 type ConfigMetadataDependency struct {
-	Checksum        string        `toml:"checksum"         json:"checksum,omitempty"`
-	CPE             string        `toml:"cpe"              json:"cpe,omitempty"`
-	PURL            string        `toml:"purl"             json:"purl,omitempty"`
-	DeprecationDate *time.Time    `toml:"deprecation_date" json:"deprecation_date,omitempty"`
-	ID              string        `toml:"id"               json:"id,omitempty"`
-	Licenses        []interface{} `toml:"licenses"         json:"licenses,omitempty"`
-	Name            string        `toml:"name"             json:"name,omitempty"`
-	SHA256          string        `toml:"sha256"           json:"sha256,omitempty"`
-	Source          string        `toml:"source"           json:"source,omitempty"`
-	SourceChecksum  string        `toml:"source-checksum"  json:"source-checksum,omitempty"`
-	SourceSHA256    string        `toml:"source_sha256"    json:"source_sha256,omitempty"`
-	Stacks          []string      `toml:"stacks"           json:"stacks,omitempty"`
-	StripComponents int           `toml:"strip-components" json:"strip-components,omitempty"`
-	URI             string        `toml:"uri"              json:"uri,omitempty"`
-	Version         string        `toml:"version"          json:"version,omitempty"`
+	Arch            string         `toml:"arch"             json:"arch,omitempty"`
+	Checksum        string         `toml:"checksum"         json:"checksum,omitempty"`
+	CPE             string         `toml:"cpe"              json:"cpe,omitempty"`
+	Distros         []ConfigDistro `toml:"distros"          json:"distros,omitempty"`
+	PURL            string         `toml:"purl"             json:"purl,omitempty"`
+	DeprecationDate *time.Time     `toml:"deprecation_date" json:"deprecation_date,omitempty"`
+	ID              string         `toml:"id"               json:"id,omitempty"`
+	Licenses        []interface{}  `toml:"licenses"         json:"licenses,omitempty"`
+	Name            string         `toml:"name"             json:"name,omitempty"`
+	OS              string         `toml:"os"               json:"os,omitempty"`
+	SHA256          string         `toml:"sha256"           json:"sha256,omitempty"`
+	Source          string         `toml:"source"           json:"source,omitempty"`
+	SourceChecksum  string         `toml:"source-checksum"  json:"source-checksum,omitempty"`
+	SourceSHA256    string         `toml:"source_sha256"    json:"source_sha256,omitempty"`
+	Stacks          []string       `toml:"stacks"           json:"stacks,omitempty"`
+	StripComponents int            `toml:"strip-components" json:"strip-components,omitempty"`
+	URI             string         `toml:"uri"              json:"uri,omitempty"`
+	Version         string         `toml:"version"          json:"version,omitempty"`
 }
 
 type ConfigMetadataDependencyConstraint struct {

--- a/cargo/config_test.go
+++ b/cargo/config_test.go
@@ -59,8 +59,8 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 				},
 				Targets: []cargo.ConfigTarget{
 					{
-						OS:     "linux",
-						Arch:   "arm64",
+						OS:   "linux",
+						Arch: "arm64",
 					},
 				},
 				Metadata: cargo.ConfigMetadata{
@@ -87,6 +87,14 @@ func testConfig(t *testing.T, context spec.G, it spec.S) {
 							StripComponents: 1,
 							URI:             "http://some-url",
 							Version:         "1.2.3",
+							OS:              "some-os",
+							Arch:            "some-arch",
+							Distros: []cargo.ConfigDistro{
+								{
+									Name:    "some-distro-name",
+									Version: "some-distro-version",
+								},
+							},
 						},
 					},
 					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{
@@ -156,6 +164,12 @@ api = "0.6"
   strip-components = 1
   uri = "http://some-url"
   version = "1.2.3"
+  os = "some-os"
+  arch = "some-arch"
+
+	[[metadata.dependencies.distros]]
+	name = "some-distro-name"
+	version = "some-distro-version"
 
 [[metadata.dependency-constraints]]
   id = "some-dependency"
@@ -464,6 +478,12 @@ api = "0.6"
 	strip-components = 1
   uri = "http://some-url"
   version = "1.2.3"
+  os = "some-os"
+  arch = "some-arch"
+
+	[[metadata.dependencies.distros]]
+	name = "some-distro-name"
+	version = "some-distro-version"
 
 [[metadata.dependency-constraints]]
   id = "some-dependency"
@@ -540,6 +560,14 @@ api = "0.6"
 							StripComponents: 1,
 							URI:             "http://some-url",
 							Version:         "1.2.3",
+							OS:              "some-os",
+							Arch:            "some-arch",
+							Distros: []cargo.ConfigDistro{
+								{
+									Name:    "some-distro-name",
+									Version: "some-distro-version",
+								},
+							},
 						},
 					},
 					DependencyConstraints: []cargo.ConfigMetadataDependencyConstraint{

--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -10,6 +10,7 @@ import (
 )
 
 type Checksum = cargo.Checksum
+type Distro = cargo.ConfigDistro
 
 // Dependency is a representation of a buildpack dependency.
 type Dependency struct {
@@ -75,8 +76,12 @@ type Dependency struct {
 	// removing the first n levels from the final decompression destination.
 	StripComponents int `toml:"strip-components"`
 
-	// ARCH is the architecture of this dependency
+	// Platform information of the dependency
+	OS   string `toml:"OS"`
 	Arch string `toml:"arch"`
+
+	// Optional list of OS distribution supported by the dependency.
+	Distros []Distro `toml:"distros"`
 }
 
 func parseBuildpack(path, name string) ([]Dependency, string, error) {

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -330,15 +330,17 @@ sha256 = "some-sha-amd64"
 stacks = ["*"]
 uri = "some-uri"
 version = "1.2.3"
+os = "linux"
 arch = "amd64"
 
 [[metadata.dependencies]]
 id = "some-entry"
-sha256 = "some-sha-arm"
+sha256 = "some-sha-arm64"
 stacks = ["*"]
 uri = "some-uri"
 version = "1.2.3"
-arch = "arm"
+os = "linux"
+arch = "arm64"
 
 [[metadata.dependencies]]
 id = "some-other-entry"
@@ -373,9 +375,9 @@ version = "1.2.4"
 				})
 			})
 
-			context("BP_ARCH=arm", func() {
+			context("BP_ARCH=arm64", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_ARCH", "arm")).To(Succeed())
+					Expect(os.Setenv("BP_ARCH", "arm64")).To(Succeed())
 				})
 
 				it.After(func() {
@@ -385,13 +387,15 @@ version = "1.2.4"
 				it("picks the dependency with the correct arch", func() {
 					dependency, err := service.Resolve(path, "some-entry", "1.2.3", "some-stack")
 					Expect(err).NotTo(HaveOccurred())
-					Expect(dependency.SHA256).To(Equal("some-sha-arm"))
+					Expect(dependency.OS).To(Equal("linux"))
+					Expect(dependency.Arch).To(Equal("arm64"))
+					Expect(dependency.SHA256).To(Equal("some-sha-arm64"))
 				})
 
 				it("fails if no dependency with the correct arch is found", func() {
 					_, err := service.Resolve(path, "some-other-entry", "1.2.4", "some-stack")
 					Expect(err).To(MatchError(ContainSubstring("failed to satisfy")))
-					Expect(err).To(MatchError(ContainSubstring("\"arm\"")))
+					Expect(err).To(MatchError(ContainSubstring("\"arm64\"")))
 				})
 			})
 		})

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -136,6 +136,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 			Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 			// Ensure documentNamespace and creationInfo.created have reproducible values
+			// The DocumentNamespace inculdes the sha1 uuid of the data, which may differ if running locally versus in github actions
 			Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-04aad2fb-ad20-54bc-a8a3-3702ac37734a"), buffer.String())
 			Expect(spdxOutput.CreationInfo.Created).To(BeZero(), buffer.String())
 
@@ -186,6 +187,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 					Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 					// Ensure documentNamespace and creationInfo.created have reproducible values
+					// The DocumentNamespace inculdes the sha1 uuid of the data, which may differ if running locally versus in github actions
 					Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-b103dc3d-2f7a-59c8-835c-ffaa80cd92a0"), buffer.String())
 					Expect(spdxOutput.CreationInfo.Created).To(Equal(time.Unix(1659551872, 0).UTC()), buffer.String())
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This change adds `OS` and `Distros` to buildpack.toml dependency metadata in accordance to [this RFC](https://github.com/paketo-buildpacks/rfcs/blob/main/text/0059-standard-dependency-metadata-format.md) and updates the existing unit tests to verify they work as expected. It also adds comments above unit test lines that fail when not running in github actions. This happens because there are directory paths in the data and they will almost certainly differ when running locally.

resolves https://github.com/paketo-buildpacks/packit/issues/650

This change is required before a PR to jam in order to prevent buildpacks from dropping OS and Arch metadata during packaging.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
