### PR TITLE
Structure re-usability for the extension

### DIFF
--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -49,13 +49,8 @@ type ConfigExtension struct {
 	Homepage    string                   `toml:"homepage,omitempty"    json:"homepage,omitempty"`
 	Description string                   `toml:"description,omitempty" json:"description,omitempty"`
 	Keywords    []string                 `toml:"keywords,omitempty"    json:"keywords,omitempty"`
-	Licenses    []ConfigExtensionLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
+	Licenses    []ConfigBuildpackLicense `toml:"licenses,omitempty"    json:"licenses,omitempty"`
 	SBOMFormats []string                 `toml:"sbom-formats,omitempty"    json:"sbom-formats,omitempty"`
-}
-
-type ConfigExtensionLicense struct {
-	Type string `toml:"type" json:"type"`
-	URI  string `toml:"uri"  json:"uri"`
 }
 
 func EncodeExtensionConfig(writer io.Writer, extensionConfig ExtensionConfig) error {

--- a/cargo/extension_config.go
+++ b/cargo/extension_config.go
@@ -11,12 +11,7 @@ type ExtensionConfig struct {
 	API       string                  `toml:"api"       json:"api,omitempty"`
 	Extension ConfigExtension         `toml:"extension" json:"extension,omitempty"`
 	Metadata  ConfigExtensionMetadata `toml:"metadata"  json:"metadata,omitempty"`
-	Targets   []ExtensionConfigTarget `toml:"targets"   json:"targets,omitempty"`
-}
-
-type ExtensionConfigTarget struct {
-	OS   string `toml:"os"     json:"os,omitempty"`
-	Arch string `toml:"arch"   json:"arch,omitempty"`
+	Targets   []ConfigTarget          `toml:"targets"   json:"targets,omitempty"`
 }
 
 type ConfigExtensionMetadata struct {

--- a/cargo/extension_config_test.go
+++ b/cargo/extension_config_test.go
@@ -35,7 +35,7 @@ func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 					Homepage:    "some-extension-homepage",
 					Description: "some-extension-description",
 					Keywords:    []string{"some-extension-keyword"},
-					Licenses: []cargo.ConfigExtensionLicense{
+					Licenses: []cargo.ConfigBuildpackLicense{
 						{
 							Type: "some-license-type",
 							URI:  "some-license-uri",
@@ -77,7 +77,7 @@ func testExtensionConfig(t *testing.T, context spec.G, it spec.S) {
 						"some-dependency": "1.2.x",
 					},
 				},
-				Targets: []cargo.ExtensionConfigTarget{
+				Targets: []cargo.ConfigTarget{
 					{
 						OS:   "linux",
 						Arch: "arm64",
@@ -152,7 +152,7 @@ api = "0.7"
 						Homepage:    "some-extension-homepage",
 						Description: "some-extension-description",
 						Keywords:    []string{"some-extension-keyword"},
-						Licenses: []cargo.ConfigExtensionLicense{
+						Licenses: []cargo.ConfigBuildpackLicense{
 							{
 								Type: "some-license-type",
 								URI:  "some-license-uri",
@@ -311,7 +311,7 @@ keywords = [ "some-extension-keyword" ]
 					Homepage:    "some-extension-homepage",
 					Description: "some-extension-description",
 					Keywords:    []string{"some-extension-keyword"},
-					Licenses: []cargo.ConfigExtensionLicense{
+					Licenses: []cargo.ConfigBuildpackLicense{
 						{
 							Type: "some-license-type",
 							URI:  "some-license-uri",
@@ -410,7 +410,7 @@ api = "0.2"
 						Name:     "some-extension-name",
 						Version:  "some-extension-version",
 						Homepage: "some-extension-homepage",
-						Licenses: []cargo.ConfigExtensionLicense{
+						Licenses: []cargo.ConfigBuildpackLicense{
 							{
 								Type: "some-license-type",
 								URI:  "some-license-uri",

--- a/scribe/formatted_map.go
+++ b/scribe/formatted_map.go
@@ -36,7 +36,7 @@ func (m FormattedMap) String() string {
 			key = key + " "
 		}
 
-		builder.WriteString(fmt.Sprintf("%s -> \"%v\"\n", key, value))
+		fmt.Fprintf(&builder, "%s -> \"%v\"\n", key, value)
 	}
 
 	return strings.TrimSpace(builder.String())


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR:
* uses the buildpacks structures, removing that way duplicate code
* Fixes the linting issue

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
