### PR TITLE
Adding support of target metadata, based on the api version 10

### DIFF
--- a/postal/service.go
+++ b/postal/service.go
@@ -118,9 +118,22 @@ func (s Service) WithDependencyMirrorResolver(mirrorResolver MirrorResolver) Ser
 // used. If there is no default version for that dependency, a wildcard
 // constraint will be used.
 func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
-	dependencies, defaultVersion, err := parseBuildpack(path, id)
+	_, apiV10orGreater := os.LookupEnv("CNB_TARGET_OS")
+
+	if apiV10orGreater && stack != "" {
+		return Dependency{}, fmt.Errorf("Stack id must be empty on API version 0.10 or greater")
+	}
+
+	allDependencies, defaultVersion, err := parseBuildpack(path, id)
 	if err != nil {
 		return Dependency{}, err
+	}
+
+	dependencies := []Dependency{}
+	for _, dep := range allDependencies {
+		if dep.ID == id {
+			dependencies = append(dependencies, dep)
+		}
 	}
 
 	var targetOs string
@@ -169,8 +182,14 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 
 	var supportedVersions []string
 	for _, dependency := range dependencies {
-		if dependency.ID != id || !stacksInclude(dependency.Stacks, stack) || !supportsPlatform(targetOs, targetArch, dependency) {
-			continue
+		if apiV10orGreater {
+			if !supportsPlatform(targetOs, targetArch, dependency) {
+				continue
+			}
+		} else {
+			if !stacksInclude(dependency.Stacks, stack) || !supportsPlatform(targetOs, targetArch, dependency) {
+				continue
+			}
 		}
 
 		sVersion, err := semver.NewVersion(dependency.Version)
@@ -185,21 +204,43 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 		supportedVersions = append(supportedVersions, dependency.Version)
 	}
 
-	if len(compatibleVersions) == 0 {
+	if len(compatibleVersions) == 0 && apiV10orGreater {
 		return Dependency{}, &ErrNoDeps{id, version, stack, supportedVersions, targetOs, targetArch}
+	} else if len(compatibleVersions) == 0 {
+		return Dependency{}, &ErrNoDeps{id, version, stack, supportedVersions, "", ""}
 	}
 
-	stacksForVersion := map[string][]string{}
+	if apiV10orGreater {
+		targetsForVersion := map[string][]string{}
 
-	for _, dep := range compatibleVersions {
-		stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
-	}
-
-	for version, stacks := range stacksForVersion {
-		count := stringSliceElementCount(stacks, "*")
-		if count > 1 {
-			return Dependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
+		for _, dep := range compatibleVersions {
+			targetsForVersion[dep.Version] = append(targetsForVersion[dep.Version], fmt.Sprintf("%s/%s", dep.OS, dep.Arch))
 		}
+
+		// Ensure that there are no duplicate target os/arch entries for a given version
+		for version, targets := range targetsForVersion {
+			mapDuplicateTargetVersion := make(map[string]bool)
+			for _, target := range targets {
+				if mapDuplicateTargetVersion[target] {
+					return Dependency{}, fmt.Errorf("Dependency with version %q has multiple entries for %s/%s", version, targetOs, targetArch)
+				}
+				mapDuplicateTargetVersion[target] = true
+			}
+		}
+	} else {
+		stacksForVersion := map[string][]string{}
+
+		for _, dep := range compatibleVersions {
+			stacksForVersion[dep.Version] = append(stacksForVersion[dep.Version], dep.Stacks...)
+		}
+
+		for version, stacks := range stacksForVersion {
+			count := stringSliceElementCount(stacks, "*")
+			if count > 1 {
+				return Dependency{}, fmt.Errorf("multiple dependencies support wildcard stack for version: %q", version)
+			}
+		}
+
 	}
 
 	sort.Slice(compatibleVersions, func(i, j int) bool {

--- a/postal/service.go
+++ b/postal/service.go
@@ -55,10 +55,22 @@ type ErrNoDeps struct {
 	version           string
 	stack             string
 	supportedVersions []string
+	targetOs          string
+	targetArch        string
 }
 
 // Error implements the error.Error interface
 func (e *ErrNoDeps) Error() string {
+	if e.targetOs != "" && e.targetArch != "" {
+		return fmt.Sprintf("failed to satisfy %q dependency version constraint %q: no compatible versions on %q/%q platform. Supported versions are: [%s]",
+			e.id,
+			e.version,
+			e.targetOs,
+			e.targetArch,
+			strings.Join(e.supportedVersions, ", "),
+		)
+	}
+
 	return fmt.Sprintf("failed to satisfy %q dependency version constraint %q: no compatible versions on %q stack. Supported versions are: [%s]",
 		e.id,
 		e.version,
@@ -174,7 +186,7 @@ func (s Service) Resolve(path, id, version, stack string) (Dependency, error) {
 	}
 
 	if len(compatibleVersions) == 0 {
-		return Dependency{}, &ErrNoDeps{id, version, stack, supportedVersions}
+		return Dependency{}, &ErrNoDeps{id, version, stack, supportedVersions, targetOs, targetArch}
 	}
 
 	stacksForVersion := map[string][]string{}

--- a/postal/service_test.go
+++ b/postal/service_test.go
@@ -359,7 +359,7 @@ version = "1.2.3"
 			})
 		})
 
-		context("When os and arch constraint exists for the same dependency version", func() {
+		context("When different os and arch constraint exists for the same dependency version", func() {
 			it.Before(func() {
 				err := os.WriteFile(path, []byte(`
 [metadata]
@@ -416,7 +416,7 @@ uri = "some-uri-linux-arm64.tar.xz"
 			})
 
 			it("finds the best matching dependency given a plan entry", func() {
-				dependency, err := service.Resolve(path, "node", "22.19.0", "some-stack")
+				dependency, err := service.Resolve(path, "node", "22.19.0", "")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(dependency).To(Equal(postal.Dependency{
 					ID:      "node",
@@ -500,6 +500,59 @@ version = "1.2.3"
 					_, err := service.Resolve(path, "some-entry", "9.9.9", "some-stack")
 					Expect(errors.As(err, &expectedErr)).To(BeTrue())
 					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-stack\" stack. Supported versions are: [1.2.3, 4.5.6]")))
+				})
+			})
+		})
+
+		context("failure cases when target metadata has been specified.", func() {
+
+			it.Before(func() {
+				Expect(os.Setenv("CNB_TARGET_ARCH", "some-arch")).To(Succeed())
+				Expect(os.Setenv("CNB_TARGET_OS", "some-os")).To(Succeed())
+				err := os.WriteFile(path, []byte(`
+		[[metadata.dependencies]]
+		id = "some-entry"
+		sha256 = "some-sha-A"
+		os = "some-os"
+		arch = "some-arch"
+		uri = "some-uri-A"
+		version = "1.2.3"
+
+		[[metadata.dependencies]]
+		id = "some-entry"
+		sha256 = "some-sha-B"
+		os = "some-os"
+		arch = "some-arch"
+		uri = "some-uri-B"
+		version = "1.2.3"
+		`), 0600)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it.After(func() {
+				Expect(os.Unsetenv("CNB_TARGET_ARCH")).To(Succeed())
+				Expect(os.Unsetenv("CNB_TARGET_OS")).To(Succeed())
+			})
+
+			context("when multiple dependencies have the same os and arch", func() {
+
+				it("returns an error", func() {
+					_, err := service.Resolve(path, "some-entry", "1.2.3", "")
+					Expect(err).To(MatchError(ContainSubstring(`Dependency with version "1.2.3" has multiple entries for some-os/some-arch`)))
+				})
+			})
+
+			it("targets metadata are provided and stack id is also passed as an input", func() {
+				_, err := service.Resolve(path, "some-entry", "9.9.9", "some-stack")
+				Expect(err).To(MatchError(ContainSubstring("Stack id must be empty on API version 0.10 or greater")))
+			})
+
+			context("when the entry version constraint cannot be satisfied", func() {
+				it("returns a typed error with all the supported versions listed", func() {
+					expectedErr := &postal.ErrNoDeps{}
+					_, err := service.Resolve(path, "some-entry", "9.9.9", "")
+					Expect(errors.As(err, &expectedErr)).To(BeTrue())
+					Expect(err).To(MatchError(ContainSubstring("failed to satisfy \"some-entry\" dependency version constraint \"9.9.9\": no compatible versions on \"some-os\"/\"some-arch\" platform. Supported versions are: [1.2.3, 1.2.3]")))
 				})
 			})
 		})


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR handles differently the the dependencies based on the apiVersion if its greater than 10 or not. Specifically:
* If api > 10 it filters the dependencies based on the target metadata values and in case on the dependencies the os and arch is not specified, then does not do a strict checking and as a result the dependency will get accepted
* If api < 10 it filters the dependencies based on stacks and based on the platform. As a result if the stack does not match it will check if the platform matches, and due to we do not also do a strict check, if the dependencies do not include os and arch, the dependency will get accepted.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
