### PR TITLE
Fetching dependencies based on the CNB_TARGET_ARCH and CNB_TARGET_OS

### DIFF
--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -115,9 +115,9 @@ func stacksInclude(stacks []string, stack string) bool {
 
 func supportsPlatform(targetOs, targetArch string, dependency Dependency) bool {
 
+	// Avoid strict checking in case of dependency does not specify OS/Arch
 	if dependency.OS == "" && dependency.Arch == "" {
-		dependency.OS = "linux"
-		dependency.Arch = "amd64"
+		return true
 	}
 
 	if targetOs != dependency.OS || targetArch != dependency.Arch {

--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -113,7 +113,7 @@ func stacksInclude(stacks []string, stack string) bool {
 	return false
 }
 
-func platformInclude(targetOs, targetArch string, dependency Dependency) bool {
+func supportsPlatform(targetOs, targetArch string, dependency Dependency) bool {
 
 	if dependency.OS == "" && dependency.Arch == "" {
 		dependency.OS = "linux"

--- a/postal/buildpack.go
+++ b/postal/buildpack.go
@@ -112,3 +112,17 @@ func stacksInclude(stacks []string, stack string) bool {
 	}
 	return false
 }
+
+func platformInclude(targetOs, targetArch string, dependency Dependency) bool {
+
+	if dependency.OS == "" && dependency.Arch == "" {
+		dependency.OS = "linux"
+		dependency.Arch = "amd64"
+	}
+
+	if targetOs != dependency.OS || targetArch != dependency.Arch {
+		return false
+	}
+
+	return true
+}

--- a/postal/service.go
+++ b/postal/service.go
@@ -111,6 +111,18 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 		return Dependency{}, err
 	}
 
+	var targetOs string
+	targetOs = os.Getenv("CNB_TARGET_OS")
+	if targetOs == "" {
+		targetOs = runtime.GOOS
+	}
+
+	var targetArch string
+	targetArch = os.Getenv("CNB_TARGET_ARCH")
+	if targetArch == "" {
+		targetArch = runtime.GOARCH
+	}
+
 	if version == "" {
 		version = "default"
 	}
@@ -145,11 +157,7 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 
 	var supportedVersions []string
 	for _, dependency := range dependencies {
-		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) {
-			continue
-		}
-
-		if dependency.Arch != "" && archFromSystem() != dependency.Arch {
+		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) || !platformInclude(targetOs, targetArch, dependency) {
 			continue
 		}
 

--- a/postal/service.go
+++ b/postal/service.go
@@ -157,7 +157,7 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 
 	var supportedVersions []string
 	for _, dependency := range dependencies {
-		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) || !platformInclude(targetOs, targetArch, dependency) {
+		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) || !supportsPlatform(targetOs, targetArch, dependency) {
 			continue
 		}
 

--- a/postal/service.go
+++ b/postal/service.go
@@ -226,15 +226,6 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 	return compatibleVersions[0], nil
 }
 
-func archFromSystem() string {
-	archFromEnv, ok := os.LookupEnv("BP_ARCH")
-	if !ok {
-		archFromEnv = runtime.GOARCH
-	}
-
-	return archFromEnv
-}
-
 func stringSliceContains(slice []string, str string) bool {
 	for _, s := range slice {
 		if s == str {

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -310,67 +310,6 @@ version = "4.5.6"
 			})
 		})
 
-		context("when the dependencies specify an architecture", func() {
-			it.Before(func() {
-				err := os.WriteFile(path, []byte(`
-[metadata]
-[metadata.default-versions]
-some-entry = "1.2.x"
-
-[[metadata.dependencies]]
-id = "some-entry"
-sha256 = "some-sha-amd64"
-stacks = ["*"]
-uri = "some-uri"
-version = "1.2.3"
-os = "linux"
-arch = "amd64"
-
-[[metadata.dependencies]]
-id = "some-entry"
-sha256 = "some-sha-arm64"
-stacks = ["*"]
-uri = "some-uri"
-version = "1.2.3"
-os = "linux"
-arch = "arm64"
-
-`), 0600)
-				Expect(err).NotTo(HaveOccurred())
-			})
-
-			context("BP_ARCH is valid", func() {
-				it.Before(func() {
-					Expect(os.Setenv("BP_ARCH", "amd64")).To(Succeed())
-				})
-
-				it.After(func() {
-					Expect(os.Unsetenv("BP_ARCH")).To(Succeed())
-				})
-
-				it("picks dependency with the correct arch", func() {
-					dependency, err := service.Resolve(path, "some-entry", "1.2.3", "some-stack")
-					Expect(err).NotTo(HaveOccurred())
-					Expect(dependency.SHA256).To(Equal("some-sha-amd64"))
-				})
-			})
-
-			context("BP_ARCH is not valid", func() {
-				it.Before(func() {
-					Expect(os.Setenv("BP_ARCH", "some-invalid-arch")).To(Succeed())
-				})
-
-				it.After(func() {
-					Expect(os.Unsetenv("BP_ARCH")).To(Succeed())
-				})
-
-				it("returns an error", func() {
-					_, err := service.Resolve(path, "some-other-entry", "1.2.3", "some-stack")
-					Expect(err).To(MatchError(ContainSubstring("failed to satisfy")))
-				})
-			})
-		})
-
 		context("when both a wildcard stack constraint and a specific stack constraint exist for the same dependency version", func() {
 			it.Before(func() {
 				err := os.WriteFile(path, []byte(`
@@ -416,6 +355,76 @@ version = "1.2.3"
 					URI:     "some-uri-specific-stack",
 					SHA256:  "some-sha",
 					Version: "1.2.3",
+				}))
+			})
+		})
+
+		context("When os and arch constraint exists for the same dependency version", func() {
+			it.Before(func() {
+				err := os.WriteFile(path, []byte(`
+[metadata]
+[[metadata.dependencies]]
+arch = "amd64"
+os = "linux"
+id = "node"
+stacks = ["some-stack"]
+version = "20.19.4"
+uri = "some-uri-linux-x64.tar.xz"
+
+[[metadata.dependencies]]
+arch = "arm64"
+os = "linux"
+id = "node"
+stacks = ["some-stack"]
+version = "20.19.4"
+uri = "some-uri-linux-arm64.tar.xz"
+
+[[metadata.dependencies]]
+arch = "some-arch"
+os = "some-os"
+id = "node"
+stacks = ["some-stack"]
+version = "22.19.0"
+uri = "some-uri-some-os-some-arch.tar.xz"
+
+[[metadata.dependencies]]
+arch = "amd64"
+os = "linux"
+id = "node"
+stacks = ["some-stack"]
+version = "22.19.0"
+uri = "some-uri-linux-x64.tar.xz"
+
+[[metadata.dependencies]]
+arch = "arm64"
+os = "linux"
+id = "node"
+stacks = ["some-stack"]
+version = "22.19.0"
+uri = "some-uri-linux-arm64.tar.xz"
+`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(os.Setenv("CNB_TARGET_ARCH", "some-arch")).To(Succeed())
+				Expect(os.Setenv("CNB_TARGET_OS", "some-os")).To(Succeed())
+
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("CNB_TARGET_ARCH")).To(Succeed())
+				Expect(os.Unsetenv("CNB_TARGET_OS")).To(Succeed())
+			})
+
+			it("finds the best matching dependency given a plan entry", func() {
+				dependency, err := service.Resolve(path, "node", "22.19.0", "some-stack")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(dependency).To(Equal(postal.Dependency{
+					ID:      "node",
+					Stacks:  []string{"some-stack"},
+					URI:     "some-uri-some-os-some-arch.tar.xz",
+					Version: "22.19.0",
+					OS:      "some-os",
+					Arch:    "some-arch",
 				}))
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR filters the dependencies from the buildpack.toml based on the CNB_TARGET_ARCH and on the CNB_TARGET_OS env variables. In case these variables are not available, it will fall back to the host architecture and os

In addition, this PR removes filtering dependencies based on the the BP_ARCH env variable.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
