### PR TITLE
Reverting commit with additional logging data

### DIFF
--- a/scribe/emitter.go
+++ b/scribe/emitter.go
@@ -86,11 +86,7 @@ func (e Emitter) SelectedDependency(entry packit.BuildpackPlanEntry, dependency 
 		source = "<unknown>"
 	}
 
-	if dependency.OS != "" && dependency.Arch != "" {
-		e.Process("Selected %s version (using %s): %s for %s/%s", dependency.Name, source, dependency.Version, dependency.OS, dependency.Arch)
-	} else {
-		e.Process("Selected %s version (using %s): %s", dependency.Name, source, dependency.Version)
-	}
+	e.Subprocess("Selected %s version (using %s): %s", dependency.Name, source, dependency.Version)
 
 	if (dependency.DeprecationDate != time.Time{}) {
 		deprecationDate := dependency.DeprecationDate

--- a/scribe/emitter_test.go
+++ b/scribe/emitter_test.go
@@ -2,7 +2,6 @@ package scribe_test
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 	"time"
 
@@ -51,7 +50,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 		it("prints details about the selected dependency", func() {
 			emitter.SelectedDependency(entry, dependency, now)
 			Expect(buffer.String()).To(ContainLines(
-				"  Selected Some Dependency version (using some-source): some-version",
+				"    Selected Some Dependency version (using some-source): some-version",
 				"",
 			))
 		})
@@ -60,7 +59,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("prints details about the selected dependency", func() {
 				emitter.SelectedDependency(packit.BuildpackPlanEntry{}, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"  Selected Some Dependency version (using <unknown>): some-version",
+					"    Selected Some Dependency version (using <unknown>): some-version",
 					"",
 				))
 			})
@@ -84,9 +83,8 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 
 			it("returns a warning that the dependency will be deprecated after the deprecation date", func() {
 				emitter.SelectedDependency(entry, dependency, now)
-				fmt.Println(buffer.String())
 				Expect(buffer.String()).To(ContainLines(
-					"  Selected Some Dependency version (using some-source): some-version",
+					"    Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency will be deprecated after 2021-04-01.",
 					"      Migrate your application to a supported version of Some Dependency before this time.",
 					"",
@@ -115,7 +113,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("returns a warning that the version of the dependency is no longer supported", func() {
 				emitter.SelectedDependency(entry, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"  Selected Some Dependency version (using some-source): some-version",
+					"    Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency is deprecated.",
 					"      Migrate your application to a supported version of Some Dependency.",
 					"",
@@ -142,7 +140,7 @@ func testEmitter(t *testing.T, context spec.G, it spec.S) {
 			it("returns a warning that the version of the dependency is no longer supported", func() {
 				emitter.SelectedDependency(entry, dependency, now)
 				Expect(buffer.String()).To(ContainLines(
-					"  Selected Some Dependency version (using some-source): some-version",
+					"    Selected Some Dependency version (using some-source): some-version",
 					"      Version some-version of Some Dependency is deprecated.",
 					"      Migrate your application to a supported version of Some Dependency.",
 					"",

--- a/scribe/example_test.go
+++ b/scribe/example_test.go
@@ -58,14 +58,14 @@ func ExampleEmitter_SelectedDependency() {
 	emitter.SelectedDependency(entry, dependency, deprecationDate.Add(24*time.Hour))
 
 	// Output:
-	//SelectedDependency
-	//   Selected Some Dependency version (using some-source): some-version
+	// SelectedDependency
+	//     Selected Some Dependency version (using some-source): some-version
 	//
-	//   Selected Some Dependency version (using some-source): some-version
+	//     Selected Some Dependency version (using some-source): some-version
 	//       Version some-version of Some Dependency will be deprecated after 2021-04-01.
 	//       Migrate your application to a supported version of Some Dependency before this time.
 	//
-	//   Selected Some Dependency version (using some-source): some-version
+	//     Selected Some Dependency version (using some-source): some-version
 	//       Version some-version of Some Dependency is deprecated.
 	//       Migrate your application to a supported version of Some Dependency.
 	//


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR reverts additional information on logging, as a lot of buildpacks rely on this check and it breaks several integration tests, as a result it wont upgrade unless there is a commit on buildpacks integration tests that fix the pattern matching.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
