### PR TITLE
Using a regex to match uuid instead of being hardcoded

### DIFF
--- a/sbom/formatted_reader_test.go
+++ b/sbom/formatted_reader_test.go
@@ -137,7 +137,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 			// Ensure documentNamespace and creationInfo.created have reproducible values
 			// The DocumentNamespace includes the sha1 uuid of the data, which may differ if running locally versus in github actions
-			Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-b1dafd91-f0f8-5e16-8d44-577cffd1ad84"), buffer.String())
+			Expect(spdxOutput.DocumentNamespace).To(MatchRegexp(`^https://paketo\.io/packit/dir/testdata-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`), buffer.String())
 			Expect(spdxOutput.CreationInfo.Created).To(BeZero(), buffer.String())
 
 			rerunBuffer := bytes.NewBuffer(nil)
@@ -188,7 +188,7 @@ func testFormattedReader(t *testing.T, context spec.G, it spec.S) {
 
 					// Ensure documentNamespace and creationInfo.created have reproducible values
 					// The DocumentNamespace includes the sha1 uuid of the data, which may differ if running locally versus in github actions
-					Expect(spdxOutput.DocumentNamespace).To(Equal("https://paketo.io/packit/dir/testdata-b355867c-6d04-5a00-bebd-f887ccff0f33"), buffer.String())
+					Expect(spdxOutput.DocumentNamespace).To(MatchRegexp(`^https://paketo\.io/packit/dir/testdata-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`), buffer.String())
 					Expect(spdxOutput.CreationInfo.Created).To(Equal(time.Unix(1659551872, 0).UTC()), buffer.String())
 
 					rerunBuffer := bytes.NewBuffer(nil)

--- a/vacation/archive.go
+++ b/vacation/archive.go
@@ -34,6 +34,7 @@ func NewArchive(inputReader io.Reader) Archive {
 // - "application/x-executable"
 // - "text/plain; charset=utf-8"
 // - "application/jar"
+// - "application/java-archive"
 // - "application/octet-stream"
 // and write the contents of the input stream to a file name specified by the
 // `Archive.WithName()` option in the destination directory.
@@ -69,6 +70,7 @@ func (a Archive) Decompress(destination string) error {
 		decompressor = NewExecutable(bufferedReader).WithName(a.name)
 	case "text/plain; charset=utf-8",
 		"application/jar",
+		"application/java-archive",
 		"application/octet-stream":
 		decompressor = NewNopArchive(bufferedReader).WithName(a.name)
 	default:


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* Uses a regex to match some of the uuids
* Adds a new mime type decompression. This is necessary for this PR to pass https://github.com/paketo-buildpacks/packit/pull/706 as in decompression, one of the java files is recognized with the `application/java-archive` instead of the `application/jar` .This does not affect the final decompression output.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
