### PR TITLE
Support fetch the CNB_TARGET_* env variables

### DIFF
--- a/build.go
+++ b/build.go
@@ -54,6 +54,12 @@ type BuildContext struct {
 	// WorkingDir is the location of the application source code as provided by
 	// the lifecycle.
 	WorkingDir string
+
+	// TargetInfo contains info of the target (os, arch, ...).
+	TargetInfo TargetInfo
+
+	// TargetDistro is the target distribution (name, version).
+	TargetDistro TargetDistro
 }
 
 // BuildResult allows buildpack authors to indicate the result of the build
@@ -156,7 +162,16 @@ func Build(f BuildFunc, options ...Option) {
 		Platform: Platform{
 			Path: platformPath,
 		},
-		Stack:      os.Getenv("CNB_STACK_ID"),
+		Stack: os.Getenv("CNB_STACK_ID"),
+		TargetInfo: TargetInfo{
+			OS:      os.Getenv("CNB_TARGET_OS"),
+			Arch:    os.Getenv("CNB_TARGET_ARCH"),
+			Variant: os.Getenv("CNB_TARGET_VARIANT"),
+		},
+		TargetDistro: TargetDistro{
+			Name:    os.Getenv("CNB_TARGET_DISTRO_NAME"),
+			Version: os.Getenv("CNB_TARGET_DISTRO_VERSION"),
+		},
 		WorkingDir: pwd,
 		Plan:       plan,
 		Layers: Layers{

--- a/build_test.go
+++ b/build_test.go
@@ -90,12 +90,22 @@ api = "0.8"
 		binaryPath = filepath.Join(cnbDir, "bin", "build")
 
 		Expect(os.Setenv("CNB_STACK_ID", "some-stack")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_OS", "some-os")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_ARCH", "some-arch")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_VARIANT", "some-variant")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_DISTRO_NAME", "some-distro-name")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_DISTRO_VERSION", "some-distro-version")).To(Succeed())
 
 		exitHandler = &fakes.ExitHandler{}
 	})
 
 	it.After(func() {
 		Expect(os.Unsetenv("CNB_STACK_ID")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_OS")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_ARCH")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_VARIANT")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_NAME")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_VERSION")).To(Succeed())
 
 		Expect(os.Chdir(workingDir)).To(Succeed())
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
@@ -115,6 +125,15 @@ api = "0.8"
 		Expect(context).To(Equal(packit.BuildContext{
 			CNBPath: cnbDir,
 			Stack:   "some-stack",
+			TargetInfo: packit.TargetInfo{
+				OS:      "some-os",
+				Arch:    "some-arch",
+				Variant: "some-variant",
+			},
+			TargetDistro: packit.TargetDistro{
+				Name:    "some-distro-name",
+				Version: "some-distro-version",
+			},
 			Platform: packit.Platform{
 				Path: platformDir,
 			},
@@ -474,7 +493,16 @@ api = "0.6"
 				Platform: packit.Platform{
 					Path: platformDir,
 				},
-				Stack:      "some-stack",
+				Stack: "some-stack",
+				TargetInfo: packit.TargetInfo{
+					OS:      "some-os",
+					Arch:    "some-arch",
+					Variant: "some-variant",
+				},
+				TargetDistro: packit.TargetDistro{
+					Name:    "some-distro-name",
+					Version: "some-distro-version",
+				},
 				WorkingDir: tmpDir,
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
@@ -532,7 +560,16 @@ api = "0.6"
 				Platform: packit.Platform{
 					Path: platformDir,
 				},
-				Stack:      "some-stack",
+				Stack: "some-stack",
+				TargetInfo: packit.TargetInfo{
+					OS:      "some-os",
+					Arch:    "some-arch",
+					Variant: "some-variant",
+				},
+				TargetDistro: packit.TargetDistro{
+					Name:    "some-distro-name",
+					Version: "some-distro-version",
+				},
 				WorkingDir: tmpDir,
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
@@ -590,7 +627,16 @@ api = "0.6"
 				Platform: packit.Platform{
 					Path: platformDir,
 				},
-				Stack:      "some-stack",
+				Stack: "some-stack",
+				TargetInfo: packit.TargetInfo{
+					OS:      "some-os",
+					Arch:    "some-arch",
+					Variant: "some-variant",
+				},
+				TargetDistro: packit.TargetDistro{
+					Name:    "some-distro-name",
+					Version: "some-distro-version",
+				},
 				WorkingDir: tmpDir,
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
@@ -648,7 +694,16 @@ api = "0.6"
 				Platform: packit.Platform{
 					Path: platformDir,
 				},
-				Stack:      "some-stack",
+				Stack: "some-stack",
+				TargetInfo: packit.TargetInfo{
+					OS:      "some-os",
+					Arch:    "some-arch",
+					Variant: "some-variant",
+				},
+				TargetDistro: packit.TargetDistro{
+					Name:    "some-distro-name",
+					Version: "some-distro-version",
+				},
 				WorkingDir: tmpDir,
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{

--- a/buildpack_info.go
+++ b/buildpack_info.go
@@ -57,3 +57,24 @@ type InfoLicense struct {
 	// the buildpack.toml.
 	URI string `toml:"uri"`
 }
+
+// TargetDistro is the supported target distro
+type TargetDistro struct {
+	// Name is the name of the supported distro.
+	Name string `toml:"name"`
+
+	// Version is the version of the supported distro.
+	Version string `toml:"version"`
+}
+
+// TargetInfo is the supported target
+type TargetInfo struct {
+	// OS is the supported os.
+	OS string `toml:"os"`
+
+	// Arch is the supported architecture.
+	Arch string `toml:"arch"`
+
+	// Variant is the supported variant of the architecture.
+	Variant string `toml:"variant"`
+}

--- a/generate.go
+++ b/generate.go
@@ -44,6 +44,12 @@ type GenerateContext struct {
 	// WorkingDir is the location of the application source code as provided by
 	// the lifecycle.
 	WorkingDir string
+
+	// TargetInfo contains info of the target (os, arch, ...).
+	TargetInfo TargetInfo
+
+	// TargetDistro is the target distribution (name, version).
+	TargetDistro TargetDistro
 }
 
 // GenerateResult allows extension authors to indicate the result of the generate
@@ -124,6 +130,15 @@ func Generate(f GenerateFunc, options ...Option) {
 		CNBPath: cnbPath,
 		Platform: Platform{
 			Path: platformPath,
+		},
+		TargetInfo: TargetInfo{
+			OS:      os.Getenv("CNB_TARGET_OS"),
+			Arch:    os.Getenv("CNB_TARGET_ARCH"),
+			Variant: os.Getenv("CNB_TARGET_VARIANT"),
+		},
+		TargetDistro: TargetDistro{
+			Name:    os.Getenv("CNB_TARGET_DISTRO_NAME"),
+			Version: os.Getenv("CNB_TARGET_DISTRO_VERSION"),
 		},
 		Stack:      os.Getenv("CNB_STACK_ID"),
 		WorkingDir: pwd,

--- a/generate_test.go
+++ b/generate_test.go
@@ -83,12 +83,16 @@ api = "0.9"
 		Expect(os.Setenv("CNB_BP_PLAN_PATH", planPath)).To(Succeed())
 		Expect(os.Setenv("CNB_PLATFORM_DIR", platformDir)).To(Succeed())
 		Expect(os.Setenv("CNB_EXTENSION_DIR", cnbDir)).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_OS", "some-os")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_ARCH", "some-arch")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_VARIANT", "some-variant")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_DISTRO_NAME", "some-distro-name")).To(Succeed())
+		Expect(os.Setenv("CNB_TARGET_DISTRO_VERSION", "some-distro-version")).To(Succeed())
 
 		exitHandler = &fakes.ExitHandler{}
 		exitHandler.ErrorCall.Stub = func(err error) {
 			Expect(err).NotTo(HaveOccurred())
 		}
-
 	})
 
 	it.After(func() {
@@ -96,10 +100,74 @@ api = "0.9"
 		Expect(os.Unsetenv("CNB_BP_PLAN_PATH")).To(Succeed())
 		Expect(os.Unsetenv("CNB_PLATFORM_DIR")).To(Succeed())
 		Expect(os.Unsetenv("CNB_EXTENSION_DIR")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_OS")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_ARCH")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_VARIANT")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_NAME")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_VERSION")).To(Succeed())
 
 		Expect(os.Chdir(workingDir)).To(Succeed())
 		Expect(os.RemoveAll(tmpDir)).To(Succeed())
 		Expect(os.RemoveAll(platformDir)).To(Succeed())
+	})
+
+	it("when the CNB_TARGET_* is not set, provides the generate context to the given GenerateFunc", func() {
+		Expect(os.Unsetenv("CNB_TARGET_OS")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_ARCH")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_VARIANT")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_NAME")).To(Succeed())
+		Expect(os.Unsetenv("CNB_TARGET_DISTRO_VERSION")).To(Succeed())
+
+		var context packit.GenerateContext
+		packit.Generate(func(ctx packit.GenerateContext) (packit.GenerateResult, error) {
+			context = ctx
+
+			return packit.GenerateResult{}, nil
+		}, packit.WithArgs([]string{binaryPath}), packit.WithExitHandler(exitHandler))
+
+		Expect(exitHandler.ErrorCall.CallCount).To(Equal(0))
+		Expect(context).To(Equal(packit.GenerateContext{
+			CNBPath: cnbDir,
+			Stack:   "some-stack",
+			Platform: packit.Platform{
+				Path: platformDir,
+			},
+			WorkingDir: tmpDir,
+			TargetInfo: packit.TargetInfo{
+				OS:      "",
+				Arch:    "",
+				Variant: "",
+			},
+			TargetDistro: packit.TargetDistro{
+				Name:    "",
+				Version: "",
+			},
+			Plan: packit.BuildpackPlan{
+				Entries: []packit.BuildpackPlanEntry{
+					{
+						Name: "some-entry",
+						Metadata: map[string]interface{}{
+							"version":  "some-version",
+							"some-key": "some-value",
+						},
+					},
+				},
+			},
+			Info: packit.Info{
+				ID:          "some-id",
+				Name:        "some-name",
+				Version:     "some-version",
+				Homepage:    "some-homepage",
+				Description: "some-description",
+				Keywords:    []string{"some-keyword"},
+				Licenses: []packit.BuildpackInfoLicense{
+					{
+						Type: "some-license-type",
+						URI:  "some-license-uri",
+					},
+				},
+			},
+		}))
 	})
 
 	it("provides the generate context to the given GenerateFunc", func() {
@@ -118,6 +186,15 @@ api = "0.9"
 				Path: platformDir,
 			},
 			WorkingDir: tmpDir,
+			TargetInfo: packit.TargetInfo{
+				OS:      "some-os",
+				Arch:    "some-arch",
+				Variant: "some-variant",
+			},
+			TargetDistro: packit.TargetDistro{
+				Name:    "some-distro-name",
+				Version: "some-distro-version",
+			},
 			Plan: packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{
 					{

--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -86,7 +86,11 @@ func (e Emitter) SelectedDependency(entry packit.BuildpackPlanEntry, dependency 
 		source = "<unknown>"
 	}
 
-	e.Subprocess("Selected %s version (using %s): %s", dependency.Name, source, dependency.Version)
+	if dependency.OS != "" && dependency.Arch != "" {
+		e.Process("Selected %s version (using %s): %s for %s/%s", dependency.Name, source, dependency.Version, dependency.OS, dependency.Arch)
+	} else {
+		e.Process("Selected %s version (using %s): %s", dependency.Name, source, dependency.Version)
+	}
 
 	if (dependency.DeprecationDate != time.Time{}) {
 		deprecationDate := dependency.DeprecationDate

--- a/scribe/emitter_test.go
+++ b/scribe/emitter_test.go
@@ -2,6 +2,7 @@ package scribe_test
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -50,7 +51,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 		it("prints details about the selected dependency", func() {
 			emitter.SelectedDependency(entry, dependency, now)
 			Expect(buffer.String()).To(ContainLines(
-				"    Selected Some Dependency version (using some-source): some-version",
+				"  Selected Some Dependency version (using some-source): some-version",
 				"",
 			))
 		})
@@ -59,7 +60,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("prints details about the selected dependency", func() {
 				emitter.SelectedDependency(packit.BuildpackPlanEntry{}, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"    Selected Some Dependency version (using <unknown>): some-version",
+					"  Selected Some Dependency version (using <unknown>): some-version",
 					"",
 				))
 			})
@@ -83,8 +84,9 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns a warning that the dependency will be deprecated after the deprecation date", func() {
 				emitter.SelectedDependency(entry, dependency, now)
+				fmt.Println(buffer.String())
 				Expect(buffer.String()).To(ContainLines(
-					"    Selected Some Dependency version (using some-source): some-version",
+					"  Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency will be deprecated after 2021-04-01.",
 					"      Migrate your application to a supported version of Some Dependency before this time.",
 					"",
@@ -113,7 +115,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("returns a warning that the version of the dependency is no longer supported", func() {
 				emitter.SelectedDependency(entry, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"    Selected Some Dependency version (using some-source): some-version",
+					"  Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency is deprecated.",
 					"      Migrate your application to a supported version of Some Dependency.",
 					"",
@@ -140,7 +142,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("returns a warning that the version of the dependency is no longer supported", func() {
 				emitter.SelectedDependency(entry, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"    Selected Some Dependency version (using some-source): some-version",
+					"  Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency is deprecated.",
 					"      Migrate your application to a supported version of Some Dependency.",
 					"",

--- a/scribe/example_test.go
+++ b/scribe/example_test.go
@@ -58,14 +58,14 @@ func ExampleEmitter_SelectedDependency() {
 	emitter.SelectedDependency(entry, dependency, deprecationDate.Add(24*time.Hour))
 
 	// Output:
-	// SelectedDependency
-	//     Selected Some Dependency version (using some-source): some-version
+	//SelectedDependency
+	//   Selected Some Dependency version (using some-source): some-version
 	//
-	//     Selected Some Dependency version (using some-source): some-version
+	//   Selected Some Dependency version (using some-source): some-version
 	//       Version some-version of Some Dependency will be deprecated after 2021-04-01.
 	//       Migrate your application to a supported version of Some Dependency before this time.
 	//
-	//     Selected Some Dependency version (using some-source): some-version
+	//   Selected Some Dependency version (using some-source): some-version
 	//       Version some-version of Some Dependency is deprecated.
 	//       Migrate your application to a supported version of Some Dependency.
 	//


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds support for fetching the values of below env variables ( for buildpacks & extensions) :
```
CNB_TARGET_OS
CNB_TARGET_ARCH
CNB_TARGET_VARIANT
CNB_TARGET_DISTRO_NAME
CNB_TARGET_DISTRO_VERSION
```
These variables are getting introduced on API = 0.10 and are also for deprecating `CNB_STACK_ID` env variable.

This PR it does not remove fetching the `CNB_STACK_ID` variable, as the migration guide suggest to keep this variable for a few API versions.

This PR also fixes the indentation of some of the unit tests that were failing.

Related issue:  https://github.com/paketo-buildpacks/packit/issues/559

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
