### PR TITLE
Only enforce strict arch checking when dependency specifies arch

### DIFF
--- a/postal/service.go
+++ b/postal/service.go
@@ -54,17 +54,15 @@ type ErrNoDeps struct {
 	id                string
 	version           string
 	stack             string
-	arch              string
 	supportedVersions []string
 }
 
 // Error implements the error.Error interface
 func (e *ErrNoDeps) Error() string {
-	return fmt.Sprintf("failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack with architecture %q. Supported versions are: [%s]",
+	return fmt.Sprintf("failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
 		e.id,
 		e.version,
 		e.stack,
-		e.arch,
 		strings.Join(e.supportedVersions, ", "),
 	)
 }
@@ -151,7 +149,7 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 			continue
 		}
 
-		if !isCorrectArch(dependency) {
+		if dependency.Arch != "" && archFromSystem() != dependency.Arch {
 			continue
 		}
 
@@ -168,7 +166,7 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 	}
 
 	if len(compatibleVersions) == 0 {
-		return Dependency{}, &ErrNoDeps{id, version, stack, archFromSystem(), supportedVersions}
+		return Dependency{}, &ErrNoDeps{id, version, stack, supportedVersions}
 	}
 
 	stacksForVersion := map[string][]string{}
@@ -226,16 +224,6 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 	})
 
 	return compatibleVersions[0], nil
-}
-
-func isCorrectArch(dep Dependency) bool {
-	systemArch := archFromSystem()
-
-	if systemArch == "amd64" && dep.Arch == "" {
-		return true
-	}
-
-	return systemArch == dep.Arch
 }
 
 func archFromSystem() string {

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -23,7 +23,6 @@ import (
 	//nolint Ignore SA1019, usage of deprecated package within a deprecated test case
 	"github.com/paketo-buildpacks/packit/v2/paketosbom"
 
-	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
@@ -116,12 +115,6 @@ strip-components = 1
 		service = postal.NewService(transport).
 			WithDependencyMappingResolver(mappingResolver).
 			WithDependencyMirrorResolver(mirrorResolver)
-
-		Expect(os.Setenv("BP_ARCH", "amd64")).To(Succeed())
-	})
-
-	AfterEach(func() {
-		Expect(os.Unsetenv("BP_ARCH")).To(Succeed())
 	})
 
 	context("Resolve", func() {
@@ -317,7 +310,7 @@ version = "4.5.6"
 			})
 		})
 
-		context("when there architecture specific versions", func() {
+		context("when the dependencies specify an architecture", func() {
 			it.Before(func() {
 				err := os.WriteFile(path, []byte(`
 [metadata]
@@ -342,18 +335,11 @@ version = "1.2.3"
 os = "linux"
 arch = "arm64"
 
-[[metadata.dependencies]]
-id = "some-other-entry"
-sha256 = "some-other-sha"
-stacks = ["*"]
-uri = "some-uri"
-version = "1.2.4"
-
 `), 0600)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			context("BP_ARCH=amd64", func() {
+			context("BP_ARCH is valid", func() {
 				it.Before(func() {
 					Expect(os.Setenv("BP_ARCH", "amd64")).To(Succeed())
 				})
@@ -362,40 +348,25 @@ version = "1.2.4"
 					Expect(os.Unsetenv("BP_ARCH")).To(Succeed())
 				})
 
-				it("picks the dependency with the correct arch", func() {
+				it("picks dependency with the correct arch", func() {
 					dependency, err := service.Resolve(path, "some-entry", "1.2.3", "some-stack")
 					Expect(err).NotTo(HaveOccurred())
 					Expect(dependency.SHA256).To(Equal("some-sha-amd64"))
 				})
-
-				it("picks the dependency with the no arch", func() {
-					dependency, err := service.Resolve(path, "some-other-entry", "1.2.4", "some-stack")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(dependency.SHA256).To(Equal("some-other-sha"))
-				})
 			})
 
-			context("BP_ARCH=arm64", func() {
+			context("BP_ARCH is not valid", func() {
 				it.Before(func() {
-					Expect(os.Setenv("BP_ARCH", "arm64")).To(Succeed())
+					Expect(os.Setenv("BP_ARCH", "some-invalid-arch")).To(Succeed())
 				})
 
 				it.After(func() {
 					Expect(os.Unsetenv("BP_ARCH")).To(Succeed())
 				})
 
-				it("picks the dependency with the correct arch", func() {
-					dependency, err := service.Resolve(path, "some-entry", "1.2.3", "some-stack")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(dependency.OS).To(Equal("linux"))
-					Expect(dependency.Arch).To(Equal("arm64"))
-					Expect(dependency.SHA256).To(Equal("some-sha-arm64"))
-				})
-
-				it("fails if no dependency with the correct arch is found", func() {
-					_, err := service.Resolve(path, "some-other-entry", "1.2.4", "some-stack")
+				it("returns an error", func() {
+					_, err := service.Resolve(path, "some-other-entry", "1.2.3", "some-stack")
 					Expect(err).To(MatchError(ContainSubstring("failed to satisfy")))
-					Expect(err).To(MatchError(ContainSubstring("\"arm64\"")))
 				})
 			})
 		})
@@ -519,7 +490,7 @@ version = "1.2.3"
 					expectedErr := &postal.ErrNoDeps{}
 					_, err := service.Resolve(path, "some-entry", "9.9.9", "some-stack")
 					Expect(errors.As(err, &expectedErr)).To(BeTrue())
-					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-stack\" stack with architecture \"amd64\". Supported versions are: [1.2.3, 4.5.6]")))
+					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-stack\" stack. Supported versions are: [1.2.3, 4.5.6]")))
 				})
 			})
 		})

--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -136,7 +136,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 			Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 			// Ensure documentNamespace and creationInfo.created have reproducible values
-			// The DocumentNamespace inculdes the sha1 uuid of the data, which may differ if running locally versus in github actions
+			// The DocumentNamespace includes the sha1 uuid of the data, which may differ if running locally versus in github actions
 			Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-04aad2fb-ad20-54bc-a8a3-3702ac37734a"), buffer.String())
 			Expect(spdxOutput.CreationInfo.Created).To(BeZero(), buffer.String())
 
@@ -187,7 +187,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 					Expect(spdxOutput.Packages[5].Name).To(Equal("wrappy"), buffer.String())
 
 					// Ensure documentNamespace and creationInfo.created have reproducible values
-					// The DocumentNamespace inculdes the sha1 uuid of the data, which may differ if running locally versus in github actions
+					// The DocumentNamespace includes the sha1 uuid of the data, which may differ if running locally versus in github actions
 					Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-b103dc3d-2f7a-59c8-835c-ffaa80cd92a0"), buffer.String())
 					Expect(spdxOutput.CreationInfo.Created).To(Equal(time.Unix(1659551872, 0).UTC()), buffer.String())
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

This PR does the following:
* Disables strict dependency checking based on architecture
* Only set BP_ARCH for unit tests related to dependencies with architecture
* Removes the architecture from the error message because it can be confusing for noarch dependencies such as pip and yarn
* Fixes typos in a few comments

this is related to https://github.com/paketo-buildpacks/packit/commit/be25401c29f2c5e05f10e97fdcdfcd900ebba745
resolves https://github.com/paketo-buildpacks/packit/issues/650
relates to https://github.com/paketo-buildpacks/packit/issues/618
relates to https://github.com/paketo-buildpacks/nodejs/issues/995

## Use Cases
<!-- An explanation of the use cases your change enables -->

The [0059-standard-dependency-metadata-format](https://github.com/paketo-buildpacks/rfcs/blob/e601a1b0bbf21b54da05588df876fb1d989e2497/text/0059-standard-dependency-metadata-format.md?plain=1#L54-L56) RFC says that when `os` and `arch` are not given it should be assumed that the dependency is compatible with any architecture. This will be a requirement for some buildpacks such as [pip](https://github.com/paketo-buildpacks/pip/blob/58c86600835adab848d144c155c8e1f7002c4dbf/buildpack.toml#L25) and [yarn](https://github.com/paketo-buildpacks/yarn/blob/8b4b8e00f2168f22d4e7b0ddc29e7510f59d5a04/buildpack.toml#L29), which work on any architecture.

This PR makes it so that when dependencies specify `arch` they can only be used on systems with the specified `arch` or if env `BP_ARCH` is set to match. This means strict checking is only enabled when dependencies specify `arch`.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
